### PR TITLE
feat: implement emergency reshuffle logic for empty deck scenarios

### DIFF
--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -187,9 +187,9 @@ class GameState {
 
       if (!deck.isEmpty) {
         card = deck.drawCard();
-      } else if (discardPile.length > minDiscardForReshuffle) {
-        // Try reshuffling if deck is empty but discard pile has cards
-        _reshuffleDiscardIntoDeck();
+      } else {
+        // Deck is empty - try reshuffling discard pile
+        _attemptReshuffleForEmptyDeck();
         if (!deck.isEmpty) {
           card = deck.drawCard();
         }
@@ -198,12 +198,13 @@ class GameState {
       if (card != null) {
         cardsDrawn.add(card);
       } else {
-        // Unable to draw required cards - return what we drew and fail
+        // Still unable to draw - this should be extremely rare
+        // Return any cards we managed to draw
         for (final drawnCard in cardsDrawn) {
           deck.returnCard(drawnCard);
         }
         _logAction(
-          'cannot draw - insufficient cards available even after attempting reshuffle',
+          'cannot draw - insufficient cards available even after exhaustive reshuffle attempt',
         );
         return false;
       }
@@ -586,6 +587,59 @@ class GameState {
       ordered.add(players[index]);
     }
     return ordered;
+  }
+
+  /// Attempts to reshuffle discard pile when deck is completely empty.
+  ///
+  /// This is more aggressive than the normal reshuffle - will attempt to reshuffle
+  /// even with minimal discard cards to prevent game from breaking.
+  void _attemptReshuffleForEmptyDeck() {
+    if (discardPile.isEmpty) {
+      // Nothing to reshuffle
+      _logAction(
+        'deck empty and no discard cards to reshuffle - game may be stuck',
+      );
+      return;
+    }
+
+    if (discardPile.length == 1) {
+      // Only one card in discard pile - this is the absolute edge case
+      // Log this rare occurrence but don't reshuffle as it would leave no discard
+      _logAction(
+        'deck empty with only 1 discard card - cannot reshuffle safely',
+      );
+      return;
+    }
+
+    // We have at least 2 cards in discard pile - force reshuffle regardless of normal rules
+    _forceReshuffleForEmptyDeck();
+
+    if (!deck.isEmpty) {
+      _logAction('emergency reshuffle successful - deck restored');
+    } else {
+      _logAction('emergency reshuffle failed - this should not happen');
+    }
+  }
+
+  /// Forces a reshuffle when deck is empty, bypassing normal restrictions.
+  void _forceReshuffleForEmptyDeck() {
+    if (discardPile.length < 2) return;
+
+    // Keep the top discard card (last item in the list)
+    final topCard = discardPile.removeLast();
+
+    // Take all other discard cards and add them to deck
+    final cardsToShuffle = List<PlayingCard>.from(discardPile);
+    discardPile.clear();
+    discardPile.add(topCard);
+
+    // Add the cards to deck and shuffle
+    deck.addCards(cardsToShuffle);
+    deck.shuffle();
+
+    _logAction(
+      'force reshuffled ${cardsToShuffle.length} cards from discard into deck',
+    );
   }
 
   /// Reshuffles discard pile into deck when deck runs low.

--- a/test/models/deck_reshuffle_edge_cases_test.dart
+++ b/test/models/deck_reshuffle_edge_cases_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/deck.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Deck Reshuffle Edge Cases', () {
+    late GameState gameState;
+    late List<Player> players;
+
+    setUp(() {
+      players = [
+        Player(id: '1', name: 'Player 1', type: PlayerType.human),
+        Player(id: '2', name: 'Bot 2', type: PlayerType.bot),
+      ];
+      final deck = Deck();
+      gameState = GameState(players: players, deck: deck);
+    });
+
+    test('should handle deck empty with sufficient discard cards', () {
+      // Empty the deck
+      while (!gameState.deck.isEmpty) {
+        gameState.deck.drawCard();
+      }
+
+      // Add cards to discard pile to simulate game progression
+      gameState.discardPile.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ten),
+      ]);
+
+      expect(gameState.deck.isEmpty, isTrue);
+      expect(gameState.discardPile.length, equals(4));
+
+      // Attempt to draw - should trigger reshuffle
+      final drawSuccess = gameState.drawFromDeck();
+
+      expect(drawSuccess, isTrue);
+      expect(gameState.deck.isEmpty, isFalse);
+      expect(
+        gameState.discardPile.length,
+        equals(1),
+      ); // Should keep top discard
+    });
+
+    test('should handle deck empty with minimal discard cards (edge case)', () {
+      // Empty the deck
+      while (!gameState.deck.isEmpty) {
+        gameState.deck.drawCard();
+      }
+
+      // Add exactly 3 cards to discard pile (allows reshuffle with 2 cards)
+      gameState.discardPile.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+      ]);
+
+      expect(gameState.deck.isEmpty, isTrue);
+      expect(gameState.discardPile.length, equals(3));
+
+      // Attempt to draw - should trigger emergency reshuffle
+      final drawSuccess = gameState.drawFromDeck();
+
+      expect(drawSuccess, isTrue);
+      expect(
+        gameState.discardPile.length,
+        equals(1),
+      ); // Should keep top discard
+      // Deck might be empty again after drawing if we only had 2 cards to reshuffle
+    });
+
+    test(
+      'should handle absolute edge case: deck empty with 1 discard card',
+      () {
+        // Empty the deck
+        while (!gameState.deck.isEmpty) {
+          gameState.deck.drawCard();
+        }
+
+        // Add exactly 1 card to discard pile (cannot reshuffle safely)
+        gameState.discardPile.add(
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        );
+
+        expect(gameState.deck.isEmpty, isTrue);
+        expect(gameState.discardPile.length, equals(1));
+
+        // Attempt to draw - should fail gracefully
+        final drawSuccess = gameState.drawFromDeck();
+
+        expect(drawSuccess, isFalse);
+        expect(
+          gameState.discardPile.length,
+          equals(1),
+        ); // Should preserve discard
+      },
+    );
+
+    test('should handle completely empty deck and discard pile', () {
+      // Empty both deck and discard pile
+      while (!gameState.deck.isEmpty) {
+        gameState.deck.drawCard();
+      }
+      gameState.discardPile.clear();
+
+      expect(gameState.deck.isEmpty, isTrue);
+      expect(gameState.discardPile.isEmpty, isTrue);
+
+      // Attempt to draw - should fail gracefully
+      final drawSuccess = gameState.drawFromDeck();
+
+      expect(drawSuccess, isFalse);
+    });
+
+    test('should successfully draw multiple cards after reshuffle', () {
+      // Empty the deck
+      while (!gameState.deck.isEmpty) {
+        gameState.deck.drawCard();
+      }
+
+      // Add plenty of cards to discard pile
+      for (int i = 0; i < 10; i++) {
+        gameState.discardPile.add(
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        );
+      }
+
+      expect(gameState.deck.isEmpty, isTrue);
+      expect(gameState.discardPile.length, equals(10));
+
+      // Should be able to draw required number of cards (usually 2)
+      final drawSuccess = gameState.drawFromDeck();
+
+      expect(drawSuccess, isTrue);
+      expect(
+        gameState.discardPile.length,
+        equals(1),
+      ); // Should keep top discard
+      expect(gameState.deck.isEmpty, isFalse); // Should have cards left
+    });
+
+    test('should handle reshuffle during multi-card draw', () {
+      // Set up deck with exactly 1 card
+      while (!gameState.deck.isEmpty) {
+        gameState.deck.drawCard();
+      }
+      gameState.deck.addCards([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+      ]);
+
+      // Add cards to discard pile for reshuffling
+      gameState.discardPile.addAll([
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ten),
+      ]);
+
+      expect(gameState.deck.isEmpty, isFalse);
+      expect(gameState.discardPile.length, equals(3));
+
+      // Draw should succeed: 1 from deck, reshuffle, then 1 more from reshuffled deck
+      final drawSuccess = gameState.drawFromDeck();
+
+      expect(drawSuccess, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
- Added a new method to attempt reshuffling the discard pile when the deck is empty, enhancing game resilience.
- Introduced a force reshuffle mechanism to handle edge cases with minimal discard cards.
- Updated existing draw logic to accommodate the new reshuffle behavior and ensure graceful handling of insufficient cards.
- Added comprehensive tests to cover various edge cases related to deck and discard pile interactions.