### PR TITLE
feat: implement display order for playing cards and update sorting logic

### DIFF
--- a/lib/models/card.dart
+++ b/lib/models/card.dart
@@ -89,6 +89,40 @@ class PlayingCard {
     }
   }
 
+  /// Display order for cards in hand: 3s → 4-K → Aces → 2s (wilds) → Jokers
+  int get displayOrder {
+    switch (rank) {
+      case CardRank.three:
+        return 1;
+      case CardRank.four:
+        return 2;
+      case CardRank.five:
+        return 3;
+      case CardRank.six:
+        return 4;
+      case CardRank.seven:
+        return 5;
+      case CardRank.eight:
+        return 6;
+      case CardRank.nine:
+        return 7;
+      case CardRank.ten:
+        return 8;
+      case CardRank.jack:
+        return 9;
+      case CardRank.queen:
+        return 10;
+      case CardRank.king:
+        return 11;
+      case CardRank.ace:
+        return 12;
+      case CardRank.two:
+        return 13; // Wild card
+      case CardRank.joker:
+        return 14; // Wild card
+    }
+  }
+
   String get displayName {
     if (isJoker) return 'Joker';
     final rankName = rank.name[0].toUpperCase() + rank.name.substring(1);

--- a/lib/models/player.dart
+++ b/lib/models/player.dart
@@ -367,22 +367,15 @@ class Player {
 
   void sortHandByRank() {
     _sortHandPreservingNewlyDrawnCards((a, b) {
-      if (a.isJoker && b.isJoker) return 0;
-      if (a.isJoker) return 1;
-      if (b.isJoker) return -1;
-      return a.meldValue.compareTo(b.meldValue);
+      return a.displayOrder.compareTo(b.displayOrder);
     });
   }
 
   void sortHandBySuit() {
     _sortHandPreservingNewlyDrawnCards((a, b) {
-      if (a.isJoker && b.isJoker) return 0;
-      if (a.isJoker) return 1;
-      if (b.isJoker) return -1;
-
       final suitComparison = (a.suit?.index ?? 4).compareTo(b.suit?.index ?? 4);
       if (suitComparison != 0) return suitComparison;
-      return a.meldValue.compareTo(b.meldValue);
+      return a.displayOrder.compareTo(b.displayOrder);
     });
   }
 

--- a/lib/widgets/advanced_meld_selector.dart
+++ b/lib/widgets/advanced_meld_selector.dart
@@ -541,6 +541,7 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
                   key: ValueKey('mobile_card_$handIndex'),
                   card: card,
                   isSelected: isSelected,
+                  isDisabled: card.isThree,
                   onTap: () => _toggleCardSelection(index),
                 );
               },
@@ -686,6 +687,12 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
     final handIndex = availableCardIndices[availableIndex];
     final card = widget.player.currentHand[handIndex];
 
+    // Prevent selection of 3s
+    if (card.isThree) {
+      _showError('3s cannot be melded');
+      return;
+    }
+
     setState(() {
       if (selectedAvailableIndices.contains(availableIndex)) {
         selectedAvailableIndices.remove(availableIndex);
@@ -750,10 +757,7 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
     availableCardIndices.sort((a, b) {
       final cardA = widget.player.currentHand[a];
       final cardB = widget.player.currentHand[b];
-
-      if (cardA.isWild && !cardB.isWild) return 1;
-      if (!cardA.isWild && cardB.isWild) return -1;
-      return cardA.rank.index.compareTo(cardB.rank.index);
+      return cardA.displayOrder.compareTo(cardB.displayOrder);
     });
   }
 
@@ -838,10 +842,12 @@ class _MobileCardWidget extends StatelessWidget {
     required this.card,
     required this.isSelected,
     required this.onTap,
+    this.isDisabled = false,
   });
 
   final PlayingCard card;
   final bool isSelected;
+  final bool isDisabled;
   final VoidCallback onTap;
 
   @override
@@ -849,7 +855,7 @@ class _MobileCardWidget extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: onTap,
+        onTap: isDisabled ? null : onTap,
         borderRadius: BorderRadius.circular(12),
         child: Container(
           decoration: isSelected
@@ -867,11 +873,29 @@ class _MobileCardWidget extends StatelessWidget {
                   ],
                 )
               : null,
-          child: PlayingCardWidget(
-            card: card,
-            width: _ResponsiveHelper.getCardWidth(context),
-            height: _ResponsiveHelper.getCardHeight(context),
-            isSelected: isSelected,
+          child: Stack(
+            children: [
+              PlayingCardWidget(
+                card: card,
+                width: _ResponsiveHelper.getCardWidth(context),
+                height: _ResponsiveHelper.getCardHeight(context),
+                isSelected: isSelected,
+              ),
+              if (isDisabled)
+                Positioned.fill(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      color: Colors.black.withValues(alpha: 0.6),
+                    ),
+                    child: Icon(
+                      Icons.block,
+                      color: Colors.red.withValues(alpha: 0.8),
+                      size: 32,
+                    ),
+                  ),
+                ),
+            ],
           ),
         ),
       ),

--- a/lib/widgets/meld_widget.dart
+++ b/lib/widgets/meld_widget.dart
@@ -131,12 +131,18 @@ class MeldWidget extends StatelessWidget {
             Wrap(
               spacing: 4,
               runSpacing: 4,
-              children: meld.cards
-                  .map(
-                    (card) =>
-                        PlayingCardWidget(card: card, width: 40, height: 56),
-                  )
-                  .toList(),
+              children: () {
+                final sortedCards = [...meld.cards];
+                sortedCards.sort(
+                  (a, b) => a.displayOrder.compareTo(b.displayOrder),
+                );
+                return sortedCards
+                    .map(
+                      (card) =>
+                          PlayingCardWidget(card: card, width: 40, height: 56),
+                    )
+                    .toList();
+              }(),
             ),
           ],
         ),

--- a/test/models/player_test.dart
+++ b/test/models/player_test.dart
@@ -358,12 +358,12 @@ void main() {
 
       player.dealHand(List.from(cards));
 
-      // Sort by rank (meld value)
+      // Sort by rank (display order: 3s → 4-K → Aces → 2s → Jokers)
       player.sortHandByRank();
       expect(
         player.currentHand.first.rank,
-        equals(CardRank.two),
-      ); // Lowest meld value
+        equals(CardRank.four),
+      ); // Four comes first (lowest display order of available cards)
       expect(
         player.currentHand.last.rank,
         equals(CardRank.joker),

--- a/test/newly_drawn_cards_sorting_test.dart
+++ b/test/newly_drawn_cards_sorting_test.dart
@@ -42,49 +42,46 @@ void main() {
         false,
       ); // King (not newly drawn)
 
-      // Sort by rank - this will rearrange cards
-      // Expected order after sort: Two(2), Four(4), Queen(12), King(13), Ace(14)
+      // Sort by rank - this will rearrange cards using new display order
+      // Expected order after sort: Four(2), Queen(10), King(11), Ace(12), Two(13)
       humanPlayer.sortHandByRank();
 
       // Verify the cards are in the expected positions after sorting
+      expect(humanPlayer.currentHand[0].rank, CardRank.four); // Four first
+      expect(humanPlayer.currentHand[1].rank, CardRank.queen); // Queen
+      expect(humanPlayer.currentHand[2].rank, CardRank.king); // King
+      expect(humanPlayer.currentHand[3].rank, CardRank.ace); // Ace
       expect(
-        humanPlayer.currentHand[0].rank,
+        humanPlayer.currentHand[4].rank,
         CardRank.two,
-      ); // Two moved to beginning
-      expect(humanPlayer.currentHand[1].rank, CardRank.four); // Four
-      expect(
-        humanPlayer.currentHand[2].rank,
-        CardRank.queen,
-      ); // Queen moved to middle
-      expect(humanPlayer.currentHand[3].rank, CardRank.king); // King
-      expect(humanPlayer.currentHand[4].rank, CardRank.ace); // Ace moved to end
+      ); // Two moved to end (wild card)
 
       // IMPORTANT: The newly drawn cards should still be highlighted at their new positions
       expect(
-        humanPlayer.isCardIndexNewlyDrawn(0),
+        humanPlayer.isCardIndexNewlyDrawn(4),
         true,
-        reason: 'Two should still be highlighted at its new position (index 0)',
+        reason: 'Two should still be highlighted at its new position (index 4)',
       );
       expect(
-        humanPlayer.isCardIndexNewlyDrawn(2),
+        humanPlayer.isCardIndexNewlyDrawn(1),
         true,
         reason:
-            'Queen should still be highlighted at its new position (index 2)',
+            'Queen should still be highlighted at its new position (index 1)',
       );
 
       // The original cards should not be highlighted
       expect(
-        humanPlayer.isCardIndexNewlyDrawn(1),
+        humanPlayer.isCardIndexNewlyDrawn(0),
         false,
         reason: 'Four should not be highlighted (was not newly drawn)',
       );
       expect(
-        humanPlayer.isCardIndexNewlyDrawn(3),
+        humanPlayer.isCardIndexNewlyDrawn(2),
         false,
         reason: 'King should not be highlighted (was not newly drawn)',
       );
       expect(
-        humanPlayer.isCardIndexNewlyDrawn(4),
+        humanPlayer.isCardIndexNewlyDrawn(3),
         false,
         reason: 'Ace should not be highlighted (was not newly drawn)',
       );


### PR DESCRIPTION
- Added a new `displayOrder` property to the `PlayingCard` class to define the order of cards in hand: 3s → 4-K → Aces → 2s (wilds) → Jokers.
- Updated the `sortHandByRank` and `sortHandBySuit` methods in the `Player` class to utilize the new `displayOrder` for sorting.
- Enhanced the `AdvancedMeldSelector` to prevent selection of 3s and updated the card sorting logic in the meld widget.
- Adjusted tests to reflect changes in sorting behavior based on the new display order.