### PR TITLE
Add player view switching E2E tests and refactor player tap logic

### DIFF
--- a/e2e_test/player_view_switching_e2e_test.dart
+++ b/e2e_test/player_view_switching_e2e_test.dart
@@ -1,0 +1,314 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'test_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Player View Switching E2E Tests', () {
+    testWidgets('Player view switching works correctly', (
+      WidgetTester tester,
+    ) async {
+      await E2ETestUtils.startAppWithCleanState(tester);
+
+      print('✅ Game started successfully');
+
+      // Wait for initial UI to stabilize
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify we start in our own view
+      expect(find.text('Your Melds:'), findsOneWidget);
+      expect(find.text('Back to yours'), findsNothing);
+
+      print('✅ Confirmed starting in own melds view');
+
+      // Look for bot player cards to tap on
+      final botNames = [
+        'Clara', 'Carl', 'Bob', 'Rita', 'Ben', 'Penny', 'Alex', 'Sue',
+        'Bot 1', 'Bot 2', 'Bot 3', // fallback names
+      ];
+
+      String? firstBotFound;
+      for (final botName in botNames) {
+        if (find.textContaining(botName).evaluate().isNotEmpty) {
+          firstBotFound = botName;
+          break;
+        }
+      }
+
+      if (firstBotFound == null) {
+        throw Exception('No bot players found to test view switching');
+      }
+
+      print('✅ Found bot player: $firstBotFound');
+
+      // Tap on a bot player to view their melds
+      await E2ETestUtils.safeTap(
+        tester,
+        find.textContaining(firstBotFound).first,
+        debugLabel: 'Switch to $firstBotFound view',
+      );
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify we switched to bot's view
+      expect(find.textContaining('$firstBotFound\'s Melds:'), findsOneWidget);
+      expect(find.text('Back to yours'), findsOneWidget);
+      expect(find.text('Your Melds:'), findsNothing);
+
+      print('✅ Successfully switched to bot\'s melds view');
+      print('✅ Confirmed "Back to yours" button is visible');
+
+      // Test tapping "Back to yours" button
+      await E2ETestUtils.safeTap(
+        tester,
+        find.text('Back to yours'),
+        debugLabel: 'Back to own view',
+      );
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify we're back to our own view
+      expect(find.text('Your Melds:'), findsOneWidget);
+      expect(find.text('Back to yours'), findsNothing);
+      expect(find.textContaining('$firstBotFound\'s Melds:'), findsNothing);
+
+      print('✅ Successfully returned to own melds view');
+      print('✅ Confirmed "Back to yours" button is hidden');
+
+      print('✅ Player view switching test complete');
+      await E2ETestUtils.cleanShutdown(tester);
+    });
+
+    testWidgets(
+      'Clicking on own player when viewing bot melds returns to own view',
+      (WidgetTester tester) async {
+        await E2ETestUtils.startAppWithCleanState(tester);
+
+        // Wait for initial UI to stabilize
+        await E2ETestUtils.stabilize(tester);
+
+        // Find a bot to switch to first
+        final botNames = [
+          'Clara', 'Carl', 'Bob', 'Rita', 'Ben', 'Penny', 'Alex', 'Sue',
+          'Bot 1', 'Bot 2', 'Bot 3', // fallback names
+        ];
+
+        String? firstBotFound;
+        for (final botName in botNames) {
+          if (find.textContaining(botName).evaluate().isNotEmpty) {
+            firstBotFound = botName;
+            break;
+          }
+        }
+
+        if (firstBotFound == null) {
+          throw Exception('No bot players found to test view switching');
+        }
+
+        // Switch to bot's view first
+        await E2ETestUtils.safeTap(
+          tester,
+          find.textContaining(firstBotFound).first,
+          debugLabel: 'Switch to $firstBotFound view',
+        );
+        await E2ETestUtils.stabilize(tester);
+
+        // Verify we're viewing bot's melds
+        expect(find.textContaining('$firstBotFound\'s Melds:'), findsOneWidget);
+        expect(find.text('Back to yours'), findsOneWidget);
+
+        print('✅ Currently viewing bot\'s melds');
+
+        // Now tap on our own player card ("You")
+        await E2ETestUtils.safeTap(
+          tester,
+          find.textContaining('You').first,
+          debugLabel: 'Switch back to own view by clicking You',
+        );
+        await E2ETestUtils.stabilize(tester);
+
+        // Add extra stabilization and debug info
+        await tester.pumpAndSettle(const Duration(milliseconds: 500));
+
+        // Debug: Print what we can find
+        print('DEBUG: Looking for melds header text after clicking You');
+        print(
+          'DEBUG: Found "Your Melds:": ${find.text('Your Melds:').evaluate().length}',
+        );
+        print(
+          'DEBUG: Found "Back to yours": ${find.text('Back to yours').evaluate().length}',
+        );
+
+        // Verify we're back to our own view
+        expect(find.text('Your Melds:'), findsOneWidget);
+        expect(find.text('Back to yours'), findsNothing);
+        expect(find.textContaining('$firstBotFound\'s Melds:'), findsNothing);
+
+        print(
+          '✅ Successfully returned to own view by clicking own player card',
+        );
+        print('✅ "Back to yours" button correctly hidden');
+
+        await E2ETestUtils.cleanShutdown(tester);
+      },
+    );
+
+    testWidgets('Switching between multiple bot players works correctly', (
+      WidgetTester tester,
+    ) async {
+      await E2ETestUtils.startAppWithCleanState(tester);
+
+      // Wait for initial UI to stabilize
+      await E2ETestUtils.stabilize(tester);
+
+      // Find at least two different bots
+      final botNames = [
+        'Clara', 'Carl', 'Bob', 'Rita', 'Ben', 'Penny', 'Alex', 'Sue',
+        'Bot 1', 'Bot 2', 'Bot 3', // fallback names
+      ];
+
+      final foundBots = <String>[];
+      for (final botName in botNames) {
+        if (find.textContaining(botName).evaluate().isNotEmpty) {
+          foundBots.add(botName);
+          if (foundBots.length >= 2) break;
+        }
+      }
+
+      if (foundBots.length < 2) {
+        throw Exception(
+          'Need at least 2 bot players to test switching between them',
+        );
+      }
+
+      final firstBot = foundBots[0];
+      final secondBot = foundBots[1];
+
+      print('✅ Found bots to test: $firstBot and $secondBot');
+
+      // Switch to first bot's view
+      await E2ETestUtils.safeTap(
+        tester,
+        find.textContaining(firstBot).first,
+        debugLabel: 'Switch to $firstBot view',
+      );
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify we're viewing first bot's melds
+      expect(find.textContaining('$firstBot\'s Melds:'), findsOneWidget);
+      expect(find.text('Back to yours'), findsOneWidget);
+
+      print('✅ Viewing $firstBot\'s melds');
+
+      // Switch to second bot's view
+      await E2ETestUtils.safeTap(
+        tester,
+        find.textContaining(secondBot).first,
+        debugLabel: 'Switch to $secondBot view',
+      );
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify we're viewing second bot's melds
+      expect(find.textContaining('$secondBot\'s Melds:'), findsOneWidget);
+      expect(find.text('Back to yours'), findsOneWidget);
+      expect(find.textContaining('$firstBot\'s Melds:'), findsNothing);
+
+      print('✅ Successfully switched from $firstBot to $secondBot');
+      print('✅ "Back to yours" button remains visible');
+
+      // Switch back to first bot
+      await E2ETestUtils.safeTap(
+        tester,
+        find.textContaining(firstBot).first,
+        debugLabel: 'Switch back to $firstBot view',
+      );
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify we're viewing first bot's melds again
+      expect(find.textContaining('$firstBot\'s Melds:'), findsOneWidget);
+      expect(find.text('Back to yours'), findsOneWidget);
+      expect(find.textContaining('$secondBot\'s Melds:'), findsNothing);
+
+      print('✅ Successfully switched back to $firstBot');
+
+      // Return to own view
+      await E2ETestUtils.safeTap(
+        tester,
+        find.text('Back to yours'),
+        debugLabel: 'Return to own view',
+      );
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify we're back to our own view
+      expect(find.text('Your Melds:'), findsOneWidget);
+      expect(find.text('Back to yours'), findsNothing);
+
+      print('✅ Successfully returned to own view');
+      print('✅ Multiple bot switching test complete');
+
+      await E2ETestUtils.cleanShutdown(tester);
+    });
+
+    testWidgets('Header text changes correctly when switching views', (
+      WidgetTester tester,
+    ) async {
+      await E2ETestUtils.startAppWithCleanState(tester);
+
+      // Wait for initial UI to stabilize
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify initial header text
+      expect(find.text('Your Melds:'), findsOneWidget);
+
+      // Find a bot to switch to
+      final botNames = [
+        'Clara', 'Carl', 'Bob', 'Rita', 'Ben', 'Penny', 'Alex', 'Sue',
+        'Bot 1', 'Bot 2', 'Bot 3', // fallback names
+      ];
+
+      String? firstBotFound;
+      for (final botName in botNames) {
+        if (find.textContaining(botName).evaluate().isNotEmpty) {
+          firstBotFound = botName;
+          break;
+        }
+      }
+
+      if (firstBotFound == null) {
+        throw Exception('No bot players found to test header text');
+      }
+
+      print('✅ Testing header text changes with bot: $firstBotFound');
+
+      // Switch to bot's view
+      await E2ETestUtils.safeTap(
+        tester,
+        find.textContaining(firstBotFound).first,
+        debugLabel: 'Switch to $firstBotFound for header test',
+      );
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify header text changed to bot's name
+      expect(find.textContaining('$firstBotFound\'s Melds:'), findsOneWidget);
+      expect(find.text('Your Melds:'), findsNothing);
+
+      print('✅ Header text correctly shows "$firstBotFound\'s Melds:"');
+
+      // Switch back to own view
+      await E2ETestUtils.safeTap(
+        tester,
+        find.text('Back to yours'),
+        debugLabel: 'Return to own view for header test',
+      );
+      await E2ETestUtils.stabilize(tester);
+
+      // Verify header text changed back to "Your Melds:"
+      expect(find.text('Your Melds:'), findsOneWidget);
+      expect(find.textContaining('$firstBotFound\'s Melds:'), findsNothing);
+
+      print('✅ Header text correctly shows "Your Melds:" again');
+      print('✅ Header text changes test complete');
+
+      await E2ETestUtils.cleanShutdown(tester);
+    });
+  });
+}

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1499,7 +1499,12 @@ class _GameScreenState extends State<GameScreen> {
               viewingPlayerMelds: _viewingPlayerMelds,
               onPlayerTap: (player) {
                 setState(() {
-                  _viewingPlayerMelds = player;
+                  // If tapping on the human player, set to null (view own melds)
+                  // Otherwise, set to the specific player to view their melds
+                  final humanPlayer = gameState.players.firstWhere(
+                    (p) => p.type == PlayerType.human,
+                  );
+                  _viewingPlayerMelds = player == humanPlayer ? null : player;
                 });
               },
               botPersonalityManager: _botAI.personalityManager,

--- a/lib/screens/managers/dialog_manager.dart
+++ b/lib/screens/managers/dialog_manager.dart
@@ -373,7 +373,10 @@ class DialogManager {
         onCancel: () {
           Navigator.of(context).pop();
         },
-        onConfirm: onMeldsCreated,
+        onConfirm: (meldIndices) {
+          Navigator.of(context).pop();
+          onMeldsCreated(meldIndices);
+        },
       ),
     );
   }

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -452,8 +452,15 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
                 CompactPlayerScores(
                   gameState: gameState,
                   viewingPlayerMelds: _viewingPlayerMelds,
-                  onPlayerTap: (player) =>
-                      setState(() => _viewingPlayerMelds = player),
+                  onPlayerTap: (player) {
+                    setState(() {
+                      // If tapping on the current user's player, set to null (view own melds)
+                      // Otherwise, set to the specific player to view their melds
+                      _viewingPlayerMelds = player.id == _gameController.userId
+                          ? null
+                          : player;
+                    });
+                  },
                   currentUserId:
                       _gameController.userId, // Enable multiplayer mode
                 ),

--- a/test/screens/player_view_switching_test.dart
+++ b/test/screens/player_view_switching_test.dart
@@ -1,0 +1,298 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+/// Helper function to test button visibility logic
+/// Simulates the condition from melds_section.dart line 63
+bool _shouldShowBackButton(Player? viewingPlayerMelds) {
+  return viewingPlayerMelds != null;
+}
+
+void main() {
+  group('Player View Switching Logic', () {
+    late List<Player> players;
+    late Player humanPlayer;
+    late Player bot1Player;
+    late Player bot2Player;
+
+    setUp(() {
+      players = [
+        Player(id: 'human', name: 'You', type: PlayerType.human),
+        Player(id: 'bot1', name: 'Bot 1', type: PlayerType.bot),
+        Player(id: 'bot2', name: 'Bot 2', type: PlayerType.bot),
+      ];
+
+      humanPlayer = players[0];
+      bot1Player = players[1];
+      bot2Player = players[2];
+    });
+
+    group('Single Player Mode', () {
+      test('clicking human player should set viewingPlayerMelds to null', () {
+        // Simulate the logic from game_screen.dart onPlayerTap
+        Player? viewingPlayerMelds;
+
+        // Simulate clicking on human player
+        final tappedPlayer = humanPlayer;
+        final foundHumanPlayer = players.firstWhere(
+          (p) => p.type == PlayerType.human,
+        );
+
+        viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+            ? null
+            : tappedPlayer;
+
+        expect(viewingPlayerMelds, isNull);
+      });
+
+      test('clicking bot player should set viewingPlayerMelds to that bot', () {
+        // Simulate the logic from game_screen.dart onPlayerTap
+        Player? viewingPlayerMelds;
+
+        // Simulate clicking on bot player
+        final tappedPlayer = bot1Player;
+        final foundHumanPlayer = players.firstWhere(
+          (p) => p.type == PlayerType.human,
+        );
+
+        viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+            ? null
+            : tappedPlayer;
+
+        expect(viewingPlayerMelds, equals(bot1Player));
+        expect(viewingPlayerMelds?.name, equals('Bot 1'));
+      });
+
+      test(
+        'switching from bot view back to human should set viewingPlayerMelds to null',
+        () {
+          // Start viewing a bot's melds
+          Player? viewingPlayerMelds = bot1Player;
+          expect(viewingPlayerMelds, equals(bot1Player));
+
+          // Now click on human player
+          final tappedPlayer = humanPlayer;
+          final foundHumanPlayer = players.firstWhere(
+            (p) => p.type == PlayerType.human,
+          );
+
+          viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+              ? null
+              : tappedPlayer;
+
+          expect(viewingPlayerMelds, isNull);
+        },
+      );
+
+      test(
+        'switching from one bot to another bot should update viewingPlayerMelds',
+        () {
+          // Start viewing bot1's melds
+          Player? viewingPlayerMelds = bot1Player;
+          expect(viewingPlayerMelds, equals(bot1Player));
+
+          // Now click on bot2 player
+          final tappedPlayer = bot2Player;
+          final foundHumanPlayer = players.firstWhere(
+            (p) => p.type == PlayerType.human,
+          );
+
+          viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+              ? null
+              : tappedPlayer;
+
+          expect(viewingPlayerMelds, equals(bot2Player));
+          expect(viewingPlayerMelds?.name, equals('Bot 2'));
+        },
+      );
+    });
+
+    group('Multiplayer Mode', () {
+      const String currentUserId = 'human';
+
+      test('clicking current user should set viewingPlayerMelds to null', () {
+        // Simulate the logic from multiplayer_game_screen.dart onPlayerTap
+        Player? viewingPlayerMelds;
+
+        // Simulate clicking on current user's player
+        final tappedPlayer = humanPlayer;
+        viewingPlayerMelds = tappedPlayer.id == currentUserId
+            ? null
+            : tappedPlayer;
+
+        expect(viewingPlayerMelds, isNull);
+      });
+
+      test(
+        'clicking other player should set viewingPlayerMelds to that player',
+        () {
+          // Simulate the logic from multiplayer_game_screen.dart onPlayerTap
+          Player? viewingPlayerMelds;
+
+          // Simulate clicking on other player
+          final tappedPlayer = bot1Player;
+          viewingPlayerMelds = tappedPlayer.id == currentUserId
+              ? null
+              : tappedPlayer;
+
+          expect(viewingPlayerMelds, equals(bot1Player));
+          expect(viewingPlayerMelds?.name, equals('Bot 1'));
+        },
+      );
+
+      test(
+        'switching from other player view back to current user should set viewingPlayerMelds to null',
+        () {
+          // Start viewing another player's melds
+          Player? viewingPlayerMelds = bot1Player;
+          expect(viewingPlayerMelds, equals(bot1Player));
+
+          // Now click on current user
+          final tappedPlayer = humanPlayer;
+          viewingPlayerMelds = tappedPlayer.id == currentUserId
+              ? null
+              : tappedPlayer;
+
+          expect(viewingPlayerMelds, isNull);
+        },
+      );
+    });
+
+    group('Back to Yours Button Visibility Logic', () {
+      test('should show Back to yours button when viewing another player', () {
+        // Simulate viewing bot's melds (not null)
+        expect(_shouldShowBackButton(bot1Player), isTrue);
+      });
+
+      test('should hide Back to yours button when viewing own melds', () {
+        // Simulate viewing own melds (null)
+        expect(_shouldShowBackButton(null), isFalse);
+      });
+    });
+
+    group('Melds Header Text Logic', () {
+      test(
+        'should show "Your Melds:" when viewing human player with name "You"',
+        () {
+          final player = humanPlayer;
+
+          // This simulates the logic in melds_section.dart _getMeldsHeaderText
+          String headerText;
+          if (player.name == 'You') {
+            headerText = 'Your Melds:';
+          } else {
+            headerText = '${player.name}\'s Melds:';
+          }
+
+          expect(headerText, equals('Your Melds:'));
+        },
+      );
+
+      test('should show "Bot Name\'s Melds:" when viewing bot player', () {
+        final player = bot1Player;
+
+        // This simulates the logic in melds_section.dart _getMeldsHeaderText
+        String headerText;
+        if (player.name == 'You') {
+          headerText = 'Your Melds:';
+        } else {
+          headerText = '${player.name}\'s Melds:';
+        }
+
+        expect(headerText, equals('Bot 1\'s Melds:'));
+      });
+    });
+
+    group('Edge Cases', () {
+      test('should handle null player gracefully in single player mode', () {
+        Player? viewingPlayerMelds;
+
+        // This shouldn't happen in practice, but testing defensive behavior
+        expect(viewingPlayerMelds, isNull);
+
+        // Clicking human when already null should remain null
+        final tappedPlayer = humanPlayer;
+        final foundHumanPlayer = players.firstWhere(
+          (p) => p.type == PlayerType.human,
+        );
+
+        viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+            ? null
+            : tappedPlayer;
+        expect(viewingPlayerMelds, isNull);
+      });
+
+      test('should handle invalid user ID in multiplayer mode', () {
+        const String invalidUserId = 'nonexistent';
+        Player? viewingPlayerMelds;
+
+        // Simulate clicking on human player with invalid current user ID
+        final tappedPlayer = humanPlayer;
+        viewingPlayerMelds = tappedPlayer.id == invalidUserId
+            ? null
+            : tappedPlayer;
+
+        // Should treat as different player since IDs don't match
+        expect(viewingPlayerMelds, equals(humanPlayer));
+      });
+
+      test(
+        'should handle player list without human player in single player mode',
+        () {
+          final botsOnlyPlayers = [
+            Player(id: 'bot1', name: 'Bot 1', type: PlayerType.bot),
+            Player(id: 'bot2', name: 'Bot 2', type: PlayerType.bot),
+          ];
+
+          // This would throw in practice, but testing the logic assumption
+          expect(
+            () => botsOnlyPlayers.firstWhere((p) => p.type == PlayerType.human),
+            throwsStateError,
+          );
+        },
+      );
+    });
+
+    group('Player View State Consistency', () {
+      test(
+        'should maintain consistent state through multiple player switches',
+        () {
+          Player? viewingPlayerMelds;
+          final foundHumanPlayer = players.firstWhere(
+            (p) => p.type == PlayerType.human,
+          );
+
+          // Start with human view (null)
+          expect(viewingPlayerMelds, isNull);
+
+          // Switch to bot1
+          var tappedPlayer = bot1Player;
+          viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+              ? null
+              : tappedPlayer;
+          expect(viewingPlayerMelds, equals(bot1Player));
+
+          // Switch to bot2
+          tappedPlayer = bot2Player;
+          viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+              ? null
+              : tappedPlayer;
+          expect(viewingPlayerMelds, equals(bot2Player));
+
+          // Switch back to human
+          tappedPlayer = humanPlayer;
+          viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+              ? null
+              : tappedPlayer;
+          expect(viewingPlayerMelds, isNull);
+
+          // Switch to bot1 again
+          tappedPlayer = bot1Player;
+          viewingPlayerMelds = tappedPlayer == foundHumanPlayer
+              ? null
+              : tappedPlayer;
+          expect(viewingPlayerMelds, equals(bot1Player));
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Introduced end-to-end tests for player view switching, ensuring correct behavior when switching between human and bot melds.
- Updated player tap logic in game and multiplayer screens to handle switching back to the human player's melds correctly.
- Added unit tests for player view switching logic, covering scenarios for both single and multiplayer modes, including edge cases and button visibility.
- Enhanced header text logic to reflect the current player's view accurately.