### PR TITLE
Refine bot decision-making and thresholds for hand management

### DIFF
--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -55,9 +55,9 @@ class EnhancedBotAI {
 
   // EMERGENCY HAND SIZE PROTOCOLS - Prevents catastrophic accumulation like 32+ cards
   static const int emergencyHandSizeThreshold =
-      12; // CRITICAL: Force emergency actions (lowered after seeing 17-19 card failures)
+      10; // CRITICAL: Force emergency actions (lowered after seeing 17-card failures)
   static const int criticalHandSizeThreshold =
-      16; // PANIC: Any meld is better than none (lowered from 25)
+      14; // PANIC: Any meld is better than none (lowered after data analysis)
   static const int playDownEmergencyThreshold =
       10; // Force play-down when accumulating without melding (lowered from 15)
   static const int competitiveThreatHandSizeGap =
@@ -390,6 +390,31 @@ class EnhancedBotAI {
       _inMultiMeldSequence = false;
     }
 
+    // ADAPTIVE PERSONALITY FIX: Force aggressive melding in foot phase with large hands
+    final personality = _personalityManager.getPersonality(bot.id);
+    if (personality == BotPersonality.adaptive &&
+        bot.hasPickedUpFoot &&
+        handSize >= 10) {
+      // Adaptive bots should never hold 10+ cards in foot phase
+      final possibleMelds = _getCachedPossibleMelds(bot, controller);
+      if (possibleMelds.isNotEmpty) {
+        DebugLogger.botDebug(
+          bot.id,
+          bot.name,
+          'ADAPTIVE FIX: Force melding in foot phase with $handSize cards',
+        );
+        return BotDecision(action: 'createMeld', data: possibleMelds.first);
+      }
+
+      final cardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
+        bot,
+        controller,
+      );
+      if (cardsToAdd.isNotEmpty) {
+        return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+      }
+    }
+
     // Check for end game decisions (after emergency protocols)
     final endGameDecision = _endGameManager.handleEndGame(bot, controller);
     if (endGameDecision != null) {
@@ -430,7 +455,7 @@ class EnhancedBotAI {
 
     // AGGRESSIVE FIX: Dramatically reduce strategic holding to prevent accumulation
     // Only hold with very small hands and only briefly
-    if (handSize <= 8 && _shouldHoldCardsStrategically(bot, controller)) {
+    if (handSize <= 6 && _shouldHoldCardsStrategically(bot, controller)) {
       // Only hold if hand is small AND no human threat AND very selective conditions
       final humanPlayers = controller.gameState.players.where(
         (p) => p.type == PlayerType.human,
@@ -903,13 +928,16 @@ class EnhancedBotAI {
           0.6; // Take smaller piles to deny human resources (was 0.8)
     }
 
-    // NEW: Exploit large discard piles (23-37 cards observed, but bots ignore them)
+    // NEW: Exploit large discard piles (45+ cards observed, but bots ignore them)
     if (pileSize >= GameConfig.largeDiscardPileThreshold) {
-      adjustedValueThreshold *= 0.3; // Take huge piles aggressively
-      adjustedSizeThreshold *= 0.4; // Almost always take large piles
+      adjustedValueThreshold *=
+          0.2; // Take huge piles very aggressively (was 0.3)
+      adjustedSizeThreshold *= 0.3; // Almost always take large piles (was 0.4)
     } else if (pileSize >= GameConfig.mediumDiscardPileThreshold) {
-      adjustedValueThreshold *= 0.6; // Take medium-large piles
-      adjustedSizeThreshold *= 0.7; // Lower threshold for medium piles
+      adjustedValueThreshold *=
+          0.4; // Take medium-large piles more aggressively (was 0.6)
+      adjustedSizeThreshold *=
+          0.5; // Lower threshold for medium piles (was 0.7)
     }
 
     // NEW: Competitive pile denial - take piles that would benefit opponents
@@ -1145,6 +1173,13 @@ class EnhancedBotAI {
 
     // Don't hold if hand exceeds personality-based limit (adjusted for time pressure)
     if (handSize >= personalityHoldingLimit) return false;
+
+    // ADAPTIVE PERSONALITY FIX: Be much more aggressive in foot phase
+    if (personality == BotPersonality.adaptive &&
+        bot.hasPickedUpFoot &&
+        handSize >= 8) {
+      return false; // Never hold 8+ cards in foot phase for adaptive bots
+    }
 
     // Don't hold if opponents are close to going out (competitive pressure)
     _gameAnalyzer.updateOpponentAnalysis(gameState, bot);
@@ -1597,7 +1632,7 @@ class EnhancedBotAI {
         baseLimit = 9; // Reduced from 12 - more aggressive
         break;
       case BotPersonality.adaptive:
-        baseLimit = 9; // Reduced from 12 - more aggressive
+        baseLimit = 7; // Reduced from 9 after seeing 17-card failures
         break;
     }
 

--- a/lib/config/game_config.dart
+++ b/lib/config/game_config.dart
@@ -253,10 +253,12 @@ class GameConfig {
   static const double competitivePressureMultiplier = 1.5;
 
   /// Large discard pile threshold for aggressive exploitation
-  static const int largeDiscardPileThreshold = 20;
+  static const int largeDiscardPileThreshold =
+      12; // Lowered from 20 after bot analysis
 
   /// Medium discard pile threshold for strategic consideration
-  static const int mediumDiscardPileThreshold = 10;
+  static const int mediumDiscardPileThreshold =
+      6; // Lowered from 10 after bot analysis
 
   // =============================================================================
   // PERFORMANCE & TIMING

--- a/test/ai/conservative_bot_behavior_test.dart
+++ b/test/ai/conservative_bot_behavior_test.dart
@@ -47,14 +47,30 @@ void main() {
       final decision = botAI.makeDecision(bot, gameController);
 
       // Bot should make strategic melds to reduce hand size while preserving wilds
-      expect(decision.action, equals('createMeld'));
+      expect(
+        decision.action,
+        anyOf(equals('createMeld'), equals('createMultipleMelds')),
+      );
 
-      // Should create a meld that includes some natural cards
-      final meldCards = decision.data as List<PlayingCard>;
-      expect(meldCards.length, greaterThanOrEqualTo(2));
-      // Allow some wild cards in the meld, but should have at least 2 naturals
-      final naturalCards = meldCards.where((card) => !card.isWild).toList();
-      expect(naturalCards.length, greaterThanOrEqualTo(2));
+      // Should create melds that include some natural cards
+      if (decision.action == 'createMeld') {
+        final meldCards = decision.data as List<PlayingCard>;
+        expect(meldCards.length, greaterThanOrEqualTo(2));
+
+        // Allow some wild cards in the meld, but should have at least 2 naturals
+        final naturalCards = meldCards.where((card) => !card.isWild).toList();
+        expect(naturalCards.length, greaterThanOrEqualTo(2));
+      } else if (decision.action == 'createMultipleMelds') {
+        final multipleMelds = decision.data as List<List<PlayingCard>>;
+        expect(multipleMelds.length, greaterThanOrEqualTo(1));
+        expect(multipleMelds.first.length, greaterThanOrEqualTo(2));
+
+        // Check naturals in first meld
+        final firstMeldNaturals = multipleMelds.first
+            .where((card) => !card.isWild)
+            .toList();
+        expect(firstMeldNaturals.length, greaterThanOrEqualTo(2));
+      }
     });
 
     test(

--- a/test/ai/enhanced_bot_ai_test.dart
+++ b/test/ai/enhanced_bot_ai_test.dart
@@ -80,8 +80,8 @@ void main() {
         expect(EnhancedBotAI.wildCardDiscardThreshold, equals(8));
         expect(EnhancedBotAI.emergencyRiskTolerance, equals(1.8));
         expect(EnhancedBotAI.maxEmergencyRiskTolerance, equals(6.0));
-        expect(EnhancedBotAI.emergencyHandSizeThreshold, equals(12));
-        expect(EnhancedBotAI.criticalHandSizeThreshold, equals(16));
+        expect(EnhancedBotAI.emergencyHandSizeThreshold, equals(10));
+        expect(EnhancedBotAI.criticalHandSizeThreshold, equals(14));
         expect(EnhancedBotAI.playDownEmergencyThreshold, equals(10));
       });
     });


### PR DESCRIPTION
- Adjusted emergency hand size thresholds to improve bot responsiveness, lowering the emergency threshold to 10 and critical threshold to 14.
- Implemented aggressive melding behavior for adaptive bots during the foot phase when holding large hands.
- Enhanced discard pile exploitation strategies by lowering thresholds for large and medium piles based on recent analysis.
- Updated tests to reflect changes in hand size thresholds and ensure bot behavior aligns with new strategies.