### PR TITLE
Update emergency hand size thresholds and enhance bot AI decision-making

### DIFF
--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -51,9 +51,9 @@ class EnhancedBotAI {
 
   // EMERGENCY HAND SIZE PROTOCOLS - Prevents catastrophic accumulation like 32+ cards
   static const int emergencyHandSizeThreshold =
-      25; // CRITICAL: Force emergency actions (based on gameplay analysis)
+      20; // CRITICAL: Force emergency actions (lowered after seeing 18-card failures)
   static const int criticalHandSizeThreshold =
-      30; // PANIC: Any meld is better than none (absolute emergency)
+      25; // PANIC: Any meld is better than none (lowered from 30)
   static const int competitiveThreatHandSizeGap =
       15; // When opponent is ahead by this much (competitive intelligence)
   static const double maxEmergencyRiskTolerance =
@@ -148,6 +148,12 @@ class EnhancedBotAI {
               bot.name,
               'EMERGENCY: Hand size $handSize exceeds $emergencyHandSizeThreshold - forcing emergency meld',
             );
+
+            // If not played down, force emergency play-down
+            if (!bot.hasPlayedDown) {
+              return _handleEmergencyPlayDown(bot, controller);
+            }
+
             return BotDecision(
               action: 'createMeld',
               data: emergencyMelds.first,
@@ -163,6 +169,18 @@ class EnhancedBotAI {
           );
           return BotDecision(action: 'drawFromDeck');
         }
+      }
+
+      // SPECIAL EMERGENCY: Bot with too many cards and no play-down
+      if (handSize >= 15 &&
+          !bot.hasPlayedDown &&
+          gameState.turnPhase == TurnPhase.meld) {
+        DebugLogger.botDebug(
+          bot.id,
+          bot.name,
+          'PLAY-DOWN EMERGENCY: $handSize cards without play-down - forcing any viable meld',
+        );
+        return _handleEmergencyPlayDown(bot, controller);
       }
 
       // PANIC MODE: Override normal logic for bots in terrible situations

--- a/test/ai/enhanced_bot_ai_test.dart
+++ b/test/ai/enhanced_bot_ai_test.dart
@@ -80,6 +80,8 @@ void main() {
         expect(EnhancedBotAI.wildCardDiscardThreshold, equals(8));
         expect(EnhancedBotAI.emergencyRiskTolerance, equals(1.8));
         expect(EnhancedBotAI.maxEmergencyRiskTolerance, equals(6.0));
+        expect(EnhancedBotAI.emergencyHandSizeThreshold, equals(20));
+        expect(EnhancedBotAI.criticalHandSizeThreshold, equals(25));
       });
     });
 


### PR DESCRIPTION
- Lowered emergency hand size threshold from 25 to 20 to improve response to critical situations.
- Adjusted critical hand size threshold from 30 to 25 for better emergency handling.
- Added logic to force emergency play-down if the bot has not played down and has too many cards.
- Enhanced logging for emergency situations to provide clearer insights into bot actions during gameplay.
- Updated unit tests to reflect the new thresholds and ensure robust AI behavior.