### PR TITLE
feat: improve BotAI decision-making for meld creation and add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+
+.env

--- a/lib/ai/bot_ai.dart
+++ b/lib/ai/bot_ai.dart
@@ -152,6 +152,22 @@ class BotAI {
             data: strategicPlayDown.first,
           );
         }
+      } else {
+        // No strategic play-down found, but we have possible melds
+        // This might be a bug - if we have melds that meet requirement, we should play them
+        if (possibleMelds.isNotEmpty) {
+          // Check if any single meld meets the play-down requirement
+          final playDownRequirement = controller.gameState.playDownRequirement;
+          for (final meld in possibleMelds) {
+            final points = meld.fold<int>(
+              0,
+              (sum, card) => sum + card.pointValue,
+            );
+            if (points >= playDownRequirement) {
+              return BotDecision(action: 'createMeld', data: meld);
+            }
+          }
+        }
       }
     } else {
       // Already played down - be more strategic about melding

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -149,9 +149,8 @@ class GameController {
       }
     }
 
-    if (wildCards.length >= 3) {
-      possibleMelds.add(wildCards.take(3).toList());
-    }
+    // Note: Wild-only melds are not allowed in Hand & Foot rules
+    // Wild cards can only supplement natural card melds
 
     return possibleMelds;
   }

--- a/test/ai/bot_stuck_meld_fix_test.dart
+++ b/test/ai/bot_stuck_meld_fix_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/ai/bot_ai.dart';
+
+void main() {
+  group('Bot Stuck Meld Fix', () {
+    test(
+      'should create meld when strategic play-down fails but direct meld meets requirement',
+      () async {
+        final players = [
+          Player(id: '1', name: 'Human', type: PlayerType.human),
+          Player(id: '2', name: 'Bot1', type: PlayerType.bot),
+          Player(id: '3', name: 'Bot2', type: PlayerType.bot),
+        ];
+        final gameController = GameController(players: players);
+        final botAI = BotAI();
+
+        final bot1 = players[1];
+
+        // Give Bot 1 a hand that can form a valid mixed meld: 2 queens + 1 joker (70 points)
+        bot1.dealHand([
+          const PlayingCard(suit: null, rank: CardRank.joker), // 50 points
+          const PlayingCard(
+            suit: Suit.hearts,
+            rank: CardRank.queen,
+          ), // 10 points
+          const PlayingCard(
+            suit: Suit.diamonds,
+            rank: CardRank.queen,
+          ), // 10 points
+          // Total: 70 points, exceeds 60-point play-down requirement
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.two),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.eight),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+        ]);
+
+        // Set up the exact scenario from the bug report
+        gameController.gameState.round = 1;
+        gameController.gameState.currentPlayerIndex = 1; // Bot 1
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+        gameController.gameState.hasMelded = false;
+
+        // Verify the bot has cards that can form a meld (2 queens + 1 joker + 2 more twos)
+        final wildCards = bot1.hand.where((c) => c.isWild).toList();
+        final queens = bot1.hand
+            .where((c) => c.rank == CardRank.queen)
+            .toList();
+        expect(queens.length, equals(2)); // 2 queens
+        expect(wildCards.length, equals(3)); // 1 joker + 2 twos
+
+        // Verify play down requirement is 60 for round 1
+        expect(gameController.gameState.playDownRequirement, equals(60));
+
+        // Find possible melds - should find at least one wild meld
+        final possibleMelds = gameController.findPossibleMelds(bot1);
+        expect(possibleMelds.isNotEmpty, true);
+
+        // Find the queen meld (2 queens + 1 joker, which should be worth 70 points)
+        final queenMeld = possibleMelds.firstWhere(
+          (meld) =>
+              meld.any((card) => card.rank == CardRank.queen) &&
+              meld.length == 3,
+          orElse: () => [],
+        );
+        expect(queenMeld.isNotEmpty, true);
+
+        final meldPoints = queenMeld.fold<int>(
+          0,
+          (sum, card) => sum + card.pointValue,
+        );
+        expect(meldPoints, equals(70)); // 2 queens (10 each) + 1 joker (50)
+        expect(meldPoints >= 60, true); // Meets play-down requirement
+
+        // Now test the bot decision - this should NOT get stuck
+        final decision = botAI.makeDecision(bot1, gameController);
+
+        // The bot should decide to create a meld (not get stuck)
+        expect(decision.action, equals('createMeld'));
+        expect(decision.data, isA<List<PlayingCard>>());
+
+        final decidedMeld = decision.data as List<PlayingCard>;
+        expect(decidedMeld.length, equals(3));
+        expect(decidedMeld.any((card) => card.rank == CardRank.queen), true);
+
+        // Verify the decided meld meets the play-down requirement
+        final decidedMeldPoints = decidedMeld.fold<int>(
+          0,
+          (sum, card) => sum + card.pointValue,
+        );
+        expect(decidedMeldPoints >= 60, true);
+
+        // Verify the bot can actually execute this meld
+        final success = gameController.createMeld(decidedMeld);
+        expect(success, true);
+
+        // Verify the bot has played down after the meld
+        expect(bot1.hasPlayedDown, true);
+        expect(bot1.melds.length, equals(1));
+        expect(gameController.gameState.hasMelded, true);
+      },
+    );
+
+    test(
+      'should handle fallback logic when strategic play-down returns empty but melds exist',
+      () async {
+        final players = [
+          Player(id: '1', name: 'Human', type: PlayerType.human),
+          Player(id: '2', name: 'Bot1', type: PlayerType.bot),
+          Player(id: '3', name: 'Bot2', type: PlayerType.bot),
+        ];
+        final gameController = GameController(players: players);
+        final botAI = BotAI();
+
+        final bot1 = players[1];
+
+        // Give bot a hand that can create a valid meld: 2 kings + 1 joker (70 points)
+        bot1.dealHand([
+          const PlayingCard(suit: null, rank: CardRank.joker), // 50 points
+          const PlayingCard(
+            suit: Suit.hearts,
+            rank: CardRank.king,
+          ), // 10 points
+          const PlayingCard(
+            suit: Suit.spades,
+            rank: CardRank.king,
+          ), // 10 points
+          // Additional cards
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.two),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ]);
+
+        // Set up similar scenario but with a configuration that might cause strategic play-down to fail
+        gameController.gameState.currentPlayerIndex = 1;
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        // This should find possible melds
+        final possibleMelds = gameController.findPossibleMelds(bot1);
+        expect(possibleMelds.isNotEmpty, true);
+
+        // Test that bot makes a decision (doesn't get stuck)
+        final decision = botAI.makeDecision(bot1, gameController);
+        expect(decision.action, isIn(['createMeld', 'discard']));
+
+        // If it decided to create a meld, it should be executable
+        if (decision.action == 'createMeld') {
+          final success = gameController.createMeld(
+            decision.data as List<PlayingCard>,
+          );
+          expect(success, true);
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
- Enhanced the BotAI logic to ensure it creates melds when strategic play-down fails but valid melds exist, preventing the bot from getting stuck.
- Updated the GameController to clarify that wild-only melds are not allowed under Hand & Foot rules.
- Introduced a new test suite to validate the BotAI's behavior in scenarios where melds can be formed, ensuring robust decision-making.
- Added .env to .gitignore to prevent sensitive information from being tracked.

These changes enhance the gameplay experience by improving the bot's decision-making capabilities and ensuring proper game rules are followed.