### PR TITLE
refactor: update newly drawn card handling in game state management

### DIFF
--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -133,13 +133,13 @@ class GameState {
   }
 
   void nextPlayer() {
-    // Clear newly drawn cards from the current player before switching
-    currentPlayer.clearNewlyDrawnCards();
-
     currentPlayerIndex = (currentPlayerIndex + 1) % players.length;
     turnPhase = TurnPhase.draw;
     hasDrawnFromDeck = false;
     hasMelded = false;
+
+    // Clear newly drawn cards from the new current player at the start of their turn
+    currentPlayer.clearNewlyDrawnCards();
   }
 
   void startRound() {

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -62,9 +62,6 @@ class _GameScreenState extends State<GameScreen> {
     _botAI = BotAI();
     _gameController.initializeGame();
 
-    // Clear any stale newly drawn card highlighting
-    _gameController.clearAllNewlyDrawnCards();
-
     // Sort the human player's initial hand
     final humanPlayer = players.firstWhere((p) => p.type == PlayerType.human);
     humanPlayer.sortHandByRank();

--- a/test/newly_drawn_cards_gameplay_test.dart
+++ b/test/newly_drawn_cards_gameplay_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+
+void main() {
+  group('Newly Drawn Cards During Gameplay', () {
+    test(
+      'should properly mark cards as newly drawn when drawing from deck during gameplay',
+      () {
+        // Create a fresh game (no saved game restore scenario)
+        final players = [
+          Player(id: '1', name: 'Human', type: PlayerType.human),
+          Player(id: '2', name: 'Bot 1', type: PlayerType.bot),
+        ];
+
+        final controller = GameController(players: players);
+        controller.initializeGame();
+
+        // Verify initial state - no newly drawn cards should be highlighted after dealing
+        final humanPlayer = players[0];
+        expect(humanPlayer.currentHand.length, 11); // Initial hand size
+
+        // No cards should be highlighted as newly drawn after initial deal
+        for (int i = 0; i < humanPlayer.currentHand.length; i++) {
+          expect(
+            humanPlayer.isCardIndexNewlyDrawn(i),
+            false,
+            reason:
+                'Initial dealt cards should not be highlighted as newly drawn',
+          );
+        }
+
+        // Simulate drawing cards during gameplay (like the user's scenario)
+        final success = controller.drawFromDeck();
+        expect(success, true);
+
+        // After drawing, the newly drawn cards should be highlighted
+        final expectedHandSize = 11 + GameState.requiredDrawCount;
+        expect(humanPlayer.currentHand.length, expectedHandSize);
+
+        // The last drawn cards should be marked as newly drawn
+        for (int i = 11; i < expectedHandSize; i++) {
+          expect(
+            humanPlayer.isCardIndexNewlyDrawn(i),
+            true,
+            reason:
+                'Card at index $i should be highlighted as newly drawn after drawing from deck',
+          );
+        }
+
+        // But the original cards should still not be highlighted
+        for (int i = 0; i < 11; i++) {
+          expect(
+            humanPlayer.isCardIndexNewlyDrawn(i),
+            false,
+            reason: 'Original card at index $i should not be highlighted',
+          );
+        }
+      },
+    );
+
+    test(
+      'should maintain newly drawn highlighting after game controller creation but before clearing',
+      () {
+        // Create players and add some cards
+        final humanPlayer = Player(
+          id: '1',
+          name: 'Human',
+          type: PlayerType.human,
+        );
+        final botPlayer = Player(id: '2', name: 'Bot', type: PlayerType.bot);
+
+        // Add some initial cards
+        humanPlayer.hand.addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        ]);
+
+        // Simulate properly drawn cards (using the correct method)
+        final drawnCard1 = const PlayingCard(
+          suit: Suit.clubs,
+          rank: CardRank.joker,
+        );
+        final drawnCard2 = const PlayingCard(
+          suit: Suit.diamonds,
+          rank: CardRank.eight,
+        );
+        humanPlayer.addNewlyDrawnCard(drawnCard1);
+        humanPlayer.addNewlyDrawnCard(drawnCard2);
+
+        // Verify the cards are marked as newly drawn
+        expect(humanPlayer.isCardIndexNewlyDrawn(2), true); // Joker
+        expect(humanPlayer.isCardIndexNewlyDrawn(3), true); // Eight
+        expect(humanPlayer.isCardIndexNewlyDrawn(0), false); // Original ace
+        expect(humanPlayer.isCardIndexNewlyDrawn(1), false); // Original king
+
+        // Creating a game controller should NOT clear these valid newly drawn cards
+        // (This simulates the normal game flow, not a save/restore scenario)
+        final controller = GameController(players: [humanPlayer, botPlayer]);
+
+        // The newly drawn cards should still be marked
+        expect(
+          humanPlayer.isCardIndexNewlyDrawn(2),
+          true,
+        ); // Joker still highlighted
+        expect(
+          humanPlayer.isCardIndexNewlyDrawn(3),
+          true,
+        ); // Eight still highlighted
+
+        // Only when we explicitly clear (like in save/restore scenarios) should they be cleared
+        controller.clearAllNewlyDrawnCards();
+
+        expect(humanPlayer.isCardIndexNewlyDrawn(2), false); // Now cleared
+        expect(humanPlayer.isCardIndexNewlyDrawn(3), false); // Now cleared
+      },
+    );
+  });
+}

--- a/test/newly_drawn_cards_persistence_test.dart
+++ b/test/newly_drawn_cards_persistence_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+
+void main() {
+  group('Newly Drawn Cards Persistence During Gameplay', () {
+    test(
+      'should maintain newly drawn card highlighting throughout player\'s entire turn',
+      () {
+        // Create a game with human player first
+        final humanPlayer = Player(
+          id: '1',
+          name: 'Human',
+          type: PlayerType.human,
+        );
+        final botPlayer1 = Player(id: '2', name: 'Bot 1', type: PlayerType.bot);
+        final botPlayer2 = Player(id: '3', name: 'Bot 2', type: PlayerType.bot);
+
+        final controller = GameController(
+          players: [humanPlayer, botPlayer1, botPlayer2],
+        );
+        controller.initializeGame();
+
+        // Verify human player goes first
+        expect(controller.gameState.currentPlayer.id, '1');
+        expect(controller.gameState.currentPlayer.type, PlayerType.human);
+
+        // Human player draws cards
+        expect(controller.drawFromDeck(), true);
+
+        // Verify newly drawn cards are highlighted
+        final handSize = humanPlayer.currentHand.length;
+        final expectedNewCardCount = GameState.requiredDrawCount;
+        for (int i = handSize - expectedNewCardCount; i < handSize; i++) {
+          expect(
+            humanPlayer.isCardIndexNewlyDrawn(i),
+            true,
+            reason: 'Card at index $i should be highlighted as newly drawn',
+          );
+        }
+
+        // During meld phase, newly drawn cards should still be highlighted
+        expect(controller.gameState.turnPhase.name, 'meld');
+        for (int i = handSize - expectedNewCardCount; i < handSize; i++) {
+          expect(
+            humanPlayer.isCardIndexNewlyDrawn(i),
+            true,
+            reason:
+                'Card at index $i should remain highlighted during meld phase',
+          );
+        }
+
+        // Player discards to end turn - this should advance to next player
+        final cardToDiscard = humanPlayer.currentHand.first;
+        expect(controller.discardCard(cardToDiscard), true);
+
+        // Verify turn advanced to bot player
+        expect(controller.gameState.currentPlayer.id, '2');
+        expect(controller.gameState.currentPlayer.type, PlayerType.bot);
+
+        // IMPORTANT: Human player should still have their newly drawn cards highlighted
+        // because clearing only happens at the START of the new current player's turn
+        for (
+          int i = handSize - expectedNewCardCount - 1;
+          i < handSize - 1;
+          i++
+        ) {
+          // -1 because we discarded
+          expect(
+            humanPlayer.isCardIndexNewlyDrawn(i),
+            true,
+            reason:
+                'Human card at index $i should still be highlighted after their turn ended',
+          );
+        }
+
+        // But the bot (current player) should have no newly drawn cards highlighted yet
+        expect(
+          botPlayer1.newlyDrawnCardIndices.isEmpty,
+          true,
+          reason: 'Bot should have no highlighted cards at start of turn',
+        );
+      },
+    );
+
+    test(
+      'should clear newly drawn cards when it becomes that player\'s turn again',
+      () {
+        // Create a 2-player game to make turns cycle faster
+        final humanPlayer = Player(
+          id: '1',
+          name: 'Human',
+          type: PlayerType.human,
+        );
+        final botPlayer = Player(id: '2', name: 'Bot', type: PlayerType.bot);
+
+        final controller = GameController(players: [humanPlayer, botPlayer]);
+        controller.initializeGame();
+
+        // Human draws cards and gets highlighting
+        expect(controller.drawFromDeck(), true);
+        final handSize = humanPlayer.currentHand.length;
+
+        // Verify highlighting exists
+        for (
+          int i = handSize - GameState.requiredDrawCount;
+          i < handSize;
+          i++
+        ) {
+          expect(humanPlayer.isCardIndexNewlyDrawn(i), true);
+        }
+
+        // Human discards, bot's turn starts
+        final humanCard = humanPlayer.currentHand.first;
+        expect(controller.discardCard(humanCard), true);
+        expect(controller.gameState.currentPlayer.id, '2'); // Bot's turn
+
+        // Human should still have highlighting
+        final newHandSize = humanPlayer.currentHand.length; // -1 from discard
+        for (
+          int i = newHandSize - GameState.requiredDrawCount;
+          i < newHandSize;
+          i++
+        ) {
+          expect(
+            humanPlayer.isCardIndexNewlyDrawn(i),
+            true,
+            reason: 'Human should still have highlighting during bot\'s turn',
+          );
+        }
+
+        // Bot draws and discards to return turn to human
+        expect(controller.drawFromDeck(), true);
+        final botCard = botPlayer.currentHand.first;
+        expect(controller.discardCard(botCard), true);
+        expect(controller.gameState.currentPlayer.id, '1'); // Back to human
+
+        // NOW human's newly drawn cards should be cleared (start of their new turn)
+        for (int i = 0; i < humanPlayer.currentHand.length; i++) {
+          expect(
+            humanPlayer.isCardIndexNewlyDrawn(i),
+            false,
+            reason:
+                'All human cards should have highlighting cleared at start of new turn',
+          );
+        }
+      },
+    );
+
+    test('should handle highlighting correctly in 3+ player games', () {
+      // Create a 3-player game
+      final humanPlayer = Player(
+        id: '1',
+        name: 'Human',
+        type: PlayerType.human,
+      );
+      final botPlayer1 = Player(id: '2', name: 'Bot 1', type: PlayerType.bot);
+      final botPlayer2 = Player(id: '3', name: 'Bot 2', type: PlayerType.bot);
+
+      final controller = GameController(
+        players: [humanPlayer, botPlayer1, botPlayer2],
+      );
+      controller.initializeGame();
+
+      // Human draws and discards
+      expect(controller.drawFromDeck(), true);
+      final humanHandSize = humanPlayer.currentHand.length;
+      final humanCard = humanPlayer.currentHand.first;
+      expect(controller.discardCard(humanCard), true);
+
+      // Bot 1's turn - human should still have highlighting
+      expect(controller.gameState.currentPlayer.id, '2');
+      for (
+        int i = humanHandSize - GameState.requiredDrawCount - 1;
+        i < humanHandSize - 1;
+        i++
+      ) {
+        expect(
+          humanPlayer.isCardIndexNewlyDrawn(i),
+          true,
+          reason: 'Human should keep highlighting during bot 1 turn',
+        );
+      }
+
+      // Bot 1 draws and discards
+      expect(controller.drawFromDeck(), true);
+      final bot1Card = botPlayer1.currentHand.first;
+      expect(controller.discardCard(bot1Card), true);
+
+      // Bot 2's turn - human should STILL have highlighting
+      expect(controller.gameState.currentPlayer.id, '3');
+      for (
+        int i = humanHandSize - GameState.requiredDrawCount - 1;
+        i < humanHandSize - 1;
+        i++
+      ) {
+        expect(
+          humanPlayer.isCardIndexNewlyDrawn(i),
+          true,
+          reason: 'Human should keep highlighting during bot 2 turn',
+        );
+      }
+
+      // Bot 2 draws and discards to return to human
+      expect(controller.drawFromDeck(), true);
+      final bot2Card = botPlayer2.currentHand.first;
+      expect(controller.discardCard(bot2Card), true);
+
+      // Back to human - NOW highlighting should be cleared
+      expect(controller.gameState.currentPlayer.id, '1');
+      for (int i = 0; i < humanPlayer.currentHand.length; i++) {
+        expect(
+          humanPlayer.isCardIndexNewlyDrawn(i),
+          false,
+          reason:
+              'Human highlighting should be cleared when their turn starts again',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
- Moved the clearing of newly drawn cards to the start of the new player's turn in the `nextPlayer` method, ensuring that the correct player has their newly drawn cards cleared at the appropriate time.
- Removed the clearing of newly drawn cards from the game initialization process to prevent premature clearing before the player's turn begins.
- Added unit tests to verify the correct behavior of newly drawn card highlighting and persistence during gameplay, ensuring that the game state management is robust and user-friendly.