### PR TITLE
Fix bot foot transition failures and opponent-pressure AI

### DIFF
--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -645,10 +645,7 @@ class EnhancedBotAI {
 
     // AGGRESSIVE FIX: Dramatically reduce strategic holding to prevent accumulation
     // Opponents on foot are racing to go out — stop hoarding and melt hand down
-    final opponentOnFoot = context.players.any(
-      (p) => p.id != bot.id && p.hasPickedUpFoot,
-    );
-    if (opponentOnFoot && !bot.hasPickedUpFoot) {
+    if (_opponentOnFootPressure(context, bot) && !bot.hasPickedUpFoot) {
       if (_shouldExecuteDumpStrategy(bot, context)) {
         return _executeDumpStrategy(bot, context);
       }
@@ -679,7 +676,7 @@ class EnhancedBotAI {
         (h) => h.hasPickedUpFoot && h.currentHand.length <= 10,
       );
 
-      if (!humanThreat && !opponentOnFoot && handSize <= 6) {
+      if (!humanThreat) {
         return BotDecision(action: 'noMeld');
       }
       // Otherwise, continue to meld building instead of holding

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -393,16 +393,18 @@ class EnhancedBotAI {
           );
           return BotDecision(action: 'drawFromDiscard');
         }
-        // NEW: Also try unlocking pile manually if game doesn't allow it but we want it
+        // Pre-play-down: play down first so we can unlock the pile on a future turn
         if (shouldTake && !canUnlock && !bot.hasPlayedDown) {
-          // Check if we could unlock it if we had played down
           if (_couldUnlockDiscardPileIfPlayedDown(bot, gameState)) {
             DebugLogger.botDebug(
               bot.id,
               bot.name,
-              'Returning unlockDiscardPile (pre-play-down opportunity)',
+              'Valuable discard pile blocked - prioritizing play-down first',
             );
-            return BotDecision(action: 'unlockDiscardPile');
+            final playDownDecision = _handlePlayDownDecision(bot, context);
+            if (playDownDecision.action != 'noMeld') {
+              return playDownDecision;
+            }
           }
         }
       } catch (e) {
@@ -642,18 +644,42 @@ class EnhancedBotAI {
     }
 
     // AGGRESSIVE FIX: Dramatically reduce strategic holding to prevent accumulation
-    // Only hold with very small hands and only briefly
+    // Opponents on foot are racing to go out — stop hoarding and melt hand down
+    final opponentOnFoot = context.players.any(
+      (p) => p.id != bot.id && p.hasPickedUpFoot,
+    );
+    if (opponentOnFoot && !bot.hasPickedUpFoot) {
+      if (_shouldExecuteDumpStrategy(bot, context)) {
+        return _executeDumpStrategy(bot, context);
+      }
+
+      final rushCardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
+        bot,
+        controller,
+      );
+      if (rushCardsToAdd.isNotEmpty) {
+        return BotDecision(action: 'addToMeld', data: rushCardsToAdd.first);
+      }
+
+      final rushMelds = _getCachedPossibleMelds(bot, context);
+      if (rushMelds.isNotEmpty) {
+        return BotDecision(
+          action: 'createMeld',
+          data: _meldAnalyzer.findBestMeld(rushMelds, bot: bot),
+        );
+      }
+    }
+
+    // Only hold with small hands when no opponent foot pressure
     if (handSize <= 6 && _shouldHoldCardsStrategically(bot, context)) {
-      // Only hold if hand is small AND no human threat AND very selective conditions
       final humanPlayers = context.players.where(
         (p) => p.type == PlayerType.human,
       );
       final humanThreat = humanPlayers.any(
-        (h) => h.hasPickedUpFoot && h.currentHand.length <= 8,
+        (h) => h.hasPickedUpFoot && h.currentHand.length <= 10,
       );
 
-      // Much more restrictive holding - only with tiny hands and no threats
-      if (!humanThreat && handSize <= 6) {
+      if (!humanThreat && !opponentOnFoot && handSize <= 6) {
         return BotDecision(action: 'noMeld');
       }
       // Otherwise, continue to meld building instead of holding
@@ -1723,6 +1749,11 @@ class EnhancedBotAI {
     // Don't hold if hand exceeds personality-based limit (adjusted for time pressure)
     if (handSize >= personalityHoldingLimit) return false;
 
+    // Race to foot when opponents are already on foot (human-style tempo play)
+    if (_opponentOnFootPressure(context, bot) && !bot.hasPickedUpFoot) {
+      return false;
+    }
+
     // ADAPTIVE PERSONALITY FIX: Be much more aggressive in foot phase
     if (personality == BotPersonality.adaptive &&
         bot.hasPickedUpFoot &&
@@ -2305,7 +2336,18 @@ class EnhancedBotAI {
     // Reduce limit based on time pressure
     final pressureReduction = (timePressure * 5)
         .round(); // Up to 5 card reduction - more pressure
-    return (baseLimit - pressureReduction).clamp(8, baseLimit);
+    final minLimit = switch (personality) {
+      BotPersonality.adaptive => 5,
+      BotPersonality.aggressive => 6,
+      BotPersonality.bookBuilder => 7,
+      BotPersonality.conservative => 8,
+    };
+    return (baseLimit - pressureReduction).clamp(minLimit, baseLimit);
+  }
+
+  /// True when any opponent has picked up foot — bots should race to transition.
+  bool _opponentOnFootPressure(BotGameContext context, Player bot) {
+    return context.players.any((p) => p.id != bot.id && p.hasPickedUpFoot);
   }
 
   /// Enhanced book completion strategy for competitive play
@@ -2935,11 +2977,15 @@ class EnhancedBotAI {
               meldIndex < bot.melds.length;
         case 'discard':
           return decision.data is PlayingCard &&
-              bot.currentHand.contains(decision.data);
+              bot.hasHandCard(decision.data as PlayingCard);
         case 'drawFromDeck':
         case 'drawFromDiscard':
+        case 'unlockDiscardPile':
         case 'noMeld':
+        case 'endTurn':
           return true; // These are always safe
+        case 'error':
+          return false; // Routed to recovery in turn manager
         default:
           return false;
       }

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -653,9 +653,9 @@ class EnhancedBotAI {
         return _executeDumpStrategy(bot, context);
       }
 
-      final rushCardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
+      final rushCardsToAdd = _filterWildCardAdditions(
+        _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
         bot,
-        controller,
       );
       if (rushCardsToAdd.isNotEmpty) {
         return BotDecision(action: 'addToMeld', data: rushCardsToAdd.first);
@@ -2985,13 +2985,18 @@ class EnhancedBotAI {
         case 'endTurn':
           return true; // These are always safe
         case 'error':
-          return false; // Routed to recovery in turn manager
+          return _isRecoverableErrorState(bot);
         default:
           return false;
       }
     } catch (e) {
       return false;
     }
+  }
+
+  /// Empty-hand states should propagate `error` only when going out is impossible.
+  bool _isRecoverableErrorState(Player bot) {
+    return bot.currentHand.isEmpty && !bot.canGoOut;
   }
 
   /// Get safe fallback decision when normal logic fails
@@ -3004,6 +3009,12 @@ class EnhancedBotAI {
       case TurnPhase.draw:
         return BotDecision(action: 'drawFromDeck');
       case TurnPhase.meld:
+        if (bot.currentHand.isEmpty) {
+          if (context.canPlayerGoOut()) {
+            return BotDecision(action: 'goOut');
+          }
+          return BotDecision(action: 'error');
+        }
         // Try simple meld if possible, otherwise skip
         final possibleMelds = context.controller?.findPossibleMelds(bot) ?? [];
         if (possibleMelds.isNotEmpty && bot.hasPlayedDown) {
@@ -3016,11 +3027,11 @@ class EnhancedBotAI {
       case TurnPhase.discard:
         // Check if bot has any cards at all
         if (bot.currentHand.isEmpty) {
-          // Bot has no cards - this should trigger going out or error
+          // Bot has no cards - this should trigger going out or error recovery
           if (context.canPlayerGoOut()) {
             return BotDecision(action: 'goOut');
           }
-          return BotDecision(action: 'noMeld'); // Can't discard with no cards
+          return BotDecision(action: 'error');
         }
 
         // Find any valid discard

--- a/lib/models/player.dart
+++ b/lib/models/player.dart
@@ -99,10 +99,33 @@ class Player {
     return newlyDrawnCardIndices.contains(index);
   }
 
+  /// Resolves a card to the actual instance in [currentHand].
+  /// Prefers identical reference; falls back to rank+suit for multi-deck duplicates.
+  PlayingCard? findHandCardInstance(PlayingCard card) {
+    for (final handCard in currentHand) {
+      if (identical(handCard, card)) {
+        return handCard;
+      }
+    }
+    for (final handCard in currentHand) {
+      if (handCard.rank == card.rank && handCard.suit == card.suit) {
+        return handCard;
+      }
+    }
+    return null;
+  }
+
+  bool hasHandCard(PlayingCard card) => findHandCardInstance(card) != null;
+
   PlayingCard? removeCardFromHand(PlayingCard card) {
+    final instance = findHandCardInstance(card);
+    if (instance == null) {
+      return null;
+    }
+
     // Find the exact index of this card instance
     for (int i = 0; i < currentHand.length; i++) {
-      if (identical(currentHand[i], card)) {
+      if (identical(currentHand[i], instance)) {
         final removedCard = currentHand.removeAt(i);
         _updateIndicesAfterRemoval([i]);
         return removedCard;

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -317,6 +317,19 @@ class BotTurnManager {
           }
           break;
 
+        case 'unlockDiscardPile':
+          success = gameController.unlockDiscardPile();
+          if (!success && gameState.canUnlockDiscard()) {
+            success = gameController.drawFromDiscardPile();
+          }
+          if (!success) {
+            DebugLogger.debug(
+              'Bot unlockDiscardPile failed - falling back to deck draw',
+            );
+            success = gameController.drawFromDeck();
+          }
+          break;
+
         case 'createMeld':
           final cards = decision.data as List<PlayingCard>;
           success = gameController.createMeld(cards);
@@ -337,9 +350,12 @@ class BotTurnManager {
           final data = decision.data as Map<String, dynamic>;
           final meldIndex = data['meldIndex'] as int;
           final card = data['card'] as PlayingCard;
+          final handCard = botPlayer.findHandCardInstance(card);
           // Validate meld index
-          if (meldIndex >= 0 && meldIndex < botPlayer.melds.length) {
-            success = gameController.addCardToMeld(meldIndex, card);
+          if (meldIndex >= 0 &&
+              meldIndex < botPlayer.melds.length &&
+              handCard != null) {
+            success = gameController.addCardToMeld(meldIndex, handCard);
             if (success) {
               validateGameStateAfterMeld(botPlayer);
             }
@@ -348,9 +364,12 @@ class BotTurnManager {
 
         case 'discard':
           final card = decision.data as PlayingCard;
-          success = gameController.discardCard(card);
-          if (success) {
-            handlePostDiscardState(botPlayer);
+          final handCard = botPlayer.findHandCardInstance(card);
+          if (handCard != null) {
+            success = gameController.discardCard(handCard);
+            if (success) {
+              handlePostDiscardState(botPlayer);
+            }
           }
           break;
 
@@ -375,6 +394,13 @@ class BotTurnManager {
           if (botPlayer.canGoOut) {
             gameState.endRound();
             success = true;
+          } else if (botPlayer.canGoOutWithBooks &&
+              botPlayer.currentHand.length == 1) {
+            final lastCard = botPlayer.currentHand.first;
+            success = gameController.discardCard(lastCard);
+            if (success) {
+              handlePostDiscardState(botPlayer);
+            }
           } else {
             DebugLogger.warning(
               'Bot tried to go out but cannot - missing book requirements',
@@ -384,8 +410,11 @@ class BotTurnManager {
           break;
 
         case 'error':
-          DebugLogger.warning('Bot reported error state');
-          return false;
+          DebugLogger.warning(
+            'Bot reported error state - attempting turn recovery',
+          );
+          _recoverFromBotError(botPlayer);
+          return true;
 
         default:
           DebugLogger.error('Unknown bot decision: ${decision.action}');
@@ -478,6 +507,82 @@ class BotTurnManager {
     }
   }
 
+  /// Attempt a meld during forced turn completion to shrink hand toward foot.
+  bool tryForceMeld(Player botPlayer) {
+    if (!botPlayer.hasPlayedDown) {
+      return false;
+    }
+
+    for (int i = 0; i < botPlayer.melds.length; i++) {
+      for (final card in [...botPlayer.currentHand]) {
+        if (botPlayer.melds[i].canAddCard(card)) {
+          if (gameController.addCardToMeld(i, card)) {
+            validateGameStateAfterMeld(botPlayer);
+            return true;
+          }
+        }
+      }
+    }
+
+    final possibleMelds = gameController.findPossibleMelds(botPlayer)
+      ..sort((a, b) => b.length.compareTo(a.length));
+    for (final meld in possibleMelds) {
+      if (gameController.createMeld(meld)) {
+        validateGameStateAfterMeld(botPlayer);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Recover from bot error decisions without counting as failed attempts.
+  void _recoverFromBotError(Player botPlayer) {
+    final gameState = gameController.gameState;
+
+    if (gameState.phase == GamePhase.roundEnd) {
+      return;
+    }
+
+    if (botPlayer.currentHand.isEmpty) {
+      if (!botPlayer.hasPickedUpFoot && botPlayer.foot.isNotEmpty) {
+        botPlayer.pickUpFoot();
+        gameState.recentActions.add(
+          GameAction(
+            message: 'picked up foot after error recovery',
+            playerName: botPlayer.name,
+          ),
+        );
+      }
+      if (botPlayer.canGoOut) {
+        gameState.endRound();
+        onStateChanged();
+        return;
+      }
+    }
+
+    switch (gameState.turnPhase) {
+      case TurnPhase.draw:
+        if (!gameState.hasDrawnFromDeck) {
+          gameController.drawFromDeck();
+        }
+        if (gameState.turnPhase == TurnPhase.meld) {
+          tryForceMeld(botPlayer);
+        }
+        gameState.turnPhase = TurnPhase.discard;
+        absolutelyGuaranteedDiscard(botPlayer);
+        break;
+      case TurnPhase.meld:
+        tryForceMeld(botPlayer);
+        gameState.turnPhase = TurnPhase.discard;
+        absolutelyGuaranteedDiscard(botPlayer);
+        break;
+      case TurnPhase.discard:
+        absolutelyGuaranteedDiscard(botPlayer);
+        break;
+    }
+  }
+
   /// Force bot to complete their turn using fallback actions that follow game rules
   void forceCompleteBotTurn(Player botPlayer) {
     final gameState = gameController.gameState;
@@ -505,12 +610,17 @@ class BotTurnManager {
               return;
             }
           }
+          if (gameState.turnPhase == TurnPhase.meld) {
+            tryForceMeld(botPlayer);
+          }
           // Force to discard phase to complete turn
           gameState.turnPhase = TurnPhase.discard;
           guaranteedTurnCompletion(botPlayer);
           break;
 
         case TurnPhase.meld:
+          // Try melding before force-discarding to shrink hand toward foot
+          tryForceMeld(botPlayer);
           // Bot can skip melding - force to discard phase and GUARANTEE completion
           gameState.turnPhase = TurnPhase.discard;
           absolutelyGuaranteedDiscard(botPlayer);
@@ -566,15 +676,7 @@ class BotTurnManager {
         );
 
         // Check for foot pickup after discard
-        if (botPlayer.isHandEmpty && !botPlayer.hasPickedUpFoot) {
-          botPlayer.pickUpFoot();
-          gameState.recentActions.add(
-            GameAction(
-              message: 'picked up foot after forced discard',
-              playerName: botPlayer.name,
-            ),
-          );
-        }
+        handlePostDiscardState(botPlayer);
 
         // ADVANCE TURN - this is guaranteed to work
         final previousPlayer = botPlayer;
@@ -815,8 +917,7 @@ class BotTurnManager {
         return;
       }
 
-      // STEP 6: ABSOLUTE LAST RESORT - no cards available, can't create fake ones
-      // This indicates a severe game state corruption - log and advance turn
+      // STEP 6: ABSOLUTE LAST RESORT - no cards available
       DebugLogger.error(
         'ABSOLUTE LAST RESORT: No cards available, cannot force discard',
       );
@@ -824,9 +925,6 @@ class BotTurnManager {
         'Bot ${botPlayer.name} has no cards in hand or foot - advancing turn',
       );
 
-      // Add to discard pile without removing from hand (emergency fallback only)
-      final emergencyCard = PlayingCard(rank: CardRank.three, suit: Suit.clubs);
-      gameState.discardPile.add(emergencyCard);
       gameState.recentActions.add(
         GameAction(
           message: 'emergency state recovery - skipped discard',
@@ -834,7 +932,7 @@ class BotTurnManager {
         ),
       );
 
-      // Complete turn legally
+      // Complete turn without polluting discard pile with synthetic cards
       gameState.nextPlayer();
       gameController.publishTurnEndedEvent(botPlayer);
       onStateChanged();

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -202,11 +202,14 @@ class GameActionButtons extends StatelessWidget {
 
   bool get _hasSelectedCard => selectedCardIndices.length == 1;
 
+  /// Last-card discard can end the round when book requirements are met.
+  bool get _canFinishWithLastCard =>
+      humanPlayer.hasPickedUpFoot && humanPlayer.canGoOutWithBooks;
+
   String get _discardButtonText {
     if (_hasSelectedCard && humanPlayer.currentHand.length == 1) {
       if (humanPlayer.hasPickedUpFoot) {
-        // Check if player can actually go out
-        if (humanPlayer.canGoOut) {
+        if (_canFinishWithLastCard) {
           return 'Go Out';
         } else {
           // Show specific requirement that's missing
@@ -230,8 +233,7 @@ class GameActionButtons extends StatelessWidget {
   Color? get _discardButtonColor {
     if (_hasSelectedCard && humanPlayer.currentHand.length == 1) {
       if (humanPlayer.hasPickedUpFoot) {
-        // Color-code based on whether they can actually go out
-        return humanPlayer.canGoOut ? Colors.green : Colors.red;
+        return _canFinishWithLastCard ? Colors.green : Colors.red;
       } else {
         return Colors.blue; // Go to foot
       }

--- a/test/ai/bot_turn_completion_test.dart
+++ b/test/ai/bot_turn_completion_test.dart
@@ -135,8 +135,8 @@ void main() {
 
         final decision = botAI.makeDecision(botPlayer, gameController);
 
-        // Should return safe fallback decision (enhanced error handling)
-        expect(decision.action, equals('noMeld'));
+        // Propagate error so BotTurnManager can recover via _recoverFromBotError
+        expect(decision.action, equals('error'));
       });
 
       test('should never return invalid actions', () {

--- a/test/ai/bot_turn_manager_execution_test.dart
+++ b/test/ai/bot_turn_manager_execution_test.dart
@@ -131,4 +131,34 @@ void main() {
       expect(botPlayer.melds.first.cards.length, greaterThan(meldSizeBefore));
     });
   });
+
+  group('EnhancedBotAI error propagation', () {
+    late GameController gameController;
+    late Player botPlayer;
+    late EnhancedBotAI botAI;
+
+    setUp(() {
+      final players = [
+        Player(id: 'human', name: 'You', type: PlayerType.human),
+        Player(id: 'bot1', name: 'Clara', type: PlayerType.bot),
+      ];
+      gameController = GameController(players: players, seed: 1);
+      gameController.initializeGame();
+      botPlayer = players[1];
+      botAI = EnhancedBotAI(seed: 1);
+      botPlayer.hand.clear();
+      botPlayer.foot.clear();
+      botPlayer.hasPlayedDown = true;
+      botPlayer.hasPickedUpFoot = true;
+      gameController.gameState.currentPlayerIndex = 1;
+      gameController.gameState.turnPhase = TurnPhase.discard;
+      gameController.gameState.hasDrawnFromDeck = true;
+    });
+
+    test('preserves error decision for empty hand without books', () {
+      final decision = botAI.makeDecision(botPlayer, gameController);
+
+      expect(decision.action, equals('error'));
+    });
+  });
 }

--- a/test/ai/bot_turn_manager_execution_test.dart
+++ b/test/ai/bot_turn_manager_execution_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_decision.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/screens/managers/bot_turn_manager.dart';
+
+void main() {
+  group('BotTurnManager execution', () {
+    late GameController gameController;
+    late Player botPlayer;
+    late BotTurnManager turnManager;
+
+    setUp(() {
+      final players = [
+        Player(id: 'human', name: 'You', type: PlayerType.human),
+        Player(id: 'bot1', name: 'Clara', type: PlayerType.bot),
+      ];
+      gameController = GameController(players: players, seed: 454749);
+      gameController.initializeGame();
+      botPlayer = players[1];
+      botPlayer.hasPlayedDown = true;
+      gameController.gameState.currentPlayerIndex = 1;
+
+      turnManager = BotTurnManager(
+        gameController: gameController,
+        botAI: EnhancedBotAI(seed: 454749),
+        onStateChanged: () {},
+        logHumanAction: (_) {},
+        logBotDecision:
+            ({
+              required String botId,
+              required String decision,
+              required String reasoning,
+              Map<String, dynamic>? context,
+            }) {},
+      );
+    });
+
+    test('executes unlockDiscardPile without failing', () {
+      gameController.gameState.turnPhase = TurnPhase.draw;
+      gameController.gameState.discardPile.add(
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+      );
+      botPlayer.dealHand([
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.five),
+      ]);
+      botPlayer.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+      );
+
+      final success = turnManager.executeBotDecision(
+        BotDecision(action: 'unlockDiscardPile'),
+        botPlayer,
+      );
+
+      expect(success, isTrue);
+      expect(gameController.gameState.turnPhase, TurnPhase.meld);
+    });
+
+    test('discards using rank+suit match for duplicate deck cards', () {
+      final kingOne = const PlayingCard(suit: Suit.hearts, rank: CardRank.king);
+      final kingTwo = const PlayingCard(suit: Suit.hearts, rank: CardRank.king);
+      botPlayer.dealHand([kingOne, kingTwo]);
+      gameController.gameState.turnPhase = TurnPhase.discard;
+      gameController.gameState.hasDrawnFromDeck = true;
+
+      final duplicateReference = PlayingCard(
+        suit: Suit.hearts,
+        rank: CardRank.king,
+      );
+
+      final success = turnManager.executeBotDecision(
+        BotDecision(action: 'discard', data: duplicateReference),
+        botPlayer,
+      );
+
+      expect(success, isTrue);
+      expect(botPlayer.currentHand.length, 1);
+    });
+
+    test('error decision recovers by completing turn instead of failing', () {
+      botPlayer.dealHand([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.six),
+      ]);
+      gameController.gameState.turnPhase = TurnPhase.discard;
+      gameController.gameState.hasDrawnFromDeck = true;
+      final startingPlayerIndex = gameController.gameState.currentPlayerIndex;
+
+      final success = turnManager.executeBotDecision(
+        BotDecision(action: 'error'),
+        botPlayer,
+      );
+
+      expect(success, isTrue);
+      expect(
+        gameController.gameState.currentPlayerIndex,
+        isNot(startingPlayerIndex),
+      );
+    });
+
+    test('tryForceMeld adds to existing meld before force discard', () {
+      botPlayer.dealHand([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.four),
+      ]);
+      botPlayer.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.eight),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.eight),
+        ])!,
+      );
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+      final meldSizeBefore = botPlayer.melds.first.cards.length;
+
+      final melded = turnManager.tryForceMeld(botPlayer);
+
+      expect(melded, isTrue);
+      expect(botPlayer.melds.first.cards.length, greaterThan(meldSizeBefore));
+    });
+  });
+}

--- a/test/ai/empty_hand_edge_cases_test.dart
+++ b/test/ai/empty_hand_edge_cases_test.dart
@@ -76,8 +76,8 @@ void main() {
 
         final decision = botAI.makeDecision(botPlayer, controller);
 
-        // Should recognize it can go out (or return noMeld if bot logic is different)
-        expect(decision.action, isIn(['goOut', 'noMeld']));
+        // Should recognize it can go out with both books and empty hand
+        expect(decision.action, equals('goOut'));
       });
 
       test('should handle empty hand without required books safely', () {
@@ -91,8 +91,8 @@ void main() {
 
         final decision = botAI.makeDecision(botPlayer, controller);
 
-        // Should return error or safe fallback since it can't discard or go out
-        expect(decision.action, isIn(['error', 'noMeld']));
+        // Should return error recovery since it can't discard or go out
+        expect(decision.action, equals('error'));
       });
     });
 
@@ -318,15 +318,15 @@ void _setupBotWithBooks(Player player) {
     const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
   ];
 
-  // Add dirty book
+  // Add dirty book (4 naturals + 3 wilds)
   final dirtyBook = [
     const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
     const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
     const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
     const PlayingCard(suit: null, rank: CardRank.joker),
-    const PlayingCard(suit: null, rank: CardRank.joker),
-    const PlayingCard(suit: null, rank: CardRank.joker),
-    const PlayingCard(suit: null, rank: CardRank.joker),
+    const PlayingCard(suit: null, rank: CardRank.two),
+    const PlayingCard(suit: null, rank: CardRank.two),
   ];
 
   final cleanMeld = Meld.createMeld(cleanBook);

--- a/test/ai/opponent_foot_pressure_test.dart
+++ b/test/ai/opponent_foot_pressure_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Opponent foot pressure', () {
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player human;
+    late Player bot;
+
+    setUp(() {
+      botAI = EnhancedBotAI(seed: 42);
+      human = Player(id: 'human', name: 'You', type: PlayerType.human);
+      bot = Player(id: 'bot', name: 'Clara', type: PlayerType.bot);
+      gameController = GameController(players: [human, bot], seed: 42);
+      gameController.initializeGame();
+      botAI.assignPersonality(bot.id, BotPersonality.conservative);
+      bot.hasPlayedDown = true;
+      gameController.gameState.currentPlayerIndex = 1;
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+    });
+
+    test('melds aggressively when human is on foot instead of holding', () {
+      human.hasPickedUpFoot = true;
+      human.dealFoot([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+      ]);
+
+      bot.dealHand([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.four),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.six),
+      ]);
+      bot.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+      );
+
+      final decision = botAI.makeDecision(bot, gameController);
+
+      expect(decision.action, isNot('noMeld'));
+      expect(
+        decision.action,
+        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+      );
+    });
+  });
+}

--- a/test/ai/opponent_foot_pressure_test.dart
+++ b/test/ai/opponent_foot_pressure_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_config.dart';
 import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
 import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
 import 'package:hand_foot_game_flutter/game/game_controller.dart';
@@ -29,10 +30,25 @@ void main() {
 
     test('melds aggressively when human is on foot instead of holding', () {
       human.hasPickedUpFoot = true;
+      // >5 foot cards avoids _isCompetitivelyThreatened "close to going out".
       human.dealFoot([
         const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
         const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
       ]);
+      // Match meld count so meld-gap competitive threat does not trigger.
+      human.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.ten),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.ten),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.ten),
+        ])!,
+      );
 
       bot.dealHand([
         const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
@@ -49,6 +65,13 @@ void main() {
           const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
         ])!,
       );
+
+      final handSizeGap = bot.currentHand.length - human.currentHand.length;
+      final meldGap = human.melds.length - bot.melds.length;
+      expect(human.hasPickedUpFoot, isTrue);
+      expect(human.currentHand.length, greaterThan(5));
+      expect(handSizeGap, lessThan(BotConfig.competitiveThreatHandSizeGap));
+      expect(meldGap, lessThan(3));
 
       final decision = botAI.makeDecision(bot, gameController);
 

--- a/test/models/player_test.dart
+++ b/test/models/player_test.dart
@@ -107,6 +107,29 @@ void main() {
       expect(notRemoved, isNull);
     });
 
+    test('should resolve duplicate rank+suit cards when removing', () {
+      final kingInHand = const PlayingCard(
+        suit: Suit.hearts,
+        rank: CardRank.king,
+      );
+      final kingDuplicate = const PlayingCard(
+        suit: Suit.hearts,
+        rank: CardRank.king,
+      );
+      player.dealHand([kingInHand, kingDuplicate]);
+
+      final removed = player.removeCardFromHand(
+        PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+      );
+
+      expect(removed, isNotNull);
+      expect(player.currentHand.length, 1);
+      expect(
+        player.hasHandCard(kingInHand) || player.hasHandCard(kingDuplicate),
+        isTrue,
+      );
+    });
+
     test('should remove cards by indices correctly', () {
       final cards = [
         const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR review follow-up (nitpick)

### Fixed — `_opponentOnFootPressure` deduplication

**Still valid.** The meld decision path at ~647–682 duplicated the same `context.players.any(...)` predicate already centralized in `_opponentOnFootPressure`.

- Rush branch now calls `_opponentOnFootPressure(context, bot)` instead of an inline local
- Removed redundant `!opponentOnFoot` guard in the strategic hold branch — `_shouldHoldCardsStrategically` already returns `false` when opponent foot pressure applies and the bot is still on hand

### Validation

- `dart format .` — clean
- `flutter analyze` — zero issues
- `flutter test` — **765 passed**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e3b3390-2d89-417f-b27e-9a5c4bbb76e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e3b3390-2d89-417f-b27e-9a5c4bbb76e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot now adds a “play-down first” path when it can’t take valuable discards yet but can unlock them later.
  * Bot becomes more aggressive under opponent foot pressure to support faster meld “races.”
  * “Go Out” UI now reflects finishing with exactly one last card based on foot/Books status.

* **Bug Fixes**
  * Improved duplicate card resolution for bot meld/discard and hand removal.
  * Enhanced bot recovery/forced completion with safer unlock/draw fallbacks and improved error handling in empty-hand states.

* **Tests**
  * Expanded coverage for bot execution, forced meld behavior, opponent foot pressure, and empty-hand edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->