### PR TITLE
fix: ensure bot continues turn after drawing or melding

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -190,9 +190,27 @@ class _GameScreenState extends State<GameScreen> {
       switch (decision.action) {
         case 'drawFromDeck':
           _gameController.drawFromDeck();
+          // CRITICAL FIX: Continue bot turn immediately after drawing
+          // Drawing advances phase to meld - bot needs to make meld decision
+          if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
+              _gameController.gameState.turnPhase == TurnPhase.meld) {
+            // Schedule immediate continuation of the same bot's turn
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _processBotTurn();
+            });
+          }
           break;
         case 'drawFromDiscard':
           _gameController.drawFromDiscardPile();
+          // CRITICAL FIX: Continue bot turn immediately after drawing
+          // Drawing advances phase to meld - bot needs to make meld decision
+          if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
+              _gameController.gameState.turnPhase == TurnPhase.meld) {
+            // Schedule immediate continuation of the same bot's turn
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _processBotTurn();
+            });
+          }
           break;
         case 'createMeld':
           final cards = decision.data as List<PlayingCard>;
@@ -202,10 +220,26 @@ class _GameScreenState extends State<GameScreen> {
           } else {
             _gameController.createMeld(cards);
           }
+          // POTENTIAL FIX: Continue bot turn if still in meld phase after melding
+          // Some meld actions don't advance to discard phase automatically
+          if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
+              _gameController.gameState.turnPhase == TurnPhase.meld) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _processBotTurn();
+            });
+          }
           break;
         case 'addToMeld':
           final data = decision.data as Map<String, dynamic>;
           _gameController.addCardToMeld(data['meldIndex'], data['card']);
+          // POTENTIAL FIX: Continue bot turn if still in meld phase after adding
+          // Some add-to-meld actions don't advance to discard phase automatically
+          if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
+              _gameController.gameState.turnPhase == TurnPhase.meld) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _processBotTurn();
+            });
+          }
           break;
         case 'discard':
           final card = decision.data as PlayingCard;

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -47,6 +47,7 @@ class _GameScreenState extends State<GameScreen> {
   bool _statusExpanded = false;
   bool _actionsExpanded = false;
   bool _disposed = false; // Track disposal state
+  bool _botTurnScheduled = false; // Prevent multiple bot turn callbacks
 
   @override
   void initState() {
@@ -150,6 +151,35 @@ class _GameScreenState extends State<GameScreen> {
     });
   }
 
+  /// Schedule bot turn continuation after draw/meld actions
+  ///
+  /// This addresses the critical issue where bot turns require multiple sequential
+  /// decisions (draw → meld → discard) but the original code only processed one
+  /// decision per turn, causing bots to freeze mid-turn.
+  ///
+  /// Features:
+  /// - Race condition protection via _botTurnScheduled flag
+  /// - Widget disposal safety checks (prevents crashes if widget is disposed)
+  /// - Uses addPostFrameCallback for proper Flutter lifecycle integration
+  /// - Only continues if bot is still current player in meld phase
+  void _scheduleBotTurnContinuation() {
+    // Prevent multiple callbacks and check widget state
+    if (_botTurnScheduled || _disposed || !mounted) return;
+
+    // Only continue if bot is still current player and in meld phase
+    if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
+        _gameController.gameState.turnPhase == TurnPhase.meld) {
+      _botTurnScheduled = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _botTurnScheduled = false;
+        // Double-check widget state before processing
+        if (!_disposed && mounted) {
+          _processBotTurn();
+        }
+      });
+    }
+  }
+
   Future<void> _checkAndHandleRoundEnd() async {
     if (_gameController.gameState.phase == GamePhase.roundEnd) {
       await Future.delayed(
@@ -192,25 +222,13 @@ class _GameScreenState extends State<GameScreen> {
           _gameController.drawFromDeck();
           // CRITICAL FIX: Continue bot turn immediately after drawing
           // Drawing advances phase to meld - bot needs to make meld decision
-          if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
-              _gameController.gameState.turnPhase == TurnPhase.meld) {
-            // Schedule immediate continuation of the same bot's turn
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              _processBotTurn();
-            });
-          }
+          _scheduleBotTurnContinuation();
           break;
         case 'drawFromDiscard':
           _gameController.drawFromDiscardPile();
           // CRITICAL FIX: Continue bot turn immediately after drawing
           // Drawing advances phase to meld - bot needs to make meld decision
-          if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
-              _gameController.gameState.turnPhase == TurnPhase.meld) {
-            // Schedule immediate continuation of the same bot's turn
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              _processBotTurn();
-            });
-          }
+          _scheduleBotTurnContinuation();
           break;
         case 'createMeld':
           final cards = decision.data as List<PlayingCard>;
@@ -222,24 +240,14 @@ class _GameScreenState extends State<GameScreen> {
           }
           // POTENTIAL FIX: Continue bot turn if still in meld phase after melding
           // Some meld actions don't advance to discard phase automatically
-          if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
-              _gameController.gameState.turnPhase == TurnPhase.meld) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              _processBotTurn();
-            });
-          }
+          _scheduleBotTurnContinuation();
           break;
         case 'addToMeld':
           final data = decision.data as Map<String, dynamic>;
           _gameController.addCardToMeld(data['meldIndex'], data['card']);
           // POTENTIAL FIX: Continue bot turn if still in meld phase after adding
           // Some add-to-meld actions don't advance to discard phase automatically
-          if (_gameController.gameState.currentPlayer.type == PlayerType.bot &&
-              _gameController.gameState.turnPhase == TurnPhase.meld) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              _processBotTurn();
-            });
-          }
+          _scheduleBotTurnContinuation();
           break;
         case 'discard':
           final card = decision.data as PlayingCard;


### PR DESCRIPTION
- Implemented critical fixes to allow the bot to continue its turn immediately after drawing from the deck or discard pile, ensuring it can make necessary meld decisions.
- Added logic to handle cases where the bot remains in the meld phase after creating or adding to a meld, preventing unintended turn skips.
- Utilized `WidgetsBinding.instance.addPostFrameCallback` to schedule the continuation of the bot's turn seamlessly.

These changes enhance the bot's gameplay flow and decision-making efficiency.