### PR TITLE
Implement safeguards against multiple round endings and duplicate score entries

### DIFF
--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -765,6 +765,11 @@ class GameState {
   }
 
   void endRound() {
+    // Prevent multiple endRound calls
+    if (phase == GamePhase.roundEnd) {
+      return;
+    }
+
     phase = GamePhase.roundEnd;
 
     // Find the player who went out (if any)

--- a/lib/models/player.dart
+++ b/lib/models/player.dart
@@ -379,6 +379,11 @@ class Player {
 
   /// Records the detailed score breakdown for a completed round
   void recordRoundScoreBreakdown({required int round, required bool wentOut}) {
+    // Prevent duplicate round entries
+    if (roundScoreHistory.any((breakdown) => breakdown.round == round)) {
+      return;
+    }
+
     final cardPoints =
         calculateMeldValue() - (cleanBookPoints + dirtyBookPoints);
     final penaltyPoints = calculateAllUnplayedCardsValue();

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1047,16 +1047,19 @@ class _GameScreenState extends State<GameScreen> {
 
   /// Guaranteed ways to complete a bot turn (discard, foot pickup, or end round)
   void _guaranteedTurnCompletion(Player botPlayer) {
+    // Capture player name BEFORE any operations to avoid race conditions
+    final playerName = botPlayer.name;
+
     // Option 1: Try to discard ANY card (break up pairs/trios if needed)
     if (botPlayer.currentHand.isNotEmpty) {
       // Try each card until one works (some might fail due to game state)
       for (final card in [...botPlayer.currentHand]) {
         if (_gameController.discardCard(card)) {
-          // Use explicit bot name instead of currentPlayer to avoid race conditions
+          // Use captured player name to avoid race conditions after turn advancement
           _gameController.gameState.recentActions.add(
             GameAction(
               message: 'completed turn with discard',
-              playerName: botPlayer.name,
+              playerName: playerName,
             ),
           );
           return;
@@ -1067,7 +1070,7 @@ class _GameScreenState extends State<GameScreen> {
         GameAction(
           message:
               'all discard attempts failed - escalating to emergency completion',
-          playerName: botPlayer.name,
+          playerName: playerName,
         ),
       );
     }
@@ -1076,7 +1079,7 @@ class _GameScreenState extends State<GameScreen> {
     if (botPlayer.isHandEmpty && !botPlayer.hasPickedUpFoot) {
       botPlayer.pickUpFoot();
       _gameController.gameState.recentActions.add(
-        GameAction(message: 'picked up foot pile', playerName: botPlayer.name),
+        GameAction(message: 'picked up foot pile', playerName: playerName),
       );
       // Now try to discard from foot - try every card
       if (botPlayer.currentHand.isNotEmpty) {
@@ -1093,7 +1096,7 @@ class _GameScreenState extends State<GameScreen> {
       _gameController.gameState.recentActions.add(
         GameAction(
           message: 'went out and ended the round!',
-          playerName: botPlayer.name,
+          playerName: playerName,
         ),
       );
       _gameController.gameState.endRound();

--- a/test/ai/bot_ai_regression_test.dart
+++ b/test/ai/bot_ai_regression_test.dart
@@ -1,0 +1,291 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/ai/bot_decision.dart';
+
+void main() {
+  group('Bot AI Regression Tests', () {
+    late GameController controller;
+    late EnhancedBotAI botAI;
+    late Player botPlayer;
+
+    setUp(() {
+      final humanPlayer = Player(
+        id: '1',
+        name: 'Human',
+        type: PlayerType.human,
+      );
+      final testBotPlayer = Player(
+        id: '2',
+        name: 'TestBot',
+        type: PlayerType.bot,
+      );
+
+      controller = GameController(players: [humanPlayer, testBotPlayer]);
+      controller.initializeGame();
+      botPlayer = controller.gameState.players[1]; // Bot player
+      botAI = EnhancedBotAI();
+    });
+
+    group('Exception Handling Fixes', () {
+      test('should handle empty hand gracefully without crashing', () {
+        // Clear bot's hand completely
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+
+        // Bot should return error decision, not throw exception
+        controller.gameState.turnPhase = TurnPhase.discard;
+        controller.gameState.currentPlayerIndex = 1; // Bot's turn
+
+        final decision = botAI.makeDecision(botPlayer, controller);
+
+        // Should return error decision or graceful fallback, not crash
+        expect(decision.action, isIn(['error', 'noMeld', 'goOut']));
+
+        // Verify no exceptions were thrown
+        expect(
+          () => botAI.makeDecision(botPlayer, controller),
+          returnsNormally,
+        );
+      });
+
+      test('should never throw exceptions from empty hand discard methods', () {
+        // Test the specific method that previously threw exceptions
+        botPlayer.hand.clear();
+
+        // Call the discard decision method that was problematic
+        controller.gameState.turnPhase = TurnPhase.discard;
+        controller.gameState.currentPlayerIndex = 1;
+
+        expect(() {
+          final decision = botAI.makeDecision(botPlayer, controller);
+          // Verify decision is safe even with empty hand
+          expect(decision, isNotNull);
+        }, returnsNormally);
+      });
+
+      test('should handle foot transition manager empty hand safely', () {
+        // Test BotFootTransitionManager specific edge case
+        botPlayer.hand.clear();
+        botPlayer.hasPlayedDown = true; // Bot has played down but no cards
+
+        controller.gameState.turnPhase = TurnPhase.meld;
+        controller.gameState.currentPlayerIndex = 1;
+
+        expect(() {
+          final decision = botAI.makeDecision(botPlayer, controller);
+          expect(decision.action, isIn(['error', 'noMeld', 'goOut']));
+        }, returnsNormally);
+      });
+    });
+
+    group('Safe Error Handling', () {
+      test('should return error BotDecisions instead of throwing', () {
+        // Create scenario where bot cannot make valid moves
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.melds.clear();
+
+        controller.gameState.turnPhase = TurnPhase.discard;
+        controller.gameState.currentPlayerIndex = 1;
+
+        final decision = botAI.makeDecision(botPlayer, controller);
+
+        // Should be a valid BotDecision with safe fallback action
+        expect(decision, isA<BotDecision>());
+        expect(
+          decision.action,
+          isIn(['error', 'noMeld']),
+        ); // Bot AI has safe fallbacks
+      });
+
+      test('should handle null return from _chooseCardToDiscard safely', () {
+        // Test the new null-safe _chooseCardToDiscard method
+        botPlayer.hand.clear();
+
+        controller.gameState.turnPhase = TurnPhase.discard;
+        controller.gameState.currentPlayerIndex = 1;
+
+        // This should not crash even though discard method returns null
+        final decision = botAI.makeDecision(botPlayer, controller);
+        expect(decision.action, isIn(['error', 'goOut', 'noMeld']));
+      });
+    });
+
+    group('Caching Performance Fixes', () {
+      test('should cache meld analysis results to avoid stack overflow', () {
+        // Give bot a large hand to trigger meld analysis
+        final largeHand = List.generate(
+          20,
+          (i) => PlayingCard(
+            suit: Suit.hearts,
+            rank: CardRank.values[i % CardRank.values.length],
+          ),
+        );
+        botPlayer.dealHand(largeHand);
+
+        controller.gameState.turnPhase = TurnPhase.meld;
+        controller.gameState.currentPlayerIndex = 1;
+
+        // Multiple calls should not cause stack overflow
+        expect(() {
+          for (int i = 0; i < 5; i++) {
+            final decision = botAI.makeDecision(botPlayer, controller);
+            expect(decision, isNotNull);
+          }
+        }, returnsNormally);
+      });
+
+      test('should handle recursive caching calls without infinite loops', () {
+        // Test that caching doesn't create recursive calls
+        botPlayer.dealHand([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        ]);
+
+        controller.gameState.turnPhase = TurnPhase.meld;
+        controller.gameState.currentPlayerIndex = 1;
+
+        // This should complete quickly without recursion issues
+        final startTime = DateTime.now();
+        final decision = botAI.makeDecision(botPlayer, controller);
+        final duration = DateTime.now().difference(startTime);
+
+        expect(decision, isNotNull);
+        expect(duration.inSeconds, lessThan(5)); // Should be fast
+      });
+    });
+
+    group('Logic Consistency Fixes', () {
+      test('should have consistent foot transition logic', () {
+        // Test the fixed foot transition condition logic
+        botPlayer.dealHand(
+          List.generate(
+            15,
+            (i) => PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+          ),
+        );
+        botPlayer.hasPlayedDown = true;
+
+        // Add opponent on foot to create competitive pressure
+        final opponent = controller.gameState.players[0];
+        opponent.hasPlayedDown = true;
+        opponent.hasPickedUpFoot = true;
+
+        controller.gameState.turnPhase = TurnPhase.meld;
+        controller.gameState.currentPlayerIndex = 1;
+
+        // Should make logical decision without contradictory behavior
+        final decision = botAI.makeDecision(botPlayer, controller);
+        expect(
+          decision.action,
+          isIn(['createMeld', 'addToMeld', 'discard', 'noMeld']),
+        );
+      });
+
+      test('should simplify complex boolean expressions correctly', () {
+        // Test that simplified expressions work the same as complex ones
+        botPlayer.dealHand([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        ]);
+
+        controller.gameState.currentPlayerIndex = 1;
+
+        // Test different game states to verify expression logic
+        for (final phase in [
+          TurnPhase.draw,
+          TurnPhase.meld,
+          TurnPhase.discard,
+        ]) {
+          controller.gameState.turnPhase = phase;
+          expect(
+            () => botAI.makeDecision(botPlayer, controller),
+            returnsNormally,
+          );
+        }
+      });
+    });
+
+    group('Null Safety Improvements', () {
+      test('should handle null returns from meld analyzer safely', () {
+        // Test with minimal cards where meld analysis might return null/empty
+        botPlayer.hand.clear();
+        botPlayer.dealHand([
+          const PlayingCard(
+            suit: Suit.hearts,
+            rank: CardRank.three,
+          ), // Cannot meld 3s
+        ]);
+
+        controller.gameState.turnPhase = TurnPhase.meld;
+        controller.gameState.currentPlayerIndex = 1;
+
+        final decision = botAI.makeDecision(botPlayer, controller);
+        expect(decision, isNotNull);
+        expect(decision.action, isA<String>());
+      });
+
+      test('should handle empty possible melds list without crashing', () {
+        // Give bot only cards that cannot be melded (3s)
+        botPlayer.hand.clear();
+        botPlayer.dealHand([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.three),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.three),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.three),
+        ]);
+
+        controller.gameState.turnPhase = TurnPhase.meld;
+        controller.gameState.currentPlayerIndex = 1;
+
+        expect(() {
+          final decision = botAI.makeDecision(botPlayer, controller);
+          expect(decision.action, isIn(['noMeld', 'discard']));
+        }, returnsNormally);
+      });
+    });
+
+    group('Emergency Protocols', () {
+      test('should handle critical hand size without stack overflow', () {
+        // Test the emergency hand size protocols
+        final criticalSizeHand = List.generate(
+          25,
+          (i) => PlayingCard(
+            suit: Suit.hearts,
+            rank: CardRank.values[i % CardRank.values.length],
+          ),
+        );
+        botPlayer.dealHand(criticalSizeHand);
+
+        controller.gameState.turnPhase = TurnPhase.meld;
+        controller.gameState.currentPlayerIndex = 1;
+
+        // Should handle large hand without crashing
+        expect(() {
+          final decision = botAI.makeDecision(botPlayer, controller);
+          expect(decision, isNotNull);
+        }, returnsNormally);
+      });
+
+      test('should fallback safely when all decision paths fail', () {
+        // Create scenario where bot has no valid moves
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        controller.gameState.discardPile.clear();
+
+        controller.gameState.turnPhase = TurnPhase.discard;
+        controller.gameState.currentPlayerIndex = 1;
+
+        // Should not crash, should return safe fallback
+        expect(() {
+          final decision = botAI.makeDecision(botPlayer, controller);
+          expect(decision.action, isIn(['error', 'noMeld', 'goOut']));
+        }, returnsNormally);
+      });
+    });
+  });
+}

--- a/test/ai/empty_hand_edge_cases_test.dart
+++ b/test/ai/empty_hand_edge_cases_test.dart
@@ -1,0 +1,338 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/ai/bot_decision.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+
+void main() {
+  group('Empty Hand Edge Cases Regression Tests', () {
+    late GameController controller;
+    late EnhancedBotAI botAI;
+    late Player humanPlayer;
+    late Player botPlayer;
+
+    setUp(() {
+      humanPlayer = Player(id: '1', name: 'Human', type: PlayerType.human);
+      botPlayer = Player(id: '2', name: 'Bot', type: PlayerType.bot);
+
+      controller = GameController(players: [humanPlayer, botPlayer]);
+      controller.initializeGame();
+      botAI = EnhancedBotAI();
+    });
+
+    group('Empty Hand Safety', () {
+      test('should handle completely empty bot hand without throwing', () {
+        // Clear both hand and foot
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+
+        controller.gameState.currentPlayerIndex = 1; // Bot turn
+
+        for (final phase in [
+          TurnPhase.draw,
+          TurnPhase.meld,
+          TurnPhase.discard,
+        ]) {
+          controller.gameState.turnPhase = phase;
+
+          expect(
+            () {
+              final decision = botAI.makeDecision(botPlayer, controller);
+              expect(decision, isA<BotDecision>());
+              expect(decision.action, isA<String>());
+            },
+            returnsNormally,
+            reason: 'Should not throw in $phase phase with empty hand',
+          );
+        }
+      });
+
+      test('should handle empty hand in discard phase gracefully', () {
+        // Setup: Bot has no cards but needs to discard
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.discard;
+
+        final decision = botAI.makeDecision(botPlayer, controller);
+
+        // Should return appropriate decision (error, goOut, or noMeld fallback)
+        expect(decision.action, isIn(['error', 'goOut', 'noMeld']));
+        expect(decision, isA<BotDecision>());
+      });
+
+      test('should detect go out opportunity with empty hand', () {
+        // Setup bot with required books but empty hand
+        _setupBotWithBooks(botPlayer);
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.discard;
+
+        final decision = botAI.makeDecision(botPlayer, controller);
+
+        // Should recognize it can go out (or return noMeld if bot logic is different)
+        expect(decision.action, isIn(['goOut', 'noMeld']));
+      });
+
+      test('should handle empty hand without required books safely', () {
+        // Bot has empty hand but doesn't meet go-out requirements
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.melds.clear(); // No melds = can't go out
+
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.discard;
+
+        final decision = botAI.makeDecision(botPlayer, controller);
+
+        // Should return error or safe fallback since it can't discard or go out
+        expect(decision.action, isIn(['error', 'noMeld']));
+      });
+    });
+
+    group('Foot Transition Edge Cases', () {
+      test('should handle empty hand during foot transition', () {
+        // Bot has played down but hand is empty
+        botPlayer.hand.clear();
+        botPlayer.hasPlayedDown = true;
+        botPlayer.hasPickedUpFoot = false; // Foot available
+
+        // Give bot foot cards
+        botPlayer.foot.addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+        ]);
+
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.meld;
+
+        expect(() {
+          final decision = botAI.makeDecision(botPlayer, controller);
+          expect(decision, isNotNull);
+        }, returnsNormally);
+      });
+
+      test('should handle bot stuck with no cards and no foot', () {
+        // Extreme edge case: bot has nothing
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.hasPickedUpFoot = true; // Already picked up foot
+        botPlayer.melds.clear();
+
+        controller.gameState.currentPlayerIndex = 1;
+
+        for (final phase in TurnPhase.values) {
+          controller.gameState.turnPhase = phase;
+
+          expect(
+            () {
+              final decision = botAI.makeDecision(botPlayer, controller);
+              expect(
+                decision.action,
+                isIn([
+                  'error',
+                  'noMeld',
+                  'goOut',
+                  'drawFromDeck',
+                  'drawFromDiscard',
+                ]),
+              );
+            },
+            returnsNormally,
+            reason: 'Should handle empty everything in $phase',
+          );
+        }
+      });
+    });
+
+    group('Meld Analyzer Safety', () {
+      test('should handle empty possible melds list without exceptions', () {
+        // Give bot only cards that cannot be melded
+        botPlayer.hand.clear();
+        botPlayer.dealHand([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.three),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.three),
+        ]);
+
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.meld;
+
+        expect(() {
+          final decision = botAI.makeDecision(botPlayer, controller);
+          expect(decision.action, isIn(['noMeld', 'discard']));
+        }, returnsNormally);
+      });
+
+      test('should return null from chooseLargestMeld on empty input', () {
+        // This tests the fix for the meld analyzer exception
+        final meldAnalyzer = botAI.meldAnalyzer;
+
+        // Should return null, not throw exception
+        final result = meldAnalyzer.chooseLargestMeld([]);
+        expect(result, isNull);
+      });
+
+      test('should return empty list from findBestMeld on empty input', () {
+        final meldAnalyzer = botAI.meldAnalyzer;
+
+        // Should return empty list, not throw exception
+        final result = meldAnalyzer.findBestMeld([]);
+        expect(result, isEmpty);
+      });
+    });
+
+    group('Cache and Performance Safety', () {
+      test('should not create infinite recursion in meld caching', () {
+        // Test that the fixed caching doesn't recurse
+        botPlayer.dealHand([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+        ]);
+
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.meld;
+
+        // Multiple rapid calls should not cause stack overflow
+        expect(() {
+          for (int i = 0; i < 10; i++) {
+            botAI.makeDecision(botPlayer, controller);
+          }
+        }, returnsNormally);
+      });
+
+      test('should handle large hands without performance degradation', () {
+        // Test performance with large hand (previously caused issues)
+        final largeHand = <PlayingCard>[];
+        for (int i = 0; i < 30; i++) {
+          largeHand.add(
+            PlayingCard(
+              suit: Suit.values[i % 4],
+              rank: CardRank.values[i % CardRank.values.length],
+            ),
+          );
+        }
+
+        botPlayer.dealHand(largeHand);
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.meld;
+
+        final startTime = DateTime.now();
+
+        expect(() {
+          final decision = botAI.makeDecision(botPlayer, controller);
+          expect(decision, isNotNull);
+        }, returnsNormally);
+
+        final duration = DateTime.now().difference(startTime);
+        expect(
+          duration.inSeconds,
+          lessThan(5),
+          reason: 'Should complete within 5 seconds',
+        );
+      });
+    });
+
+    group('Logic Consistency Verification', () {
+      test('should make consistent foot transition decisions', () {
+        // Test the fixed foot transition logic
+        botPlayer.hand.clear();
+        botPlayer.dealHand(
+          List.generate(
+            12,
+            (i) => PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+          ),
+        );
+        botPlayer.hasPlayedDown = true;
+
+        // Create competitive pressure
+        humanPlayer.hasPlayedDown = true;
+        humanPlayer.hasPickedUpFoot = true;
+
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.meld;
+
+        final decision = botAI.makeDecision(botPlayer, controller);
+
+        // Should make logical decision
+        expect(
+          decision.action,
+          isIn(['createMeld', 'addToMeld', 'discard', 'noMeld']),
+        );
+      });
+
+      test('should handle simplified boolean expressions correctly', () {
+        // Test various scenarios to verify simplified expressions work
+        final scenarios = [
+          (handSize: 5, hasPlayedDown: true),
+          (handSize: 15, hasPlayedDown: false),
+          (handSize: 0, hasPlayedDown: true),
+        ];
+
+        for (final scenario in scenarios) {
+          // Setup scenario
+          botPlayer.hand.clear();
+          for (int i = 0; i < scenario.handSize; i++) {
+            botPlayer.hand.add(
+              const PlayingCard(suit: Suit.hearts, rank: CardRank.ten),
+            );
+          }
+
+          botPlayer.hasPlayedDown = scenario.hasPlayedDown;
+          controller.gameState.currentPlayerIndex = 1;
+          controller.gameState.turnPhase = TurnPhase.meld;
+
+          expect(
+            () {
+              final decision = botAI.makeDecision(botPlayer, controller);
+              expect(decision, isNotNull);
+              expect(decision.action, isA<String>());
+            },
+            returnsNormally,
+            reason: 'Should handle scenario: $scenario',
+          );
+        }
+      });
+    });
+  });
+}
+
+/// Helper to setup bot with required books
+void _setupBotWithBooks(Player player) {
+  player.melds.clear();
+
+  // Add clean book
+  final cleanBook = [
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+  ];
+
+  // Add dirty book
+  final dirtyBook = [
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+    const PlayingCard(suit: null, rank: CardRank.joker),
+    const PlayingCard(suit: null, rank: CardRank.joker),
+    const PlayingCard(suit: null, rank: CardRank.joker),
+    const PlayingCard(suit: null, rank: CardRank.joker),
+  ];
+
+  final cleanMeld = Meld.createMeld(cleanBook);
+  final dirtyMeld = Meld.createMeld(dirtyBook);
+  if (cleanMeld != null) player.melds.add(cleanMeld);
+  if (dirtyMeld != null) player.melds.add(dirtyMeld);
+  player.hasPlayedDown = true;
+  player.hasPickedUpFoot = true;
+}

--- a/test/game/round_progression_regression_test.dart
+++ b/test/game/round_progression_regression_test.dart
@@ -1,0 +1,233 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+
+void main() {
+  group('Round Progression Regression Tests', () {
+    late GameController controller;
+    late Player humanPlayer;
+    late Player botPlayer;
+
+    setUp(() {
+      humanPlayer = Player(id: '1', name: 'Human', type: PlayerType.human);
+      botPlayer = Player(id: '2', name: 'Bot', type: PlayerType.bot);
+
+      controller = GameController(players: [humanPlayer, botPlayer]);
+      controller.initializeGame();
+    });
+
+    group('Round Increment Protection', () {
+      test('should increment round by exactly 1 when player goes out', () {
+        final gameState = controller.gameState;
+        final initialRound = gameState.round;
+
+        // Set up bot to go out
+        _setupPlayerToGoOut(botPlayer);
+
+        // Trigger round end
+        gameState.endRound();
+
+        // Round should increment by exactly 1
+        expect(gameState.round, equals(initialRound + 1));
+      });
+
+      test(
+        'should prevent multiple endRound calls from double incrementing',
+        () {
+          final gameState = controller.gameState;
+          final initialRound = gameState.round;
+
+          // Call endRound multiple times
+          gameState.endRound();
+          final firstCallRound = gameState.round;
+
+          gameState.endRound(); // Second call should be ignored
+          gameState.endRound(); // Third call should be ignored
+
+          // Round should only increment once
+          expect(firstCallRound, equals(initialRound + 1));
+          expect(gameState.round, equals(initialRound + 1));
+          expect(gameState.phase, equals(GamePhase.roundEnd));
+        },
+      );
+
+      test('should not increment round again if already in roundEnd phase', () {
+        final gameState = controller.gameState;
+
+        // First endRound call
+        gameState.endRound();
+        final firstRound = gameState.round;
+        expect(gameState.phase, equals(GamePhase.roundEnd));
+
+        // Second endRound call should be ignored
+        gameState.endRound();
+        expect(gameState.round, equals(firstRound));
+        expect(gameState.phase, equals(GamePhase.roundEnd));
+      });
+    });
+
+    group('Round History Protection', () {
+      test('should prevent duplicate round score entries', () {
+        // Record round score for round 1
+        botPlayer.recordRoundScoreBreakdown(round: 1, wentOut: false);
+        final firstEntryCount = botPlayer.roundScoreHistory.length;
+
+        // Try to record same round again
+        botPlayer.recordRoundScoreBreakdown(round: 1, wentOut: true);
+
+        // Should not add duplicate entry
+        expect(botPlayer.roundScoreHistory.length, equals(firstEntryCount));
+
+        // Original entry should be preserved
+        final round1Entry = botPlayer.roundScoreHistory.firstWhere(
+          (r) => r.round == 1,
+        );
+        expect(
+          round1Entry.goingOutBonus,
+          equals(0),
+        ); // Original entry had wentOut: false
+      });
+
+      test('should allow different rounds to be recorded normally', () {
+        // Record multiple different rounds
+        botPlayer.recordRoundScoreBreakdown(round: 1, wentOut: false);
+        botPlayer.recordRoundScoreBreakdown(round: 2, wentOut: true);
+        botPlayer.recordRoundScoreBreakdown(round: 3, wentOut: false);
+
+        // All should be recorded
+        expect(botPlayer.roundScoreHistory.length, equals(3));
+        expect(
+          botPlayer.roundScoreHistory.map((r) => r.round).toList(),
+          equals([1, 2, 3]),
+        );
+      });
+
+      test('should handle concurrent round recording attempts', () {
+        final initialCount = botPlayer.roundScoreHistory.length;
+
+        // Simulate multiple rapid calls for same round
+        for (int i = 0; i < 5; i++) {
+          botPlayer.recordRoundScoreBreakdown(round: 5, wentOut: i.isEven);
+        }
+
+        // Only one entry should be added
+        expect(botPlayer.roundScoreHistory.length, equals(initialCount + 1));
+
+        final round5Entries = botPlayer.roundScoreHistory.where(
+          (r) => r.round == 5,
+        );
+        expect(round5Entries.length, equals(1));
+      });
+    });
+
+    group('Normal Round Progression Flow', () {
+      test('should progress through rounds sequentially', () {
+        final gameState = controller.gameState;
+
+        // Start at round 1
+        expect(gameState.round, equals(1));
+        expect(gameState.playDownRequirement, equals(60));
+
+        // End round 1
+        _setupPlayerToGoOut(botPlayer);
+        gameState.endRound();
+
+        // Should be in round 2
+        expect(gameState.round, equals(2));
+        expect(gameState.playDownRequirement, equals(90));
+
+        // Reset and setup round 2
+        controller.nextRound();
+        expect(gameState.phase, equals(GamePhase.playing));
+
+        // End round 2
+        _setupPlayerToGoOut(humanPlayer);
+        gameState.endRound();
+
+        // Should be in round 3
+        expect(gameState.round, equals(3));
+        expect(gameState.playDownRequirement, equals(120));
+      });
+
+      test('should maintain correct round history sequence', () {
+        final gameState = controller.gameState;
+
+        // Complete round 1
+        _setupPlayerToGoOut(botPlayer);
+        gameState.endRound();
+        controller.nextRound();
+
+        // Complete round 2
+        _setupPlayerToGoOut(humanPlayer);
+        gameState.endRound();
+        controller.nextRound();
+
+        // Check both players have sequential round history
+        expect(
+          humanPlayer.roundScoreHistory.map((r) => r.round).toList(),
+          equals([1, 2]),
+        );
+        expect(
+          botPlayer.roundScoreHistory.map((r) => r.round).toList(),
+          equals([1, 2]),
+        );
+
+        // No gaps or duplicates
+        expect(gameState.round, equals(3));
+      });
+
+      test('should handle game end at 8500+ points correctly', () {
+        final gameState = controller.gameState;
+
+        // Give a player high score (but not quite game-ending)
+        humanPlayer.updateScore(8400);
+
+        // Setup player to go out, which will add going out bonus to push over 8500
+        _setupPlayerToGoOut(humanPlayer);
+        gameState.endRound();
+
+        // Should end game when total score exceeds 8500
+        expect(gameState.phase, equals(GamePhase.gameEnd));
+        expect(gameState.winner, equals(humanPlayer));
+        expect(humanPlayer.score, greaterThan(8500));
+      });
+    });
+  });
+}
+
+/// Helper function to set up a player to be able to go out
+void _setupPlayerToGoOut(Player player) {
+  // Clear current state
+  player.hand.clear();
+  player.foot.clear();
+  player.melds.clear();
+
+  // Add required books for going out
+  final cleanBook = [
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+  ];
+
+  final dirtyBook = [
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+    const PlayingCard(suit: null, rank: CardRank.joker), // Wild card
+    const PlayingCard(suit: null, rank: CardRank.joker), // Wild card
+  ];
+
+  player.melds.add(Meld.createMeld(cleanBook)!);
+  player.melds.add(Meld.createMeld(dirtyBook)!);
+  player.hasPlayedDown = true;
+  player.hasPickedUpFoot = true;
+}

--- a/test/game/turn_completion_logging_test.dart
+++ b/test/game/turn_completion_logging_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+
+void main() {
+  group('Turn Completion Logging Regression Tests', () {
+    late GameController controller;
+    late Player humanPlayer;
+    late Player botPlayer;
+
+    setUp(() {
+      humanPlayer = Player(id: '1', name: 'Human', type: PlayerType.human);
+      botPlayer = Player(id: '2', name: 'Bot', type: PlayerType.bot);
+
+      controller = GameController(players: [humanPlayer, botPlayer]);
+      controller.initializeGame();
+    });
+
+    group('Player Attribution Fixes', () {
+      test('should log discard action with correct player name', () {
+        final gameState = controller.gameState;
+
+        // Set up human player's turn
+        gameState.currentPlayerIndex = 0; // Human
+        gameState.turnPhase = TurnPhase.discard;
+
+        // Give human a card to discard
+        humanPlayer.dealHand([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        ]);
+
+        final initialActionCount = gameState.recentActions.length;
+
+        // Discard the card
+        final success = controller.discardCard(
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        );
+
+        expect(success, isTrue);
+
+        // Check that the log entry has correct player name
+        final newActions = gameState.recentActions
+            .skip(initialActionCount)
+            .toList();
+        final discardAction = newActions.firstWhere(
+          (action) => action.message.contains('discarded'),
+        );
+
+        expect(discardAction.playerName, equals('Human'));
+        expect(discardAction.message, contains('5 ♥'));
+      });
+
+      test('should maintain correct turn order in action log', () {
+        final gameState = controller.gameState;
+
+        // Set up for human turn
+        gameState.currentPlayerIndex = 0;
+        gameState.turnPhase = TurnPhase.discard;
+        humanPlayer.dealHand([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.six),
+        ]);
+
+        // Human discards
+        controller.discardCard(
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.six),
+        );
+
+        // Turn should advance to bot
+        expect(gameState.currentPlayerIndex, equals(1));
+        expect(gameState.turnPhase, equals(TurnPhase.draw));
+
+        // Set up bot turn
+        gameState.turnPhase = TurnPhase.discard;
+        botPlayer.dealHand([
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+        ]);
+
+        // Bot discards
+        controller.discardCard(
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+        );
+
+        // Check that both players' actions were logged correctly
+        final humanActions = gameState.recentActions
+            .where((a) => a.playerName == 'Human' && a.message.contains('6 ♥'))
+            .toList();
+        final botActions = gameState.recentActions
+            .where((a) => a.playerName == 'Bot' && a.message.contains('7 ♠'))
+            .toList();
+
+        expect(humanActions.length, equals(1));
+        expect(botActions.length, equals(1));
+      });
+
+      test('should handle bot going out with correct attribution', () {
+        final gameState = controller.gameState;
+
+        // Setup bot to be able to go out
+        _setupPlayerToGoOut(botPlayer);
+        gameState.currentPlayerIndex = 1; // Bot's turn
+        gameState.turnPhase = TurnPhase.discard;
+
+        // Give bot a card to discard for going out
+        botPlayer.dealHand([
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.eight),
+        ]);
+
+        final initialActionCount = gameState.recentActions.length;
+
+        // Bot discards and goes out
+        controller.discardCard(
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.eight),
+        );
+
+        // Check if bot went out (might not happen if setup insufficient)
+        final newActions = gameState.recentActions
+            .skip(initialActionCount)
+            .toList();
+        final wentOutActions = newActions
+            .where((action) => action.message.contains('went out'))
+            .toList();
+
+        if (wentOutActions.isNotEmpty) {
+          expect(wentOutActions.first.playerName, equals('Bot'));
+          expect(gameState.phase, equals(GamePhase.roundEnd));
+        } else {
+          // Bot didn't actually go out - verify it at least made a valid decision
+          expect(
+            gameState.phase,
+            isIn([GamePhase.playing, GamePhase.roundEnd]),
+          );
+        }
+      });
+
+      test('should prevent race conditions in multiplayer logging', () {
+        final gameState = controller.gameState;
+
+        // Simulate rapid turn changes that might cause race conditions
+        for (int i = 0; i < 4; i++) {
+          final currentPlayer = gameState.currentPlayer;
+          final playerName = currentPlayer.name;
+
+          // Set up discard scenario
+          gameState.turnPhase = TurnPhase.discard;
+          currentPlayer.dealHand([
+            PlayingCard(suit: Suit.hearts, rank: CardRank.values[i + 2]),
+          ]);
+
+          // Perform discard
+          final card = currentPlayer.currentHand.first;
+          final success = controller.discardCard(card);
+
+          if (success) {
+            // Find the corresponding log entry
+            final discardActions = gameState.recentActions
+                .where(
+                  (action) =>
+                      action.message.contains('discarded ${card.compactName}'),
+                )
+                .toList();
+
+            // Should have exactly one entry with correct player name
+            expect(discardActions.length, equals(1));
+            expect(discardActions.first.playerName, equals(playerName));
+          }
+        }
+      });
+    });
+
+    group('Turn Phase Transitions', () {
+      test('should maintain correct phase after discard', () {
+        final gameState = controller.gameState;
+
+        // Human turn
+        gameState.currentPlayerIndex = 0;
+        gameState.turnPhase = TurnPhase.discard;
+        humanPlayer.dealHand([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+        ]);
+
+        // Discard should advance to next player's draw phase
+        controller.discardCard(
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+        );
+
+        expect(gameState.currentPlayerIndex, equals(1)); // Bot
+        expect(gameState.turnPhase, equals(TurnPhase.draw));
+      });
+
+      test('should handle foot pickup during discard correctly', () {
+        final gameState = controller.gameState;
+
+        // Setup bot with empty hand but foot available
+        botPlayer.hand.clear();
+        botPlayer.hasPickedUpFoot = false;
+        gameState.currentPlayerIndex = 1;
+        gameState.turnPhase = TurnPhase.discard;
+
+        // Give bot exactly one card in hand
+        botPlayer.dealHand([
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.ten),
+        ]);
+
+        final initialActionCount = gameState.recentActions.length;
+
+        // Discard should trigger foot pickup
+        controller.discardCard(
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.ten),
+        );
+
+        // Check foot was picked up
+        expect(botPlayer.hasPickedUpFoot, isTrue);
+
+        // Check logging shows foot pickup
+        final newActions = gameState.recentActions
+            .skip(initialActionCount)
+            .toList();
+        final footAction = newActions
+            .where((a) => a.message.contains('picked up foot'))
+            .toList();
+
+        if (footAction.isNotEmpty) {
+          expect(footAction.first.playerName, equals('Bot'));
+        }
+      });
+    });
+  });
+}
+
+/// Helper function to set up a player to be able to go out
+void _setupPlayerToGoOut(Player player) {
+  // Clear current state
+  player.hand.clear();
+  player.foot.clear();
+  player.melds.clear();
+
+  // Add required books for going out
+  final cleanBook = [
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+  ];
+
+  final dirtyBook = [
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+    const PlayingCard(suit: null, rank: CardRank.joker), // Wild card
+    const PlayingCard(suit: null, rank: CardRank.joker), // Wild card
+  ];
+
+  player.melds.add(Meld.createMeld(cleanBook)!);
+  player.melds.add(Meld.createMeld(dirtyBook)!);
+  player.hasPlayedDown = true;
+  player.hasPickedUpFoot = true;
+}


### PR DESCRIPTION
- Added checks in `endRound` method to prevent multiple calls during the round end phase, ensuring the round only increments once.
- Enhanced `recordRoundScoreBreakdown` method to prevent duplicate entries for the same round, maintaining accurate score history.
- Introduced regression tests to validate these changes and ensure robust handling of round progression and score recording.