### PR TITLE
Enhance GitHub Pages deployment workflow with cache-busting features

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -98,8 +98,34 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Build Web for GitHub Pages
-        run: flutter build web --release --base-href /${{ github.event.repository.name }}/
+      - name: Clean build cache
+        run: |
+          flutter clean
+          echo "Build cache cleared"
+
+      - name: Build Web for GitHub Pages with cache busting
+        run: |
+          # Build with unique version to prevent browser caching issues
+          export BUILD_NUMBER=$(date +%s)
+          flutter build web --release --base-href /${{ github.event.repository.name }}/ --dart-define=BUILD_NUMBER=$BUILD_NUMBER
+          echo "Built with BUILD_NUMBER: $BUILD_NUMBER"
+          
+      - name: Add cache-busting headers
+        run: |
+          cd build/web
+          # Backup original and apply changes safely
+          cp index.html index.html.orig
+          sed 's|<head>|<head>\n  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">\n  <meta http-equiv="Pragma" content="no-cache">\n  <meta http-equiv="Expires" content="0">|' index.html.orig > index.html
+          # Verify the changes were applied
+          if ! grep -q "Cache-Control" index.html; then
+            echo "Error: Cache control headers not added properly"
+            exit 1
+          fi
+          # Clean up backup file to avoid including in deployment
+          rm index.html.orig
+          # Add version comment for debugging
+          echo "<!-- Deployed: $(date) -->" >> index.html
+          echo "Cache-busting headers added and verified"
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
- Added a step to clean the build cache before deployment to ensure a fresh build.
- Implemented cache-busting by appending a unique build number to the web build, preventing browser caching issues.
- Introduced cache control meta tags in the index.html to further mitigate stale code issues.
- Added a deployment timestamp comment in the index.html for debugging purposes.