### PR TITLE
feat: add suit icons to PlayingCard display names

### DIFF
--- a/lib/models/card.dart
+++ b/lib/models/card.dart
@@ -126,10 +126,24 @@ class PlayingCard {
     }
   }
 
+  String get suitIcon {
+    if (isJoker) return '';
+    switch (suit!) {
+      case Suit.hearts:
+        return '♥';
+      case Suit.diamonds:
+        return '♦';
+      case Suit.clubs:
+        return '♣';
+      case Suit.spades:
+        return '♠';
+    }
+  }
+
   String get displayName {
     if (isJoker) return 'Joker';
     final rankName = rank.name[0].toUpperCase() + rank.name.substring(1);
-    return '$rankName of ${suit?.name ?? ''}';
+    return '$rankName$suitIcon';
   }
 
   @override

--- a/test/models/card_test.dart
+++ b/test/models/card_test.dart
@@ -174,11 +174,11 @@ void main() {
     test('should generate correct display names', () {
       expect(
         const PlayingCard(suit: Suit.hearts, rank: CardRank.ace).displayName,
-        equals('Ace of hearts'),
+        equals('Ace♥'),
       );
       expect(
         const PlayingCard(suit: Suit.spades, rank: CardRank.king).displayName,
-        equals('King of spades'),
+        equals('King♠'),
       );
       expect(
         const PlayingCard(rank: CardRank.joker).displayName,


### PR DESCRIPTION
- Introduced a new getter `suitIcon` in the PlayingCard model to return the corresponding icon for each suit.
- Updated the `displayName` method to include the suit icon instead of the suit name for a more concise representation.
- Adjusted unit tests to reflect the changes in display name formatting.