### PR TITLE
fix: simplify Firebase options injection to prevent CI build failures

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -66,14 +66,8 @@ jobs:
           # Create firebase_options.dart from secrets
           echo "${{ secrets.FIREBASE_WEB_CONFIG }}" | base64 -d > lib/firebase_options.dart
           
-          # Replace the helper class with proper import
-          sed -i 's/class _FirebaseOptionsHelper {/\/\/ Replaced by CI\/CD - import firebase options/' lib/services/firebase_service.dart
-          sed -i 's/static FirebaseOptions? get currentPlatform {/\/\/ Import DefaultFirebaseOptions from firebase_options.dart/' lib/services/firebase_service.dart
-          sed -i 's/return null;/\/\/ Using DefaultFirebaseOptions.currentPlatform/' lib/services/firebase_service.dart
-          sed -i 's/_FirebaseOptionsHelper.currentPlatform/DefaultFirebaseOptions.currentPlatform/' lib/services/firebase_service.dart
-          
-          # Add the proper import
-          sed -i '12a import '\''../firebase_options.dart'\'';' lib/services/firebase_service.dart
+          # Replace the simple function with proper Firebase options import
+          sed -i 's|return null; // Development fallback|import '\''../firebase_options.dart'\''; return DefaultFirebaseOptions.currentPlatform;|' lib/services/firebase_service.dart
 
       - name: Install dependencies
         run: flutter pub get
@@ -112,14 +106,8 @@ jobs:
           # Create firebase_options.dart from secrets
           echo "${{ secrets.FIREBASE_WEB_CONFIG }}" | base64 -d > lib/firebase_options.dart
           
-          # Replace the helper class with proper import
-          sed -i 's/class _FirebaseOptionsHelper {/\/\/ Replaced by CI\/CD - import firebase options/' lib/services/firebase_service.dart
-          sed -i 's/static FirebaseOptions? get currentPlatform {/\/\/ Import DefaultFirebaseOptions from firebase_options.dart/' lib/services/firebase_service.dart
-          sed -i 's/return null;/\/\/ Using DefaultFirebaseOptions.currentPlatform/' lib/services/firebase_service.dart
-          sed -i 's/_FirebaseOptionsHelper.currentPlatform/DefaultFirebaseOptions.currentPlatform/' lib/services/firebase_service.dart
-          
-          # Add the proper import
-          sed -i '12a import '\''../firebase_options.dart'\'';' lib/services/firebase_service.dart
+          # Replace the simple function with proper Firebase options import
+          sed -i 's|return null; // Development fallback|import '\''../firebase_options.dart'\''; return DefaultFirebaseOptions.currentPlatform;|' lib/services/firebase_service.dart
 
       - name: Install dependencies
         run: flutter pub get

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -11,14 +11,11 @@ import '../models/card.dart';
 import '../models/meld.dart';
 import 'firebase_constants.dart';
 
-// Conditional import for Firebase options
-// This will be replaced by build process in CI/CD
-class _FirebaseOptionsHelper {
-  static FirebaseOptions? get currentPlatform {
-    // In production builds, this will be replaced with actual Firebase options
-    // In development, this returns null for graceful fallback
-    return null;
-  }
+// Simple approach: Try to import firebase_options, gracefully fail if not available
+FirebaseOptions? _getFirebaseOptions() {
+  // This will work when firebase_options.dart exists (production)
+  // In development without the file, we'll just return null
+  return null; // Development fallback
 }
 
 /// Firebase service for handling multiplayer game state synchronization
@@ -55,7 +52,7 @@ class FirebaseService {
 
     try {
       // Initialize Firebase with options if available, otherwise use default
-      final options = _FirebaseOptionsHelper.currentPlatform;
+      final options = _getFirebaseOptions();
       _logger.info('🔥 Initializing Firebase with options: ${options != null}');
 
       await Firebase.initializeApp(options: options);


### PR DESCRIPTION
- Replace complex sed commands that broke class structure
- Use simple function replacement instead of class manipulation
- Ensure compilation succeeds in production with proper Firebase config
- Maintain development environment compatibility

This should resolve the 'Expected a declaration, but got '}'' error
that was causing the web build to fail in GitHub Actions.