### PR TITLE
Fix bot wild card meld selection to protect large clean melds

### DIFF
--- a/lib/ai/bot_meld_analyzer.dart
+++ b/lib/ai/bot_meld_analyzer.dart
@@ -3,7 +3,6 @@ import '../models/card.dart';
 import '../models/meld.dart';
 import '../game/game_controller.dart';
 import '../config/game_config.dart';
-import '../utils/debug_logger.dart';
 
 /// Analyzes meld opportunities and calculations for bot players.
 ///
@@ -251,6 +250,45 @@ class BotMeldAnalyzer {
   }) {
     int priority = card.pointValue;
 
+    // CRITICAL: Check clean book protection FIRST before any bonuses
+    // Check if meld has no wild cards (potential clean meld/book)
+    final meldHasNoWilds = !meld.cards.any((c) => c.isWild);
+    if (card.isWild && bot != null && meldHasNoWilds) {
+      final cleanBookCount = bot.melds
+          .where((m) => m.isClean && m.cards.length >= 7)
+          .length;
+
+      // HARD BLOCK: Never contaminate large clean melds when we need clean books
+      if (meld.cards.length >= 5 && cleanBookCount < 2) {
+        // Check if there are smaller alternatives for this wild card
+        final alternativeTargets = bot.melds
+            .where(
+              (m) =>
+                  m != meld &&
+                  m.canAddCard(card) &&
+                  m.cards.length < meld.cards.length,
+            )
+            .toList();
+
+        if (alternativeTargets.isNotEmpty) {
+          return -50000; // Absolutely never do this when smaller alternatives exist
+        }
+      }
+
+      // Strong protection for medium-sized clean melds too
+      if (meld.cards.length >= 4 && cleanBookCount == 0) {
+        final alternativeTargets = bot.melds
+            .where(
+              (m) => m != meld && m.canAddCard(card) && m.cards.length <= 3,
+            )
+            .toList();
+
+        if (alternativeTargets.isNotEmpty) {
+          return -25000; // Very strong protection when small alternatives exist
+        }
+      }
+    }
+
     // NEW: ULTRA-AGGRESSIVE WILD CARD HOARDING STRATEGY
     if (card.isWild && bot != null) {
       // Count how many 2-card rank combinations we have (potential melds)
@@ -324,23 +362,23 @@ class BotMeldAnalyzer {
       }
     }
 
-    // NEW: CRITICAL PROTECTION FOR POTENTIAL CLEAN BOOKS
-    if (card.isWild && bot != null && meld.isClean && meld.cards.length >= 5) {
+    // Additional clean book protection penalties (backup to hard blocks above)
+    if (card.isWild && bot != null && meld.isClean && meld.cards.length >= 3) {
       final cleanBookCount = bot.melds
           .where((m) => m.isClean && m.cards.length >= 7)
           .length;
 
-      // MASSIVE penalty for contaminating potential clean books
-      if (cleanBookCount < 2) {
-        // Need at least 2 clean books to go out
-        priority -= GameConfig
-            .criticalCleanBookProtectionPenalty; // NEVER contaminate potential clean books when we need them
-        DebugLogger.warning(
-          '${bot.name}: BLOCKED adding wild to potential clean book ${meld.rank} (${meld.cards.length} cards)',
-        );
-      } else if (cleanBookCount < 3) {
-        priority -= GameConfig
-            .cleanBookProtectionPenalty; // Very reluctant even with 2 clean books
+      // Escalating penalties based on meld size and clean book deficit
+      if (cleanBookCount == 0) {
+        priority -= GameConfig.criticalCleanBookProtectionPenalty;
+        if (meld.cards.length >= 5) {
+          priority -= 2000; // Extra penalty for large clean melds
+        }
+      } else if (cleanBookCount < 2) {
+        priority -= GameConfig.cleanBookProtectionPenalty;
+        if (meld.cards.length >= 5) {
+          priority -= 1000; // Extra penalty for large clean melds
+        }
       }
     }
 
@@ -372,23 +410,56 @@ class BotMeldAnalyzer {
         bonus -= 300; // Don't waste wilds on completed books
       }
     }
-    // Strategy 2: FOOT PHASE - Prioritize near-book melds (6 cards) to create more books
+    // Strategy 2: FOOT PHASE - Prioritize completing books, but PROTECT clean books
     else if (bot.hasPickedUpFoot && bot.currentHand.length <= 6) {
+      // Check if meld is clean and if we have clean book alternatives
+      final isCleanMeld = meld.isClean;
+      final cleanBookCount = bot.melds
+          .where((m) => m.isClean && m.cards.length >= 7)
+          .length;
+
       // MASSIVE bonus for completing books (6 -> 7 cards)
       if (meld.cards.length == 6) {
-        bonus += 1500; // Huge bonus for book completion
+        if (!isCleanMeld) {
+          bonus += 1500; // Huge bonus for dirty book completion
+        } else {
+          // For clean melds, only give bonus if no smaller alternatives exist
+          final smallerAlternatives = bot.melds
+              .where(
+                (m) => m != meld && m.canAddCard(card) && m.cards.length <= 4,
+              )
+              .toList();
+
+          if (smallerAlternatives.isEmpty) {
+            bonus +=
+                1000; // Reduced bonus for clean book completion when necessary
+          } else {
+            bonus -= 500; // Penalty for contaminating when alternatives exist
+          }
+        }
       }
       // Good bonus for near-book melds (5 -> 6 cards)
       else if (meld.cards.length == 5) {
-        bonus += 800; // Getting close to book
+        if (!isCleanMeld) {
+          bonus += 800; // Getting close to dirty book
+        } else {
+          bonus += 400; // Reduced bonus for clean melds
+        }
       }
       // Medium bonus for growing medium melds (4 -> 5 cards)
       else if (meld.cards.length == 4) {
         bonus += 400; // Building toward book
       }
-      // Small penalty for tiny melds (concentrate on bigger ones)
+      // REVISED: Bonus for tiny melds (prefer contaminating small melds)
       else if (meld.cards.length <= 3) {
-        bonus -= 200; // Focus on near-books instead
+        if (!isCleanMeld) {
+          bonus += 200; // Prefer already dirty small melds
+        } else if (cleanBookCount == 0) {
+          bonus -= 400; // Protect small clean melds when no clean books exist
+        } else {
+          bonus +=
+              100; // Small bonus for small clean melds when we have clean books
+        }
       }
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -355,26 +355,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -648,10 +648,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -696,10 +696,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/test/ai/bot_clean_book_protection_test.dart
+++ b/test/ai/bot_clean_book_protection_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/ai/bot_meld_analyzer.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+
+void main() {
+  group('Bot Clean Book Protection', () {
+    late GameController controller;
+    late BotMeldAnalyzer analyzer;
+
+    setUp(() {
+      final players = [
+        Player(id: 'human', name: 'Human', type: PlayerType.human),
+        Player(id: 'bot1', name: 'Bot1', type: PlayerType.bot),
+      ];
+      controller = GameController(players: players, seed: 42);
+      analyzer = BotMeldAnalyzer();
+    });
+
+    test('Bot should prefer smaller meld over large clean meld for wild card', () {
+      // Create a bot player with the same scenario as Carl
+      final bot = Player(id: '2', name: 'Carl', type: PlayerType.bot);
+      bot.hasPlayedDown = true;
+      bot.hasPickedUpFoot = true;
+
+      // Add melds exactly like Carl's scenario
+      // Large clean Kings meld (6 cards)
+      final kingsMeld = Meld(
+        rank: CardRank.king,
+        cards: [
+          PlayingCard(rank: CardRank.king, suit: Suit.spades),
+          PlayingCard(rank: CardRank.king, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.king, suit: Suit.diamonds),
+          PlayingCard(rank: CardRank.king, suit: Suit.diamonds),
+          PlayingCard(rank: CardRank.king, suit: Suit.clubs),
+          PlayingCard(rank: CardRank.king, suit: Suit.hearts),
+        ],
+      );
+
+      // Small clean 10s meld (3 cards)
+      final tensMeld = Meld(
+        rank: CardRank.ten,
+        cards: [
+          PlayingCard(rank: CardRank.ten, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.ten, suit: Suit.spades),
+          PlayingCard(rank: CardRank.ten, suit: Suit.hearts),
+        ],
+      );
+
+      bot.melds.addAll([kingsMeld, tensMeld]);
+
+      // Add a wild card to bot's hand
+      final wildCard = PlayingCard(rank: CardRank.two, suit: Suit.diamonds);
+      bot.currentHand.add(wildCard);
+
+      // Find all possible meld additions
+      final meldOptions = analyzer.findCardsToAddToExistingMelds(
+        bot,
+        controller,
+      );
+
+      // Filter for wild card additions
+      final wildCardOptions = meldOptions
+          .where((option) => option['card'] == wildCard)
+          .toList();
+
+      expect(
+        wildCardOptions.length,
+        equals(2),
+        reason: 'Wild card should be addable to both Kings and 10s melds',
+      );
+
+      // Sort by priority (highest first)
+      wildCardOptions.sort((a, b) => b['priority'].compareTo(a['priority']));
+
+      // The top priority should be the smaller 10s meld, not the large Kings meld
+      final topChoice = wildCardOptions.first;
+      final topChoiceMeld = topChoice['meld'] as Meld;
+
+      expect(
+        topChoiceMeld.rank,
+        equals(CardRank.ten),
+        reason:
+            'Bot should prefer adding wild to smaller 10s meld instead of large Kings meld',
+      );
+
+      // Verify the Kings meld gets very negative priority due to protection
+      final kingsOption = wildCardOptions.firstWhere(
+        (option) => (option['meld'] as Meld).rank == CardRank.king,
+      );
+      final kingsOptionPriority = kingsOption['priority'] as int;
+
+      expect(
+        kingsOptionPriority,
+        lessThan(-10000),
+        reason: 'Large clean Kings meld should get massive negative priority',
+      );
+    });
+
+    test(
+      'Bot should still allow contaminating large clean meld if no alternatives',
+      () {
+        // Create bot with only one large clean meld and no alternatives
+        final bot = Player(id: '2', name: 'Carl', type: PlayerType.bot);
+        bot.hasPlayedDown = true;
+        bot.hasPickedUpFoot = true;
+
+        // Only Kings meld, no alternatives
+        final kingsMeld = Meld(
+          rank: CardRank.king,
+          cards: [
+            PlayingCard(rank: CardRank.king, suit: Suit.spades),
+            PlayingCard(rank: CardRank.king, suit: Suit.hearts),
+            PlayingCard(rank: CardRank.king, suit: Suit.diamonds),
+            PlayingCard(rank: CardRank.king, suit: Suit.diamonds),
+            PlayingCard(rank: CardRank.king, suit: Suit.clubs),
+            PlayingCard(rank: CardRank.king, suit: Suit.hearts),
+          ],
+        );
+
+        bot.melds.add(kingsMeld);
+
+        // Wild card that can only go to Kings meld
+        final wildCard = PlayingCard(rank: CardRank.two, suit: Suit.diamonds);
+        bot.currentHand.add(wildCard);
+
+        final meldOptions = analyzer.findCardsToAddToExistingMelds(
+          bot,
+          controller,
+        );
+        final wildCardOptions = meldOptions
+            .where((option) => option['card'] == wildCard)
+            .toList();
+
+        expect(
+          wildCardOptions.length,
+          equals(1),
+          reason: 'Should find the Kings meld as only option',
+        );
+
+        final option = wildCardOptions.first;
+        final priority = option['priority'] as int;
+
+        // Should not be the massive negative value since no alternatives exist
+        expect(
+          priority,
+          greaterThan(-50000),
+          reason: 'Should allow contamination when no alternatives exist',
+        );
+      },
+    );
+
+    test('Bot should prefer already dirty melds over clean melds', () {
+      final bot = Player(id: '2', name: 'Carl', type: PlayerType.bot);
+      bot.hasPlayedDown = true;
+      bot.hasPickedUpFoot = true;
+
+      // Clean Kings meld
+      final cleanKingsMeld = Meld(
+        rank: CardRank.king,
+        cards: [
+          PlayingCard(rank: CardRank.king, suit: Suit.spades),
+          PlayingCard(rank: CardRank.king, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.king, suit: Suit.diamonds),
+        ],
+      );
+
+      // Already dirty Queens meld (same size)
+      final dirtyQueensMeld = Meld(
+        rank: CardRank.queen,
+        cards: [
+          PlayingCard(rank: CardRank.queen, suit: Suit.spades),
+          PlayingCard(rank: CardRank.queen, suit: Suit.hearts),
+          PlayingCard(rank: CardRank.two, suit: Suit.clubs), // Already has wild
+        ],
+      );
+
+      bot.melds.addAll([cleanKingsMeld, dirtyQueensMeld]);
+
+      final wildCard = PlayingCard(rank: CardRank.two, suit: Suit.diamonds);
+      bot.currentHand.add(wildCard);
+
+      final meldOptions = analyzer.findCardsToAddToExistingMelds(
+        bot,
+        controller,
+      );
+      final wildCardOptions = meldOptions
+          .where((option) => option['card'] == wildCard)
+          .toList();
+
+      wildCardOptions.sort((a, b) => b['priority'].compareTo(a['priority']));
+
+      final topChoice = wildCardOptions.first;
+      final topChoiceMeld = topChoice['meld'] as Meld;
+
+      expect(
+        topChoiceMeld.rank,
+        equals(CardRank.queen),
+        reason:
+            'Bot should prefer already dirty Queens meld over clean Kings meld',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Resolves issue where bots incorrectly contaminated large clean melds (e.g. 6-card Kings) instead of using smaller alternatives, destroying potential 500-point clean books.

Key improvements:
- Add hard block protection for clean melds 5+ cards when smaller alternatives exist
- Revise strategic bonuses to prefer dirty melds over clean melds for wild cards
- Implement alternative target detection before contaminating large clean melds
- Add comprehensive test coverage for clean book protection scenarios

Bot decision-making now correctly prioritizes preserving clean book potential while maintaining strategic wild card usage in critical situations.

🤖 Generated with [Claude Code](https://claude.ai/code)