### PR TITLE
feat: enhance bot discard pile handling and logging

### DIFF
--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -126,7 +126,8 @@ class EnhancedBotAI {
           bot,
         );
 
-        if (_shouldTakeDiscardPile(bot, controller, riskTolerance)) {
+        if (_shouldTakeDiscardPile(bot, controller, riskTolerance) &&
+            controller.gameState.canUnlockDiscard()) {
           DebugLogger.botDebug(
             bot.id,
             bot.name,

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -404,7 +404,19 @@ class _GameScreenState extends State<GameScreen> {
         _gameController.gameState.currentPlayer.type != PlayerType.bot) {
       return;
     }
-    _gameController.drawFromDiscardPile();
+
+    // Check if discard pile draw succeeds - if not, fallback to deck draw
+    final success = _gameController.drawFromDiscardPile();
+    if (!success) {
+      // Bot couldn't unlock discard pile - fallback to drawing from deck
+      DebugLogger.botDebug(
+        currentPlayer.id,
+        currentPlayer.name,
+        'Failed to unlock discard pile, drawing from deck instead',
+      );
+      _gameController.drawFromDeck();
+    }
+
     _scheduleBotTurnContinuation();
   }
 


### PR DESCRIPTION
- Updated the EnhancedBotAI to include a check for the ability to unlock the discard pile before taking it.
- Improved the GameScreen logic to handle failed attempts to draw from the discard pile, implementing a fallback to drawing from the deck with appropriate logging for better traceability during bot actions.