### PR TITLE
Fix bot AI foot transition and end-round strategy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit reads AGENTS.md and CLAUDE.md automatically for coding guidelines.
+# This file adds repository-wide review reminders.
+
+reviews:
+  path_instructions:
+    - path: "**/*.dart"
+      instructions: |
+        This is a PUBLIC GitHub repository. Do not suggest committing secrets, API keys,
+        Firebase credentials, .env files, or service account JSON.
+
+        All Dart changes must be formatted before merge. CI runs:
+          dart format --output=none --set-exit-if-changed .
+        Remind authors to run `dart format .` or `./format_and_test.sh` locally.
+
+        Flutter style: always use curly braces on control-flow statements.
+        `flutter analyze` must pass with zero issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # AGENTS.md
 
+## Repository context
+
+**This is a public repository** (`BenDaSpur/hand-foot-game-flutter` on GitHub). Treat all code, commits, PRs, and review comments as world-readable.
+
+- **Never commit secrets** — no API keys, Firebase credentials, `.env` files, service account JSON, or tokens.
+- **Never paste secrets** into issues, PR descriptions, or agent prompts.
+- Use the repo's **stub** `lib/firebase_options.dart` locally; inject real Firebase config only via `scripts/setup_local_firebase.sh` + a local `.env` (gitignored).
+- Assume CI logs, PR reviews (including CodeRabbit), and Cloud Agent transcripts may be visible to others.
+
 ## Cursor Cloud specific instructions
 
 This is a Flutter (Dart) app — the **Hand & Foot** card game with AI bots and optional Firebase multiplayer. Standard dev/test/build commands live in `README.md`, `CLAUDE.md`, and `format_and_test.sh`; use those as the source of truth.
@@ -19,3 +28,15 @@ This is a Flutter (Dart) app — the **Hand & Foot** card game with AI bots and 
 - `flutter test` runs the full unit/widget suite (~750 tests) and passes headlessly with no extra setup. Tests skip Firebase automatically under `FLUTTER_TEST`.
 - `flutter analyze` must be clean (zero issues) — the repo enforces this.
 - E2E integration tests (`e2e_test/`) are documented to run on `-d macos` and are **disabled in CI**; they are not runnable in this Linux/web environment.
+
+### Code quality (required before commit/PR)
+
+CI enforces formatting — unformatted Dart will fail `quality-checks`. After any code change:
+
+```bash
+dart format .              # required — CI runs: dart format --set-exit-if-changed .
+flutter analyze            # must be zero issues
+flutter test               # full suite must pass
+```
+
+Or run the all-in-one script: `./format_and_test.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Public repository
+
+**This repo is public on GitHub.** Do not commit or suggest committing secrets (Firebase keys, `.env`, service accounts, tokens). Use stub Firebase config in-tree; real credentials belong only in local `.env` via `scripts/setup_local_firebase.sh`.
+
 ## Development Commands
 
 - **Run the app**: `flutter run`
 - **Build for release**: `flutter build apk` (Android) or `flutter build ios` (iOS)
+- **Format code**: `dart format .` — **required after every change**; CI fails if formatting differs (`dart format --set-exit-if-changed .`)
+- **Run all quality checks**: `./format_and_test.sh` (format + test + analyze + deps)
 - **Static analysis**: `flutter analyze`
 - **Run tests**: `flutter test test/` for unit tests, `flutter test e2e/ -d macos` for e2e integration tests
 - **Hot reload**: Available when running with `flutter run` - press `r` to reload
@@ -218,6 +224,7 @@ Key constants defined in `GameConfig`:
 
 **Git Workflow**: 
 - Branch naming: `bs/feature-description` (developer-initials/description)
+- **Always run `dart format .` before committing** — CI will reject unformatted Dart
 - Always run `flutter analyze` before committing
 - Commit only lib/ changes unless specifically adding tests
 
@@ -263,6 +270,7 @@ for (int i = 0; i < 10; i++) {
 - **Prefer composition over inheritance** for widgets
 
 ### Static Analysis Compliance
+- Run `dart format .` before every commit — CI enforces `dart format --set-exit-if-changed .`
 - Run `flutter analyze` before every commit
 - Fix ALL warnings and errors - zero tolerance policy
 - Use `// ignore: rule_name` only for exceptional cases with clear comments explaining why

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ flutter build linux      # Linux
 - **Multi-platform CI/CD** - Ubuntu (unit tests) + macOS (E2E tests)
 - **Branch protection** - all checks must pass to merge
 - **Pre-commit hooks** for formatting
+- **CI enforces `dart format`** — run `dart format .` (or `./format_and_test.sh`) after every code change before pushing
+
+> **Public repo:** This project is open source on GitHub. Do not commit secrets, credentials, or `.env` files.
 
 ## 🎪 How to Play
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,5 +12,6 @@ This directory contains all documentation for the Hand & Foot Flutter game.
 ## Quick Links
 
 - [Main README](../README.md) - Project overview and getting started
+- [AGENTS.md](../AGENTS.md) - Instructions for Cursor Cloud agents and AI tooling
 - [CLAUDE.md](../CLAUDE.md) - Developer instructions for Claude Code
 - [Testing Guide](TESTING.md) - How to run and write tests

--- a/lib/ai/bot_end_game_manager.dart
+++ b/lib/ai/bot_end_game_manager.dart
@@ -4,6 +4,7 @@ import '../models/meld.dart';
 import '../models/game_state.dart';
 import '../game/game_controller.dart';
 import '../config/game_config.dart';
+import '../utils/debug_logger.dart';
 import 'bot_decision.dart';
 import 'bot_config.dart';
 import 'bot_meld_analyzer.dart';
@@ -226,8 +227,8 @@ class BotEndGameManager {
 
     // On foot with empty hand but missing books — cannot finish
     if (bot.currentHand.isEmpty) {
-      print(
-        'Warning: Bot ${bot.name} has empty foot but cannot go out (missing required books)',
+      DebugLogger.warning(
+        'Bot ${bot.name} has empty foot but cannot go out (missing required books)',
       );
       return null;
     }

--- a/lib/ai/bot_end_game_manager.dart
+++ b/lib/ai/bot_end_game_manager.dart
@@ -1,6 +1,7 @@
 import '../models/player.dart';
 import '../models/card.dart';
 import '../models/meld.dart';
+import '../models/game_state.dart';
 import '../game/game_controller.dart';
 import '../config/game_config.dart';
 import 'bot_decision.dart';
@@ -148,6 +149,65 @@ class BotEndGameManager {
     return hasCleanBook && hasDirtyBook;
   }
 
+  /// Whether the bot has both required books and is on the foot pile.
+  bool isReadyToFinishRound(Player bot) {
+    return bot.hasPickedUpFoot && bot.canGoOutWithBooks;
+  }
+
+  /// Build the correct action to end the round when books are satisfied.
+  ///
+  /// Going out requires an empty hand — bots must discard or meld their last
+  /// card(s) first. Returns null when the bot is not in a finishing position.
+  BotDecision? buildFinishRoundDecision(
+    Player bot,
+    GameController controller,
+    TurnPhase turnPhase,
+  ) {
+    if (!isReadyToFinishRound(bot)) {
+      return null;
+    }
+
+    if (bot.currentHand.isEmpty) {
+      return BotDecision(action: 'goOut');
+    }
+
+    if (bot.currentHand.length <= 4) {
+      final optimized = optimizeForGoOut(bot, controller);
+      if (optimized != null) {
+        return optimized;
+      }
+    }
+
+    if (bot.currentHand.length == 1) {
+      if (turnPhase == TurnPhase.discard) {
+        return BotDecision(action: 'discard', data: bot.currentHand.first);
+      }
+      final cardsToAdd = _findCardsToAddToExistingMelds(bot, controller);
+      if (cardsToAdd.isNotEmpty) {
+        return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+      }
+      return BotDecision(action: 'noMeld');
+    }
+
+    if (bot.currentHand.length == 2) {
+      if (turnPhase == TurnPhase.meld) {
+        final meldAction = _findOptimalMeldForGoOut(bot, controller);
+        if (meldAction != null) {
+          return meldAction;
+        }
+        return BotDecision(action: 'noMeld');
+      }
+      if (turnPhase == TurnPhase.discard) {
+        return BotDecision(
+          action: 'discard',
+          data: _chooseCardToDiscard(bot),
+        );
+      }
+    }
+
+    return null;
+  }
+
   /// Main entry point for end game decisions.
   ///
   /// Determines if the bot should go out, complete books, or continue building
@@ -157,35 +217,22 @@ class BotEndGameManager {
       return null; // Not ready for end game decisions
     }
 
-    // Handle empty hand scenarios properly
-    if (bot.currentHand.isEmpty) {
-      if (!bot.hasPickedUpFoot) {
-        // Empty hand but no foot picked up - should pick up foot automatically
-        // This is handled by the game controller, not bot AI, but log for debugging
-        print(
-          'Info: Bot ${bot.name} has empty hand, will automatically pick up foot',
-        );
-        return null; // Let game controller handle foot pickup
-      } else if (bot.canGoOut) {
-        // On foot with empty hand and can go out - GO OUT!
-        return BotDecision(action: 'goOut');
-      } else {
-        // On foot with empty hand but can't go out (missing books)
-        print(
-          'Warning: Bot ${bot.name} has empty foot but cannot go out (missing required books)',
-        );
-        return null; // This shouldn't happen in normal gameplay
-      }
+    final gameState = controller.gameState;
+    final finishDecision = buildFinishRoundDecision(
+      bot,
+      controller,
+      gameState.turnPhase,
+    );
+    if (finishDecision != null) {
+      return finishDecision;
     }
 
-    // CRITICAL: Go out immediately with 1-2 cards if we can
-    if (bot.currentHand.length <= 2 && controller.canPlayerGoOut()) {
-      final nonThreeCards = bot.currentHand
-          .where((card) => !card.isThree)
-          .toList();
-      if (nonThreeCards.isNotEmpty) {
-        return BotDecision(action: 'goOut', data: nonThreeCards.first);
-      }
+    // On foot with empty hand but missing books — cannot finish
+    if (bot.currentHand.isEmpty) {
+      print(
+        'Warning: Bot ${bot.name} has empty foot but cannot go out (missing required books)',
+      );
+      return null;
     }
 
     // NEW: Go-out optimization for edge cases (like Ben with Q♦ + 5s)
@@ -199,8 +246,7 @@ class BotEndGameManager {
       }
     }
 
-    // NEW: Aggressive go-out under competitive pressure
-    final gameState = controller.gameState;
+    // Aggressive go-out under competitive pressure
     if (_shouldGoOutAggressively(bot, gameState)) {
       final goOutDecision = _attemptAggressiveGoOut(bot, controller);
       if (goOutDecision != null) return goOutDecision;
@@ -240,7 +286,7 @@ class BotEndGameManager {
     // Must be on foot with few cards AND have required books
     if (!bot.hasPickedUpFoot ||
         bot.currentHand.length > BotConfig.winningPositionHandSize ||
-        !bot.canGoOut) {
+        !bot.canGoOutWithBooks) {
       return false;
     }
 
@@ -683,12 +729,15 @@ class BotEndGameManager {
         .length;
 
     if (cleanBooks > 0 && dirtyBooks > 0) {
-      // Have required books, find card to discard and go out
+      // Have required books — discard last card(s) to go out (hand must be empty)
       final possibleDiscards = bot.currentHand
           .where((card) => !card.isThree)
           .toList();
       if (possibleDiscards.isNotEmpty) {
-        return BotDecision(action: 'goOut', data: possibleDiscards.first);
+        return BotDecision(action: 'discard', data: possibleDiscards.first);
+      }
+      if (bot.currentHand.isNotEmpty) {
+        return BotDecision(action: 'discard', data: bot.currentHand.first);
       }
     }
 

--- a/lib/ai/bot_end_game_manager.dart
+++ b/lib/ai/bot_end_game_manager.dart
@@ -198,10 +198,7 @@ class BotEndGameManager {
         return BotDecision(action: 'noMeld');
       }
       if (turnPhase == TurnPhase.discard) {
-        return BotDecision(
-          action: 'discard',
-          data: _chooseCardToDiscard(bot),
-        );
+        return BotDecision(action: 'discard', data: _chooseCardToDiscard(bot));
       }
     }
 

--- a/lib/ai/bot_foot_transition_manager.dart
+++ b/lib/ai/bot_foot_transition_manager.dart
@@ -146,7 +146,9 @@ class BotFootTransitionManager {
         remainingCards > BotConfig.aggressiveFootTransitionThreshold;
 
     return (shouldTransitionForSize || shouldTransitionForPressure) &&
-        !(stillOnHandPile && hasExcessiveWilds);
+        !(stillOnHandPile &&
+            hasExcessiveWilds &&
+            remainingCards > BotConfig.aggressiveFootTransitionThreshold);
   }
 
   /// Check if bot should transition due to hand size pressure
@@ -156,9 +158,6 @@ class BotFootTransitionManager {
     int remainingCards,
   ) {
     final gameState = controller.gameState;
-    final wildCardCount = bot.currentHand.where((c) => c.isWild).length;
-    final hasExcessiveWilds =
-        wildCardCount >= BotConfig.excessiveWildsThreshold;
 
     // Check for competitive pressure
     final opponentOnFoot = gameState.players.any(
@@ -171,7 +170,7 @@ class BotFootTransitionManager {
     final hasCompetitivePressure = competitivePressure && remainingCards > 12;
     final shouldTransition = hasHandSizePressure || hasCompetitivePressure;
 
-    return shouldTransition && bot.hasPlayedDown && !hasExcessiveWilds;
+    return shouldTransition && bot.hasPlayedDown;
   }
 
   /// Check if bot should use late round transition strategy
@@ -182,13 +181,12 @@ class BotFootTransitionManager {
 
   /// Check if bot should transition after playing down
   bool _shouldPostPlaydownTransition(Player bot, int remainingCards) {
-    final stillOnHandPile = bot.hasPlayedDown && !bot.hasPickedUpFoot;
     final hasWeakMeldOpportunity = _hasOnlyWeakMeldOpportunities(bot);
 
     return bot.hasPlayedDown &&
+        !bot.hasPickedUpFoot &&
         remainingCards >= BotConfig.postPlaydownTransitionThreshold &&
-        !hasWeakMeldOpportunity &&
-        !stillOnHandPile;
+        !hasWeakMeldOpportunity;
   }
 
   /// Check if bot should transition based on hand quality
@@ -225,15 +223,13 @@ class BotFootTransitionManager {
 
   /// Check if bot should transition when most cards can be played
   bool _shouldPlayMostCardsTransition(Player bot, GameController controller) {
-    final stillOnHandPile = bot.hasPlayedDown && !bot.hasPickedUpFoot;
     final wildCardCount = bot.currentHand.where((c) => c.isWild).length;
     final hasExcessiveWilds =
         wildCardCount >= BotConfig.excessiveWildsThreshold;
     final hasWeakMeldOpportunity = _hasOnlyWeakMeldOpportunities(bot);
     final canPlayMostCards = _canPlayMostCards(bot, controller);
 
-    final shouldBeConservative =
-        hasExcessiveWilds || hasWeakMeldOpportunity || stillOnHandPile;
+    final shouldBeConservative = hasExcessiveWilds || hasWeakMeldOpportunity;
 
     return canPlayMostCards && !shouldBeConservative;
   }

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -94,15 +94,24 @@ class EnhancedBotAI {
       // Set context for personality-based decisions
       _personalityManager.setCurrentPlayerContext(bot.id);
 
-      // CRITICAL: Check if bot can go out BEFORE any other decisions
-      // Valid in both discard phase (discard last card) and meld phase (play last card into meld)
-      if ((gameState.turnPhase == TurnPhase.discard ||
-              gameState.turnPhase == TurnPhase.meld) &&
-          _shouldGoOutImmediately(bot, gameState)) {
-        DebugLogger.debug(
-          '${bot.name}: CRITICAL - Going out immediately to prevent opponent victory!',
-        );
-        return BotDecision(action: 'goOut');
+      // CRITICAL: Finish the round when books are met — discard/meld last cards
+      // before going out (empty hand required for canGoOut).
+      if (gameState.turnPhase == TurnPhase.discard ||
+          gameState.turnPhase == TurnPhase.meld) {
+        final controller = context.controller as GameController?;
+        if (controller != null) {
+          final finishDecision = _endGameManager.buildFinishRoundDecision(
+            bot,
+            controller,
+            gameState.turnPhase,
+          );
+          if (finishDecision != null) {
+            DebugLogger.debug(
+              '${bot.name}: CRITICAL - Finishing round (${finishDecision.action})',
+            );
+            return finishDecision;
+          }
+        }
       }
 
       // DEBUG: Log decision context (removed in release builds)
@@ -803,66 +812,6 @@ class EnhancedBotAI {
     }
 
     return BotDecision(action: 'noMeld');
-  }
-
-  /// CRITICAL: Check if bot should prioritize going out over other actions
-  /// This addresses the major strategic flaw where bots miss going out opportunities
-  bool _shouldGoOutImmediately(Player bot, GameState gameState) {
-    // Must have picked up foot and have both required books
-    if (!bot.hasPickedUpFoot || !bot.canGoOutWithBooks) {
-      return false;
-    }
-
-    // Check for critical going out scenarios - only return true if bot can ACTUALLY go out right now
-
-    // Scenario 1: Bot has no cards and can go out immediately
-    if (bot.currentHand.isEmpty && bot.canGoOut) {
-      DebugLogger.debug(
-        '${bot.name}: Immediate going out - hand empty and can go out',
-      );
-      return true;
-    }
-
-    // Scenario 2: EMERGENCY - Bot has 1 card and can discard to go out
-    if (bot.currentHand.length == 1 && bot.canGoOutWithBooks) {
-      DebugLogger.debug(
-        '${bot.name}: Emergency going out - 1 card left and can go out',
-      );
-      return true;
-    }
-
-    // Scenario 3: COMPETITIVE EMERGENCY - Opponent has massive book advantage and small hand
-    for (final opponent in gameState.players) {
-      if (opponent.id == bot.id) continue;
-
-      final opponentBooks = opponent.melds.where((m) => m.isBook).length;
-      final opponentHasGoingOutBooks = opponent.canGoOutWithBooks;
-
-      // If opponent has 6+ books and small hand, and bot can go out with 2-3 cards
-      if (opponentBooks >= 6 &&
-          opponentHasGoingOutBooks &&
-          opponent.currentHand.length <= 4 &&
-          bot.currentHand.length <= 3 &&
-          bot.canGoOutWithBooks) {
-        DebugLogger.debug(
-          '${bot.name}: COMPETITIVE EMERGENCY - Opponent has $opponentBooks books and ${opponent.currentHand.length} cards, going out NOW!',
-        );
-        return true;
-      }
-    }
-
-    // Scenario 4: CATASTROPHIC 3s MANAGEMENT - Bot has mostly 3s and must go out to avoid penalty spiral
-    final threeCount = bot.currentHand.where((card) => card.isThree).length;
-    if (bot.currentHand.length >= 8 &&
-        threeCount >= bot.currentHand.length - 2 && // Almost all 3s
-        bot.canGoOut) {
-      DebugLogger.debug(
-        '${bot.name}: 3s CATASTROPHE - $threeCount 3s out of ${bot.currentHand.length} cards, emergency go out!',
-      );
-      return true;
-    }
-
-    return false; // For other scenarios, we'll modify behavior in specific turn phases
   }
 
   /// Check if bot should rush to go out (affects discard and meld priorities)
@@ -2592,17 +2541,10 @@ class EnhancedBotAI {
 
     if (gameState.turnPhase == TurnPhase.meld &&
         bot.hasPickedUpFoot &&
-        bot.currentHand.length <= 10) {
-      // If we're in foot and human is still accumulating, rush to go out
-      if (context.canPlayerGoOut()) {
-        // Try to go out immediately to cut off their strategy
-        final possibleDiscards = bot.currentHand
-            .where((card) => !card.isThree)
-            .toList();
-        if (possibleDiscards.isNotEmpty) {
-          return BotDecision(action: 'goOut', data: possibleDiscards.first);
-        }
-      }
+        bot.currentHand.length <= 10 &&
+        bot.canGoOutWithBooks) {
+      // Rush to finish — meld what we can, then discard to go out
+      return BotDecision(action: 'noMeld');
     }
 
     return null;
@@ -2649,18 +2591,23 @@ class EnhancedBotAI {
     }
 
     if (bot.hasPlayedDown && !bot.hasPickedUpFoot && bot.isHandEmpty) {
-      // Rush to foot immediately
-      return BotDecision(action: 'pickUpFoot');
+      // Foot pickup is handled automatically by the game engine after meld/discard
+      return null;
     }
 
     if (bot.hasPickedUpFoot && bot.currentHand.length <= 12) {
-      // Aggressive go-out attempt - don't wait for perfect books
-      if (context.canPlayerGoOut()) {
-        final possibleDiscards = bot.currentHand
-            .where((card) => !card.isThree)
-            .toList();
-        if (possibleDiscards.isNotEmpty) {
-          return BotDecision(action: 'goOut', data: possibleDiscards.first);
+      // Aggressive finish attempt when books are met
+      if (bot.canGoOutWithBooks) {
+        final controller = context.controller as GameController?;
+        if (controller != null) {
+          final finishDecision = _endGameManager.buildFinishRoundDecision(
+            bot,
+            controller,
+            gameState.turnPhase,
+          );
+          if (finishDecision != null) {
+            return finishDecision;
+          }
         }
       }
 
@@ -2972,7 +2919,7 @@ class EnhancedBotAI {
     try {
       switch (decision.action) {
         case 'goOut':
-          return context.canPlayerGoOut() && bot.hasPickedUpFoot;
+          return bot.canGoOut && bot.hasPickedUpFoot;
         case 'createMeld':
           return decision.data is List<PlayingCard> &&
               (decision.data as List<PlayingCard>).isNotEmpty;

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance for running and debugging Flutter tests in this project.
 
+> **Public repo:** Do not commit secrets or credentials. Run `dart format .` after code changes — CI enforces formatting.
+
 ## Basic Test Commands
 
 - **Run all tests**: `flutter test`

--- a/test/ai/bot_clean_meld_and_penalty_test.dart
+++ b/test/ai/bot_clean_meld_and_penalty_test.dart
@@ -181,7 +181,8 @@ void main() {
 
         final decision = endGameManager.handleEndGame(botPlayer, controller);
         expect(decision, isNotNull);
-        expect(decision!.action, 'goOut');
+        expect(decision!.action, 'discard');
+        expect(decision.data, isA<PlayingCard>());
       },
     );
   });

--- a/test/ai/bot_finish_round_strategy_test.dart
+++ b/test/ai/bot_finish_round_strategy_test.dart
@@ -20,10 +20,7 @@ void main() {
         rank: CardRank.ace,
         cards: List.generate(
           7,
-          (i) => PlayingCard(
-            suit: Suit.values[i % 4],
-            rank: CardRank.ace,
-          ),
+          (i) => PlayingCard(suit: Suit.values[i % 4], rank: CardRank.ace),
         ),
         type: MeldType.natural,
       );
@@ -120,10 +117,7 @@ void main() {
       botPlayer.dealHand(
         List.generate(
           9,
-          (i) => PlayingCard(
-            suit: Suit.values[i % 4],
-            rank: CardRank.five,
-          ),
+          (i) => PlayingCard(suit: Suit.values[i % 4], rank: CardRank.five),
         ),
       );
 

--- a/test/ai/bot_finish_round_strategy_test.dart
+++ b/test/ai/bot_finish_round_strategy_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_end_game_manager.dart';
+import 'package:hand_foot_game_flutter/ai/bot_foot_transition_manager.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Finish round strategy', () {
+    late BotEndGameManager endGameManager;
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player botPlayer;
+
+    Meld cleanBook() {
+      return Meld(
+        rank: CardRank.ace,
+        cards: List.generate(
+          7,
+          (i) => PlayingCard(
+            suit: Suit.values[i % 4],
+            rank: CardRank.ace,
+          ),
+        ),
+        type: MeldType.natural,
+      );
+    }
+
+    Meld dirtyBook() {
+      return Meld(
+        rank: CardRank.king,
+        cards: [
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+          const PlayingCard(suit: null, rank: CardRank.joker),
+        ],
+        type: MeldType.mixed,
+      );
+    }
+
+    setUp(() {
+      endGameManager = BotEndGameManager();
+      botAI = EnhancedBotAI();
+      final players = [
+        Player(id: '1', name: 'Human', type: PlayerType.human),
+        Player(id: '2', name: 'Bot', type: PlayerType.bot),
+      ];
+      gameController = GameController(players: players);
+      botPlayer = players[1];
+      botPlayer.hasPlayedDown = true;
+      botPlayer.hasPickedUpFoot = true;
+      botPlayer.melds.addAll([cleanBook(), dirtyBook()]);
+      gameController.gameState.currentPlayerIndex = 1;
+    });
+
+    test('discards last card instead of invalid goOut when 1 card remains', () {
+      botPlayer.hand.clear();
+      botPlayer.foot.clear();
+      botPlayer.foot.add(
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+      );
+
+      expect(botPlayer.canGoOutWithBooks, isTrue);
+      expect(botPlayer.canGoOut, isFalse);
+
+      gameController.gameState.turnPhase = TurnPhase.discard;
+
+      final decision = endGameManager.buildFinishRoundDecision(
+        botPlayer,
+        gameController,
+        TurnPhase.discard,
+      );
+
+      expect(decision, isNotNull);
+      expect(decision!.action, equals('discard'));
+      expect((decision.data as PlayingCard).rank, equals(CardRank.five));
+    });
+
+    test('enhanced bot AI discards last card in discard phase', () {
+      botPlayer.hand.clear();
+      botPlayer.foot.clear();
+      botPlayer.foot.add(
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+      );
+      gameController.gameState.turnPhase = TurnPhase.discard;
+
+      final decision = botAI.makeDecision(botPlayer, gameController);
+
+      expect(decision.action, equals('discard'));
+      expect(decision.data, isA<PlayingCard>());
+    });
+
+    test('returns goOut only when hand is empty', () {
+      botPlayer.hand.clear();
+      botPlayer.foot.clear();
+
+      gameController.gameState.turnPhase = TurnPhase.discard;
+
+      final decision = endGameManager.buildFinishRoundDecision(
+        botPlayer,
+        gameController,
+        TurnPhase.discard,
+      );
+
+      expect(decision, isNotNull);
+      expect(decision!.action, equals('goOut'));
+    });
+
+    test('post-playdown transition triggers on hand pile with 8+ cards', () {
+      final transitionManager = BotFootTransitionManager();
+      botPlayer.hasPickedUpFoot = false;
+      botPlayer.hand.clear();
+      botPlayer.dealHand(
+        List.generate(
+          9,
+          (i) => PlayingCard(
+            suit: Suit.values[i % 4],
+            rank: CardRank.five,
+          ),
+        ),
+      );
+
+      gameController.gameState.turnPhase = TurnPhase.discard;
+
+      final decision = transitionManager.handleFootTransition(
+        botPlayer,
+        gameController,
+      );
+      expect(decision, isNotNull);
+      expect(decision!.action, anyOf('discard', 'createMeld', 'addToMeld'));
+    });
+  });
+}

--- a/test/regression/bot_strategic_improvements_test.dart
+++ b/test/regression/bot_strategic_improvements_test.dart
@@ -110,12 +110,12 @@ void main() {
       // Act: Bot makes decision
       final decision = botAI.makeDecision(botPlayer, gameController);
 
-      // Assert: Should skip melding (noMeld) to rush to discard phase for going out
+      // Assert: Meld the playable card first, then discard to go out same turn
       expect(
         decision.action,
-        equals('noMeld'),
+        equals('addToMeld'),
         reason:
-            'Bot with 2 cards and required books should skip melding and rush to go out',
+            'Bot with 2 cards and required books should meld playable cards before discarding to go out',
       );
     });
 
@@ -169,12 +169,12 @@ void main() {
       // Act: Bot makes decision
       final decision = botAI.makeDecision(botPlayer, gameController);
 
-      // Assert: Should go out immediately when possible (improved competitive behavior)
+      // Assert: Meld last card into existing meld to empty hand (round ends via engine)
       expect(
         decision.action,
-        equals('goOut'),
+        equals('addToMeld'),
         reason:
-            'Bot should go out immediately when they have 1 card and required books (can end round by playing last card into meld)',
+            'Bot with 1 meldable card and required books should meld it to go out (empty hand required)',
       );
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes bot AI foot transition and end-round strategy bugs, plus documentation for agents/reviewers.

### Bot AI fixes
- Bots were returning invalid `goOut` with cards still in hand — now discard/meld last cards correctly
- Dead post-playdown foot transition logic fixed
- Foot transition no longer over-blocked on hand pile or excessive wilds
- Removed broken `pickUpFoot` decision path

### Documentation (agents / CI / CodeRabbit)
- **`dart format .` required** before commit/PR — CI enforces `dart format --set-exit-if-changed .`
- **Public repo reminders** in `AGENTS.md`, `CLAUDE.md`, `README.md`, `test/CLAUDE.md`
- **`.coderabbit.yaml`** with Dart path instructions for formatting and secret hygiene

## Testing

- `flutter analyze` — clean
- `flutter test` — all 758 tests pass
- CI quality-checks — passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-879c3c92-e533-4fdb-872f-d7d9fbb3ce45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-879c3c92-e533-4fdb-872f-d7d9fbb3ce45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced bot end-of-round play with smarter “finish round” decisions, choosing between melding, discarding, and going out based on hand status and readiness.
* **Bug Fixes**
  * Fixed bot decision edge cases for foot/hand transitions and end-game validation, reducing incorrect or prematurely triggered go-out actions.
  * Adjusted aggressive behavior so the bot discards more often instead of going out in certain penalty-focused scenarios.
* **Documentation**
  * Expanded contributor guidance for formatting, CI-aligned quality checks, and preventing secret/credential commits.
  * Added links to AI/collaboration instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->