### PR TITLE
Enhance game state export/import functionality to include bot personalities

### DIFF
--- a/lib/game/enhanced_multiplayer_controller.dart
+++ b/lib/game/enhanced_multiplayer_controller.dart
@@ -909,7 +909,8 @@ class EnhancedMultiplayerController implements MultiplayerGameInterface {
   int? get gameSeed => _gameController.gameSeed;
 
   @override
-  String? exportGameState() => _gameController.exportGameState();
+  String? exportGameState([Map<String, String>? botPersonalities]) =>
+      _gameController.exportGameState(botPersonalities);
 
   @override
   void clearAllNewlyDrawnCards() => _gameController.clearAllNewlyDrawnCards();

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -10,6 +10,14 @@ import 'game_interface.dart';
 import 'managers/meld_manager.dart';
 import 'managers/game_serializer.dart';
 
+/// Result class for importing game state with bot personalities
+class ImportResult {
+  final GameController controller;
+  final Map<String, String> botPersonalities;
+
+  ImportResult(this.controller, this.botPersonalities);
+}
+
 /// Game controller that delegates responsibilities to specialized managers.
 ///
 /// This controller maintains the core game flow and state management while
@@ -185,11 +193,15 @@ class GameController implements GameInterface {
   // ============= Serialization (Delegated) =============
 
   @override
-  String exportGameState() {
-    return GameSerializer.exportGameState(_gameState, gameSeed);
+  String exportGameState([Map<String, String>? botPersonalities]) {
+    return GameSerializer.exportGameState(
+      _gameState,
+      gameSeed,
+      botPersonalities,
+    );
   }
 
-  static GameController? fromExportJson(String input) {
+  static ImportResult? fromExportJson(String input) {
     try {
       final data = GameSerializer.importGameState(input);
       if (data == null) return null;
@@ -197,6 +209,9 @@ class GameController implements GameInterface {
       final gameSeed = data['gameSeed'] as int?;
       final gameStateData = data['gameState'] as Map<String, dynamic>;
       final playersData = data['players'] as List<dynamic>;
+      final botPersonalities =
+          data['botPersonalities'] as Map<String, String>? ??
+          <String, String>{};
 
       // Recreate players
       final players = <Player>[];
@@ -232,7 +247,7 @@ class GameController implements GameInterface {
       // Restore recent actions
       _restoreRecentActions(controller._gameState, data['recentActions']);
 
-      return controller;
+      return ImportResult(controller, botPersonalities);
     } catch (e) {
       print('[GameController] Import error: $e');
       return null;

--- a/lib/game/game_interface.dart
+++ b/lib/game/game_interface.dart
@@ -42,7 +42,7 @@ abstract class GameInterface {
 
   // State management
   Map<String, dynamic> getGameStatus();
-  String? exportGameState();
+  String? exportGameState([Map<String, String>? botPersonalities]);
   void clearAllNewlyDrawnCards();
   int? get gameSeed;
 }

--- a/lib/game/managers/game_serializer.dart
+++ b/lib/game/managers/game_serializer.dart
@@ -17,7 +17,11 @@ class GameSerializer {
   static const int currentVersion = 3;
 
   /// Exports the game state to a compressed string format.
-  static String exportGameState(GameState gameState, int? gameSeed) {
+  static String exportGameState(
+    GameState gameState,
+    int? gameSeed, [
+    Map<String, String>? botPersonalities,
+  ]) {
     final export = {
       'v': kIsWeb ? currentVersion : 2, // Version 2 = gzip, 3 = web-optimized
       's': gameSeed ?? -1,
@@ -26,6 +30,9 @@ class GameSerializer {
       'deck': _serializeDeck(gameState.deck),
       'dp': gameState.discardPile.map(_compactCard).toList(),
       'ra': _serializeRecentActions(gameState.recentActions),
+      'bp':
+          botPersonalities ??
+          {}, // Bot personalities map (playerId -> personality)
     };
 
     final jsonString = jsonEncode(export);
@@ -250,6 +257,9 @@ class GameSerializer {
           .toList(),
       'deck': data['deck'],
       'recentActions': _parseRecentActions(data['ra']),
+      'botPersonalities':
+          (data['bp'] as Map<String, dynamic>?)?.cast<String, String>() ??
+          <String, String>{},
     };
   }
 
@@ -263,6 +273,8 @@ class GameSerializer {
       'discardPile': _parseLegacyCards(data['discardPile']),
       'deck': data['deck'],
       'recentActions': data['recentActions'],
+      'botPersonalities':
+          <String, String>{}, // Legacy formats don't have personalities
     };
   }
 

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -94,6 +94,45 @@ class _GameScreenState extends State<GameScreen> {
     }
   }
 
+  /// Restore bot personalities from imported save data
+  void _restoreBotPersonalities(Map<String, String> savedPersonalities) {
+    // Clear any existing assignments
+    _botAI.personalityManager.clearPersonalityData();
+
+    final botPlayers = _gameController.gameState.players
+        .where((p) => p.type == PlayerType.bot)
+        .toList();
+
+    for (final bot in botPlayers) {
+      final savedPersonalityName = savedPersonalities[bot.id];
+      if (savedPersonalityName != null) {
+        // Parse saved personality name back to enum
+        final personality = BotPersonality.values.firstWhere(
+          (p) => p.toString() == savedPersonalityName,
+          orElse: () => BotPersonality.adaptive, // Fallback to adaptive
+        );
+        _botAI.assignPersonality(bot.id, personality);
+
+        if (kDebugMode) {
+          print(
+            'Bot ${bot.name} (${bot.id}) restored personality: $personality',
+          );
+        }
+      } else {
+        // If no saved personality for this bot, assign a random one
+        final randomPersonality = BotPersonality
+            .values[Random().nextInt(BotPersonality.values.length)];
+        _botAI.assignPersonality(bot.id, randomPersonality);
+
+        if (kDebugMode) {
+          print(
+            'Bot ${bot.name} (${bot.id}) assigned new personality: $randomPersonality (no saved data)',
+          );
+        }
+      }
+    }
+  }
+
   Future<void> _initializeGame() async {
     // If a gameController was provided (continuing saved game), use it
     if (widget.gameController != null) {
@@ -2828,7 +2867,16 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   void _exportGameState() {
-    final gameStateBase64 = _gameController.exportGameState();
+    // Collect current bot personalities
+    final botPersonalities = <String, String>{};
+    for (final player in _gameController.gameState.players) {
+      if (player.type == PlayerType.bot) {
+        final personality = _botAI.personalityManager.getPersonality(player.id);
+        botPersonalities[player.id] = personality.toString();
+      }
+    }
+
+    final gameStateBase64 = _gameController.exportGameState(botPersonalities);
     Clipboard.setData(ClipboardData(text: gameStateBase64));
 
     ScaffoldMessenger.of(context).showSnackBar(
@@ -3202,8 +3250,8 @@ class _GameScreenState extends State<GameScreen> {
     }
 
     try {
-      final newController = GameController.fromExportJson(inputText);
-      if (newController == null) {
+      final importResult = GameController.fromExportJson(inputText);
+      if (importResult == null) {
         _showErrorDialog(
           'Failed to load game save. The format may be invalid or corrupted.',
         );
@@ -3211,11 +3259,11 @@ class _GameScreenState extends State<GameScreen> {
       }
 
       setState(() {
-        _gameController = newController;
+        _gameController = importResult.controller;
         _botAI = EnhancedBotAI();
 
-        // Assign consistent bot personalities based on player IDs
-        _assignBotPersonalities();
+        // Restore saved bot personalities instead of assigning random ones
+        _restoreBotPersonalities(importResult.botPersonalities);
 
         _selectedCardIndices.clear();
         _viewingPlayerMelds = null;
@@ -3225,7 +3273,7 @@ class _GameScreenState extends State<GameScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Game loaded successfully! Seed: ${newController.gameSeed ?? "No seed"}',
+            'Game loaded successfully! Seed: ${importResult.controller.gameSeed ?? "No seed"}',
           ),
           backgroundColor: BalatroTheme.neonGreen,
           behavior: SnackBarBehavior.floating,

--- a/test/game/base64_export_import_test.dart
+++ b/test/game/base64_export_import_test.dart
@@ -34,10 +34,11 @@ void main() {
       expect(jsonData['players'], hasLength(2));
 
       // Test importing the base64 encoded data
-      final importedController = GameController.fromExportJson(exportedBase64);
+      final importResult = GameController.fromExportJson(exportedBase64);
 
-      expect(importedController, isNotNull);
-      expect(importedController!.gameSeed, equals(12345));
+      expect(importResult, isNotNull);
+      final importedController = importResult!.controller;
+      expect(importedController.gameSeed, equals(12345));
       expect(importedController.gameState.players, hasLength(2));
       expect(importedController.gameState.players[0].name, equals('Player 1'));
       expect(importedController.gameState.players[1].name, equals('Bot 1'));
@@ -83,10 +84,11 @@ void main() {
       });
 
       // Test importing legacy JSON format
-      final importedController = GameController.fromExportJson(legacyJson);
+      final importResult = GameController.fromExportJson(legacyJson);
 
-      expect(importedController, isNotNull);
-      expect(importedController!.gameSeed, equals(54321));
+      expect(importResult, isNotNull);
+      final importedController = importResult!.controller;
+      expect(importedController.gameSeed, equals(54321));
       expect(importedController.gameState.players, hasLength(1));
       expect(
         importedController.gameState.players[0].name,

--- a/test/game/compression_benchmark_test.dart
+++ b/test/game/compression_benchmark_test.dart
@@ -246,11 +246,10 @@ void main() {
       );
 
       // Test that import still works correctly
-      final importedController = GameController.fromExportJson(
-        compressedExport,
-      );
-      expect(importedController, isNotNull);
-      expect(importedController!.gameSeed, equals(98765));
+      final importResult = GameController.fromExportJson(compressedExport);
+      expect(importResult, isNotNull);
+      final importedController = importResult!.controller;
+      expect(importedController.gameSeed, equals(98765));
       expect(importedController.gameState.players, hasLength(4));
       expect(
         importedController.gameState.players[0].name,

--- a/test/game/game_controller_test.dart
+++ b/test/game/game_controller_test.dart
@@ -207,11 +207,13 @@ void main() {
       // The exported state is base64 encoded, so we can't check for raw JSON strings
 
       // Create new controller from exported state
-      final newController = GameController.fromExportJson(exportedState);
-      expect(newController, isNotNull);
+      final importResult = GameController.fromExportJson(exportedState);
+      expect(importResult, isNotNull);
+
+      final newController = importResult!.controller;
 
       // Verify state was imported correctly
-      expect(newController!.gameSeed, equals(gameController.gameSeed));
+      expect(newController.gameSeed, equals(gameController.gameSeed));
       expect(
         newController.gameState.hasDrawnFromDeck,
         equals(gameController.gameState.hasDrawnFromDeck),

--- a/test/game/web_compatibility_test.dart
+++ b/test/game/web_compatibility_test.dart
@@ -31,10 +31,11 @@ void main() {
       expect(() => base64Decode(exportedData), returnsNormally);
 
       // Import should work on all platforms
-      final importedController = GameController.fromExportJson(exportedData);
+      final importResult = GameController.fromExportJson(exportedData);
 
-      expect(importedController, isNotNull);
-      expect(importedController!.gameSeed, equals(42));
+      expect(importResult, isNotNull);
+      final importedController = importResult!.controller;
+      expect(importedController.gameSeed, equals(42));
       expect(importedController.gameState.players, hasLength(2));
       expect(importedController.gameState.players[0].name, equals('Human'));
       expect(importedController.gameState.players[1].name, equals('Bot'));
@@ -78,10 +79,11 @@ void main() {
       final mobileBase64 = base64Encode(utf8.encode(mobileJson));
 
       // Should be able to import on any platform
-      final controller = GameController.fromExportJson(mobileBase64);
+      final importResult = GameController.fromExportJson(mobileBase64);
 
-      expect(controller, isNotNull);
-      expect(controller!.gameSeed, equals(12345));
+      expect(importResult, isNotNull);
+      final controller = importResult!.controller;
+      expect(controller.gameSeed, equals(12345));
       expect(controller.gameState.players, hasLength(1));
       expect(controller.gameState.players[0].name, equals('Test Player'));
       expect(controller.gameState.players[0].hand, hasLength(2));

--- a/test/regression/bot_personality_preservation_test.dart
+++ b/test/regression/bot_personality_preservation_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+
+/// Test to ensure bot personalities are preserved across export/import operations
+void main() {
+  group('Bot Personality Preservation Tests', () {
+    test('export should include bot personalities in save data', () {
+      // Setup: Create game with specific bot personalities
+      final players = [
+        Player(id: '1', name: 'Human', type: PlayerType.human),
+        Player(id: '2', name: 'BotA', type: PlayerType.bot),
+        Player(id: '3', name: 'BotB', type: PlayerType.bot),
+      ];
+
+      final controller = GameController(players: players);
+      controller.initializeGame();
+
+      // Set up specific bot personalities for testing
+      final botPersonalities = {
+        '2': 'BotPersonality.conservative',
+        '3': 'BotPersonality.aggressive',
+      };
+
+      // Act: Export game state with personalities
+      final exportedData = controller.exportGameState(botPersonalities);
+
+      // Assert: Export should contain the data and not be null/empty
+      expect(exportedData, isNotNull);
+      expect(exportedData, isNotEmpty);
+
+      // The actual personality data is embedded in the compressed format,
+      // so we can't easily verify the content here, but we can verify
+      // the method accepts the parameter and returns data
+    });
+
+    test('import should restore bot personalities from save data', () {
+      // Setup: Create game with specific bot personalities
+      final players = [
+        Player(id: '1', name: 'Human', type: PlayerType.human),
+        Player(id: '2', name: 'BotA', type: PlayerType.bot),
+        Player(id: '3', name: 'BotB', type: PlayerType.bot),
+      ];
+
+      final originalController = GameController(players: players);
+      originalController.initializeGame();
+
+      // Set up specific bot personalities for testing
+      final originalPersonalities = {
+        '2': 'BotPersonality.conservative',
+        '3': 'BotPersonality.aggressive',
+      };
+
+      // Act: Export game state with personalities
+      final exportedData = originalController.exportGameState(
+        originalPersonalities,
+      );
+
+      // Act: Import the exported data
+      final importResult = GameController.fromExportJson(exportedData);
+
+      // Assert: Import should succeed and contain bot personalities
+      expect(importResult, isNotNull);
+      expect(importResult!.controller, isNotNull);
+      expect(importResult.botPersonalities, isNotNull);
+
+      // Assert: Personalities should be preserved
+      expect(
+        importResult.botPersonalities['2'],
+        equals('BotPersonality.conservative'),
+      );
+      expect(
+        importResult.botPersonalities['3'],
+        equals('BotPersonality.aggressive'),
+      );
+
+      // Assert: Game controller should be properly restored
+      expect(importResult.controller.gameState.players.length, equals(3));
+      expect(importResult.controller.gameState.players[1].name, equals('BotA'));
+      expect(importResult.controller.gameState.players[2].name, equals('BotB'));
+    });
+
+    test('import should handle empty personality data gracefully', () {
+      // Setup: Create game without personalities
+      final players = [
+        Player(id: '1', name: 'Human', type: PlayerType.human),
+        Player(id: '2', name: 'BotA', type: PlayerType.bot),
+      ];
+
+      final controller = GameController(players: players);
+      controller.initializeGame();
+
+      // Act: Export game state without personalities (null parameter)
+      final exportedData = controller.exportGameState();
+
+      // Act: Import the exported data
+      final importResult = GameController.fromExportJson(exportedData);
+
+      // Assert: Import should succeed with empty personalities map
+      expect(importResult, isNotNull);
+      expect(importResult!.controller, isNotNull);
+      expect(importResult.botPersonalities, isNotNull);
+      expect(importResult.botPersonalities, isEmpty);
+    });
+
+    test('round-trip export/import preserves all bot personality data', () {
+      // Setup: Create game with multiple bot personalities
+      final players = [
+        Player(id: '1', name: 'Human', type: PlayerType.human),
+        Player(id: '2', name: 'Conservative Bot', type: PlayerType.bot),
+        Player(id: '3', name: 'Aggressive Bot', type: PlayerType.bot),
+        Player(id: '4', name: 'Book Builder Bot', type: PlayerType.bot),
+        Player(id: '5', name: 'Adaptive Bot', type: PlayerType.bot),
+      ];
+
+      final controller = GameController(players: players);
+      controller.initializeGame();
+
+      // Set up all personality types for comprehensive testing
+      final originalPersonalities = {
+        '2': 'BotPersonality.conservative',
+        '3': 'BotPersonality.aggressive',
+        '4': 'BotPersonality.bookBuilder',
+        '5': 'BotPersonality.adaptive',
+      };
+
+      // Act: Export and then import
+      final exportedData = controller.exportGameState(originalPersonalities);
+      final importResult = GameController.fromExportJson(exportedData);
+
+      // Assert: All personality data should be preserved exactly
+      expect(importResult, isNotNull);
+      expect(importResult!.botPersonalities.length, equals(4));
+
+      for (final entry in originalPersonalities.entries) {
+        expect(
+          importResult.botPersonalities[entry.key],
+          equals(entry.value),
+          reason: 'Personality for bot ${entry.key} should be preserved',
+        );
+      }
+
+      // Assert: Game state should also be properly restored
+      expect(importResult.controller.gameState.players.length, equals(5));
+      expect(
+        importResult.controller.gameState.players
+            .where((p) => p.type == PlayerType.bot)
+            .length,
+        equals(4),
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Updated the exportGameState method to accept an optional map of bot personalities, allowing for their preservation during game state exports.
- Modified the fromExportJson method to return an ImportResult containing both the GameController and the restored bot personalities.
- Implemented a new ImportResult class to encapsulate the results of importing game state, improving clarity and usability.
- Added tests to ensure bot personalities are correctly exported and imported, validating the integrity of game state across sessions.