### PR TITLE
feat: enhance bot strategies for wild cards and foot transitions

### DIFF
--- a/lib/ai/bot_foot_transition_manager.dart
+++ b/lib/ai/bot_foot_transition_manager.dart
@@ -230,11 +230,27 @@ class BotFootTransitionManager {
     GameController controller,
   ) {
     final handSize = bot.currentHand.length;
+    final wildCards = bot.currentHand.where((c) => c.isWild).toList();
 
     // Emergency discard for extremely large hands
     if (handSize > largeHandEmergencyThreshold) {
       final cardToDiscard = _chooseCardToDiscard(bot);
       return BotDecision(action: 'discard', data: cardToDiscard);
+    }
+
+    // Priority 1: Use wild cards aggressively when transitioning to foot
+    if (wildCards.isNotEmpty && handSize <= 8) {
+      // Try to add wilds to existing melds to clear hand faster
+      final cardsToAddWithWilds =
+          _findCardsToAddToExistingMeldsWithWildPriority(
+            bot,
+            controller,
+            prioritizeWilds: true,
+          );
+      if (cardsToAddWithWilds.isNotEmpty) {
+        final cardToAdd = cardsToAddWithWilds.first;
+        return BotDecision(action: 'addToMeld', data: cardToAdd);
+      }
     }
 
     // Add to existing melds if hand is small enough
@@ -244,10 +260,10 @@ class BotFootTransitionManager {
       return BotDecision(action: 'addToMeld', data: cardToAdd);
     }
 
-    // Try to create any meld possible
+    // Try to create any meld possible (prioritize using wilds)
     final possibleMelds = controller.findPossibleMelds(bot);
     if (possibleMelds.isNotEmpty) {
-      final bestMeld = _chooseLargestMeld(possibleMelds);
+      final bestMeld = _chooseBestMeldForTransition(possibleMelds, wildCards);
       return BotDecision(action: 'createMeld', data: bestMeld);
     }
 
@@ -440,21 +456,49 @@ class BotFootTransitionManager {
     final remainingCards = bot.currentHand.length;
     if (remainingCards <= 3) return true;
 
-    // Count addable cards
-    final cardsToAddToMelds = _findCardsToAddToExistingMelds(bot, controller);
-    final addableCards = cardsToAddToMelds.length;
+    // Count addable cards and meldable cards more accurately
+    final totalPlayable = _calculateTotalPlayableCards(bot, controller);
 
-    // Count meldable cards
-    final possibleMelds = controller.findPossibleMelds(bot);
-    int meldableCards = 0;
-    if (possibleMelds.isNotEmpty) {
-      final bestMeld = _chooseLargestMeld(possibleMelds);
-      meldableCards = bestMeld.length;
-    }
+    // Can we play ALL cards? (immediate foot transition)
+    if (totalPlayable >= remainingCards) return true;
 
     // Can we use 60%+ of remaining cards?
-    final usableCards = addableCards + meldableCards;
-    return usableCards >= (remainingCards * mostCardsPlayableThreshold).floor();
+    return totalPlayable >=
+        (remainingCards * mostCardsPlayableThreshold).floor();
+  }
+
+  /// Calculate total cards that can be played (avoiding double-counting)
+  int _calculateTotalPlayableCards(Player bot, GameController controller) {
+    Set<PlayingCard> usedCards = {};
+    int totalPlayable = 0;
+
+    // Count cards that can be added to existing melds
+    final cardsToAddToMelds = _findCardsToAddToExistingMelds(bot, controller);
+    for (final addition in cardsToAddToMelds) {
+      final card = addition['card'] as PlayingCard;
+      if (!usedCards.contains(card)) {
+        usedCards.add(card);
+        totalPlayable++;
+      }
+    }
+
+    // Count cards in possible melds (avoiding cards already counted)
+    final possibleMelds = controller.findPossibleMelds(bot);
+    for (final meld in possibleMelds) {
+      int newCardsInMeld = 0;
+      for (final card in meld) {
+        if (!usedCards.contains(card)) {
+          usedCards.add(card);
+          newCardsInMeld++;
+        }
+      }
+      // Only count this meld if it adds new cards
+      if (newCardsInMeld >= GameConfig.minTotalCardsForMeld) {
+        totalPlayable += newCardsInMeld;
+      }
+    }
+
+    return totalPlayable;
   }
 
   /// Check if bot can play some of their cards (50% threshold)
@@ -483,6 +527,39 @@ class BotFootTransitionManager {
   List<PlayingCard> _chooseLargestMeld(List<List<PlayingCard>> possibleMelds) {
     possibleMelds.sort((a, b) => b.length.compareTo(a.length));
     return possibleMelds.first;
+  }
+
+  /// Choose the best meld for foot transition (prioritize using wilds)
+  List<PlayingCard> _chooseBestMeldForTransition(
+    List<List<PlayingCard>> possibleMelds,
+    List<PlayingCard> wildCards,
+  ) {
+    if (wildCards.isEmpty) {
+      // No wilds, just choose largest meld
+      return _chooseLargestMeld(possibleMelds);
+    }
+
+    // Find melds that contain wild cards
+    final meldsWithWilds = possibleMelds.where((meld) {
+      return meld.any((card) => card.isWild);
+    }).toList();
+
+    if (meldsWithWilds.isNotEmpty) {
+      // Prefer melds that use our wild cards
+      meldsWithWilds.sort((a, b) {
+        final aWildCount = a.where((c) => c.isWild).length;
+        final bWildCount = b.where((c) => c.isWild).length;
+        // First by wild count (more wilds used = better)
+        final wildCompare = bWildCount.compareTo(aWildCount);
+        if (wildCompare != 0) return wildCompare;
+        // Then by total size
+        return b.length.compareTo(a.length);
+      });
+      return meldsWithWilds.first;
+    }
+
+    // No melds with wilds, choose largest
+    return _chooseLargestMeld(possibleMelds);
   }
 
   /// Calculate the total point value of a hand
@@ -536,6 +613,39 @@ class BotFootTransitionManager {
     }
 
     // Sort by priority (highest point value first)
+    additions.sort((a, b) => b['priority'].compareTo(a['priority']));
+    return additions;
+  }
+
+  /// Find cards that can be added to existing melds with wild card priority
+  List<Map<String, dynamic>> _findCardsToAddToExistingMeldsWithWildPriority(
+    Player bot,
+    GameController controller, {
+    bool prioritizeWilds = false,
+  }) {
+    final additions = <Map<String, dynamic>>[];
+
+    for (int i = 0; i < bot.melds.length; i++) {
+      final meld = bot.melds[i];
+      for (final card in bot.currentHand) {
+        if (_canAddCardToMeld(card, meld, controller)) {
+          // When prioritizing wilds for foot transition, give them higher priority
+          int priority = card.pointValue;
+          if (prioritizeWilds && card.isWild) {
+            priority += 100; // Boost wild card priority
+          }
+
+          additions.add({
+            'card': card,
+            'meld': meld,
+            'meldIndex': i,
+            'priority': priority,
+          });
+        }
+      }
+    }
+
+    // Sort by priority (highest value first, wilds boosted if prioritizeWilds)
     additions.sort((a, b) => b['priority'].compareTo(a['priority']));
     return additions;
   }

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -163,6 +163,14 @@ class EnhancedBotAI {
       return endGameDecision;
     }
 
+    // NEW: Check if we can play ALL cards to immediately see foot
+    if (bot.hasPlayedDown && !bot.hasPickedUpFoot) {
+      final canPlayAllDecision = _checkCanPlayAllCards(bot, controller);
+      if (canPlayAllDecision != null) {
+        return canPlayAllDecision;
+      }
+    }
+
     // Check for foot transition decisions
     final footTransitionDecision = _footTransitionManager.handleFootTransition(
       bot,
@@ -418,7 +426,18 @@ class EnhancedBotAI {
       return _selectRandomly(bestThrees);
     }
 
-    // Priority 2: Discard lowest value non-useful cards
+    // Priority 2: Check if we should hold wild cards strategically
+    final wildCards = hand.where((card) => card.isWild).toList();
+    final stillOnHandPile = bot.hasPlayedDown && !bot.hasPickedUpFoot;
+
+    // If we're still on hand pile and have wild cards, keep them for foot transition
+    // unless we have too many (excessive holding is bad)
+    if (stillOnHandPile && wildCards.isNotEmpty && wildCards.length < 8) {
+      // Don't discard wilds - they're valuable for foot transition
+      // Continue to find other cards to discard
+    }
+
+    // Priority 3: Discard lowest value non-useful cards (avoid wilds if still on hand pile)
     final rankCounts = <CardRank, int>{};
     for (final card in hand) {
       if (!card.isWild) {
@@ -441,8 +460,19 @@ class EnhancedBotAI {
       return _selectRandomly(bestSingletons);
     }
 
-    // Fallback: Discard lowest value card
-    final sortedHand = List<PlayingCard>.from(hand);
+    // Fallback: Discard lowest value card (avoiding wilds if still on hand pile)
+    List<PlayingCard> sortedHand;
+    if (stillOnHandPile && wildCards.length < 8) {
+      // Exclude wild cards from discard options when still on hand pile
+      sortedHand = List<PlayingCard>.from(hand.where((card) => !card.isWild));
+      if (sortedHand.isEmpty) {
+        // If only wilds left, must discard one
+        sortedHand = List<PlayingCard>.from(hand);
+      }
+    } else {
+      sortedHand = List<PlayingCard>.from(hand);
+    }
+
     sortedHand.sort((a, b) => a.pointValue.compareTo(b.pointValue));
     // Add variability: if there are multiple cards of the same low value, randomly pick one
     final bestValue = sortedHand.first.pointValue;
@@ -516,6 +546,8 @@ class EnhancedBotAI {
     final gameState = controller.gameState;
     final handSize = bot.currentHand.length;
     final playDownRequirement = gameState.playDownRequirement;
+    final stillOnHandPile = bot.hasPlayedDown && !bot.hasPickedUpFoot;
+    final wildCards = bot.currentHand.where((c) => c.isWild).toList();
 
     // For initial play-down: check if we have enough meld potential for the round requirement
     if (!bot.hasPlayedDown) {
@@ -531,6 +563,12 @@ class EnhancedBotAI {
 
     // Execute if hand is getting dangerously large
     if (handSize >= 15) return true;
+
+    // NEW: Be more aggressive if on hand pile with wilds and close to foot
+    if (stillOnHandPile && wildCards.isNotEmpty && handSize <= 8) {
+      // If we have wilds and are close to foot, dump everything we can
+      if (dumpPotential >= 0.6) return true; // Lower threshold with wilds
+    }
 
     // Execute if we can go directly to foot
     final possibleMelds = _meldAnalyzer.getPossibleMelds(bot, controller);
@@ -649,6 +687,59 @@ class EnhancedBotAI {
         cardsToAdd.length;
 
     return (meldableCards / handSize).clamp(0.0, 1.0);
+  }
+
+  /// Check if bot can play ALL cards to immediately transition to foot
+  BotDecision? _checkCanPlayAllCards(Player bot, GameController controller) {
+    final handSize = bot.currentHand.length;
+    if (handSize == 0) return null;
+
+    // Get all cards we can potentially play
+    final possibleMelds = _meldAnalyzer.getPossibleMelds(bot, controller);
+    final cardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
+      bot,
+      controller,
+    );
+
+    // Calculate total playable cards
+    int totalPlayableCards = 0;
+    Set<PlayingCard> usedCards = {};
+
+    // Count cards that can be added to existing melds
+    for (final addition in cardsToAdd) {
+      final card = addition['card'] as PlayingCard;
+      if (!usedCards.contains(card)) {
+        usedCards.add(card);
+        totalPlayableCards++;
+      }
+    }
+
+    // Count cards that can form new melds (avoiding double-counting)
+    for (final meld in possibleMelds) {
+      int newCardsInMeld = 0;
+      for (final card in meld) {
+        if (!usedCards.contains(card)) {
+          usedCards.add(card);
+          newCardsInMeld++;
+        }
+      }
+      totalPlayableCards += newCardsInMeld;
+    }
+
+    // If we can play ALL cards, execute the strategy
+    if (totalPlayableCards >= handSize) {
+      // Prioritize adding to existing melds first
+      if (cardsToAdd.isNotEmpty) {
+        return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+      }
+      // Then create new melds
+      if (possibleMelds.isNotEmpty) {
+        final bestMeld = _meldAnalyzer.findBestMeld(possibleMelds, bot: bot);
+        return BotDecision(action: 'createMeld', data: bestMeld);
+      }
+    }
+
+    return null;
   }
 
   /// Determine if we should hold cards based on round play-down requirements

--- a/test/ai/bot_wild_card_strategy_test.dart
+++ b/test/ai/bot_wild_card_strategy_test.dart
@@ -1,0 +1,289 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+
+void main() {
+  group('Bot Wild Card and Foot Transition Strategy Tests', () {
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player botPlayer;
+
+    setUp(() {
+      botAI = EnhancedBotAI(seed: 42); // Deterministic for testing
+
+      final players = [
+        Player(id: '1', name: 'Human', type: PlayerType.human),
+        Player(id: '2', name: 'Bot', type: PlayerType.bot),
+      ];
+
+      gameController = GameController(players: players);
+      gameController.initializeGame();
+      botPlayer = players[1];
+    });
+
+    group('Wild Card Holding Strategy', () {
+      test('should hold wild cards when still on hand pile', () {
+        // Setup: Bot has played down but not picked up foot
+        botPlayer.hasPlayedDown = true;
+        botPlayer.hasPickedUpFoot = false;
+
+        // Give bot some cards including wilds
+        botPlayer.hand.clear();
+        botPlayer.hand.addAll([
+          PlayingCard(rank: CardRank.joker), // Wild
+          PlayingCard(rank: CardRank.two, suit: Suit.hearts), // Wild
+          PlayingCard(rank: CardRank.five, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.five, suit: Suit.diamonds),
+          PlayingCard(rank: CardRank.five, suit: Suit.clubs),
+          PlayingCard(rank: CardRank.seven, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.seven, suit: Suit.diamonds),
+        ]);
+
+        // Set to discard phase
+        gameController.gameState.currentPlayerIndex = 1;
+        gameController.gameState.turnPhase = TurnPhase.discard;
+
+        // Make decision
+        final decision = botAI.makeDecision(botPlayer, gameController);
+
+        // Should NOT discard wild cards
+        expect(decision.action, equals('discard'));
+        final discardedCard = decision.data as PlayingCard;
+        expect(
+          discardedCard.isWild,
+          isFalse,
+          reason: 'Bot should hold wild cards when on hand pile',
+        );
+      });
+
+      test('should use wild cards aggressively when close to foot', () {
+        // Setup: Bot close to foot transition with wilds
+        botPlayer.hasPlayedDown = true;
+        botPlayer.hasPickedUpFoot = false;
+
+        // Create existing meld bot can add to
+        botPlayer.melds.add(
+          Meld(
+            rank: CardRank.five,
+            cards: [
+              PlayingCard(rank: CardRank.five, suit: Suit.hearts),
+              PlayingCard(rank: CardRank.five, suit: Suit.diamonds),
+              PlayingCard(rank: CardRank.five, suit: Suit.clubs),
+            ],
+          ),
+        );
+
+        // Give bot small hand with wilds (close to foot)
+        botPlayer.hand.clear();
+        botPlayer.hand.addAll([
+          PlayingCard(rank: CardRank.joker), // Wild
+          PlayingCard(rank: CardRank.two, suit: Suit.hearts), // Wild
+          PlayingCard(rank: CardRank.five, suit: Suit.spades),
+          PlayingCard(rank: CardRank.seven, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.seven, suit: Suit.diamonds),
+        ]);
+
+        // Set to meld phase
+        gameController.gameState.currentPlayerIndex = 1;
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        // Make decision - should use wilds to transition
+        final decision = botAI.makeDecision(botPlayer, gameController);
+
+        // Should be trying to meld cards (including wilds)
+        expect(
+          ['addToMeld', 'createMeld', 'noMeld'],
+          contains(decision.action),
+          reason: 'Bot should try to meld when close to foot with wilds',
+        );
+      });
+    });
+
+    group('Play All Cards Strategy', () {
+      test('should recognize when all cards can be played to see foot', () {
+        // Setup: Bot has played down but not picked up foot
+        botPlayer.hasPlayedDown = true;
+        botPlayer.hasPickedUpFoot = false;
+
+        // Create existing melds bot can add to
+        botPlayer.melds.add(
+          Meld(
+            rank: CardRank.king,
+            cards: [
+              PlayingCard(rank: CardRank.king, suit: Suit.hearts),
+              PlayingCard(rank: CardRank.king, suit: Suit.diamonds),
+              PlayingCard(rank: CardRank.king, suit: Suit.clubs),
+            ],
+          ),
+        );
+
+        botPlayer.melds.add(
+          Meld(
+            rank: CardRank.queen,
+            cards: [
+              PlayingCard(rank: CardRank.queen, suit: Suit.hearts),
+              PlayingCard(rank: CardRank.queen, suit: Suit.diamonds),
+              PlayingCard(rank: CardRank.queen, suit: Suit.clubs),
+            ],
+          ),
+        );
+
+        // Give bot cards that can ALL be played
+        botPlayer.hand.clear();
+        botPlayer.hand.addAll([
+          PlayingCard(
+            rank: CardRank.king,
+            suit: Suit.spades,
+          ), // Can add to kings
+          PlayingCard(
+            rank: CardRank.queen,
+            suit: Suit.spades,
+          ), // Can add to queens
+          PlayingCard(rank: CardRank.joker), // Wild - can add anywhere
+        ]);
+
+        // Set to meld phase
+        gameController.gameState.currentPlayerIndex = 1;
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        // Make decision
+        final decision = botAI.makeDecision(botPlayer, gameController);
+
+        // Should immediately start playing cards since all can be played
+        expect(
+          decision.action,
+          equals('addToMeld'),
+          reason: 'Bot should play all cards to transition to foot immediately',
+        );
+      });
+
+      test('should create melds to play all cards when possible', () {
+        // Setup: Bot has played down but not picked up foot
+        botPlayer.hasPlayedDown = true;
+        botPlayer.hasPickedUpFoot = false;
+
+        // Give bot cards that can form complete melds
+        botPlayer.hand.clear();
+        botPlayer.hand.addAll([
+          PlayingCard(rank: CardRank.five, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.five, suit: Suit.diamonds),
+          PlayingCard(rank: CardRank.five, suit: Suit.clubs),
+          PlayingCard(rank: CardRank.seven, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.seven, suit: Suit.diamonds),
+          PlayingCard(rank: CardRank.seven, suit: Suit.clubs),
+        ]);
+
+        // Set to meld phase
+        gameController.gameState.currentPlayerIndex = 1;
+        gameController.gameState.turnPhase = TurnPhase.meld;
+
+        // Make decision
+        final decision = botAI.makeDecision(botPlayer, gameController);
+
+        // Should create melds to clear hand
+        expect(
+          decision.action,
+          equals('createMeld'),
+          reason: 'Bot should create melds with all cards to see foot',
+        );
+      });
+
+      test('should prioritize foot transition when all cards playable', () {
+        // Setup: Bot has played down and can play all cards
+        botPlayer.hasPlayedDown = true;
+        botPlayer.hasPickedUpFoot = false;
+
+        // Create a meld that's almost a book
+        botPlayer.melds.add(
+          Meld(
+            rank: CardRank.king,
+            cards: [
+              PlayingCard(rank: CardRank.king, suit: Suit.hearts),
+              PlayingCard(rank: CardRank.king, suit: Suit.diamonds),
+              PlayingCard(rank: CardRank.king, suit: Suit.clubs),
+              PlayingCard(rank: CardRank.king, suit: Suit.spades),
+              PlayingCard(rank: CardRank.king, suit: Suit.hearts),
+              PlayingCard(rank: CardRank.king, suit: Suit.diamonds),
+            ],
+          ),
+        );
+
+        // Give bot cards that can all be added
+        botPlayer.hand.clear();
+        botPlayer.hand.addAll([
+          PlayingCard(
+            rank: CardRank.king,
+            suit: Suit.clubs,
+          ), // Complete the book
+          PlayingCard(rank: CardRank.joker), // Wild
+        ]);
+
+        // Set to meld phase
+        gameController.gameState.currentPlayerIndex = 1;
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        // Make decision
+        final decision = botAI.makeDecision(botPlayer, gameController);
+
+        // Should play cards to see foot rather than holding for strategy
+        expect(
+          decision.action,
+          equals('addToMeld'),
+          reason:
+              'Bot should prioritize seeing foot when all cards can be played',
+        );
+      });
+    });
+
+    group('Dump Strategy with Wilds', () {
+      test('should lower dump threshold when close to foot with wilds', () {
+        // Setup: Bot with wilds close to foot
+        botPlayer.hasPlayedDown = true;
+        botPlayer.hasPickedUpFoot = false;
+
+        // Create existing meld
+        botPlayer.melds.add(
+          Meld(
+            rank: CardRank.ace,
+            cards: [
+              PlayingCard(rank: CardRank.ace, suit: Suit.hearts),
+              PlayingCard(rank: CardRank.ace, suit: Suit.diamonds),
+              PlayingCard(rank: CardRank.ace, suit: Suit.clubs),
+            ],
+          ),
+        );
+
+        // Small hand with wilds and matching cards (60%+ can be melded)
+        botPlayer.hand.clear();
+        botPlayer.hand.addAll([
+          PlayingCard(rank: CardRank.joker), // Wild
+          PlayingCard(rank: CardRank.two, suit: Suit.hearts), // Wild
+          PlayingCard(rank: CardRank.ace, suit: Suit.spades), // Can add
+          PlayingCard(rank: CardRank.four, suit: Suit.hearts), // Singleton
+          PlayingCard(rank: CardRank.six, suit: Suit.diamonds), // Singleton
+        ]);
+
+        // Set to meld phase
+        gameController.gameState.currentPlayerIndex = 1;
+        gameController.gameState.turnPhase = TurnPhase.meld;
+
+        // Make decision
+        final decision = botAI.makeDecision(botPlayer, gameController);
+
+        // Should be willing to dump with lower threshold
+        expect(
+          ['addToMeld', 'createMeld', 'noMeld'],
+          contains(decision.action),
+          reason: 'Bot should have lower dump threshold with wilds near foot',
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Implemented logic for bots to hold wild cards strategically when on the hand pile and prioritize their use during foot transitions.
- Added a mechanism for bots to recognize when they can play all cards to transition to foot immediately.
- Improved decision-making for adding cards to existing melds with a focus on wild cards.
- Introduced unit tests to validate the new strategies for wild card handling and foot transition scenarios.