### PR TITLE
Firebase agent credentials workflow and analytics query tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Copy to .env and fill from Firebase console or MCP firebase_get_sdk_config (web).
+# DO NOT commit real values — .env is gitignored.
+
+FIREBASE_PROJECT_ID=hand-foot-game-flutter
+FIREBASE_PROJECT_NUMBER=
+FIREBASE_AUTH_EMAIL=
+
+FIREBASE_WEB_API_KEY=
+FIREBASE_WEB_APP_ID=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_WEB_MEASUREMENT_ID=
+
+FIREBASE_ANDROID_API_KEY=
+FIREBASE_ANDROID_APP_ID=
+FIREBASE_IOS_API_KEY=
+FIREBASE_IOS_APP_ID=
+FIREBASE_IOS_BUNDLE_ID=com.example.handFootGameFlutter
+FIREBASE_MACOS_API_KEY=
+FIREBASE_MACOS_APP_ID=
+FIREBASE_MACOS_BUNDLE_ID=com.example.handFootGameFlutter
+
+# OAuth CLI credentials (from Firebase MCP login + refresh script)
+FIREBASE_CREDENTIALS_FILE=.firebase/firebase-tools-credentials.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,11 @@ This is a Flutter (Dart) app — the **Hand & Foot** card game with AI bots and 
 - Run on web: `flutter run -d web-server --web-hostname 0.0.0.0 --web-port 8080` (serves at `http://localhost:8080`). Use a browser to reach it; the `web-server` device has no auto-launched Chrome. The first web build takes ~30–60s to compile before the URL is served.
 - Solo play (`PLAY SOLO`) is fully offline and needs no backend. `main.dart` catches Firebase init failures and continues, so the app runs without Firebase credentials.
 
-### Multiplayer / Firebase (optional, not set up here)
-- The repo ships a **stub** `lib/firebase_options.dart`. Online multiplayer (`CREATE GAME`/`JOIN GAME`) requires real Firebase/Firestore credentials injected via `scripts/setup_local_firebase.sh` + a `.env`. Without them, only solo vs. bots works — which is sufficient to exercise core gameplay.
+### Multiplayer / Firebase (optional)
+- The repo ships a **stub** `lib/firebase_options.dart`. Online multiplayer (`CREATE GAME`/`JOIN GAME`) requires real Firebase/Firestore credentials injected via `scripts/setup_local_firebase.sh` + a local `.env` (gitignored).
+- **Firebase MCP + agent credentials:** See `docs/firebase_agent_setup.md`. When configured, this workspace may contain gitignored `.env` and `.firebase/firebase-tools-credentials.json` (OAuth for admin Firestore reads). Use Firebase MCP `firebase_login` if tokens expire, then `./scripts/refresh_firebase_agent_credentials.sh`.
+- **Analytics queries:** `node scripts/query_analytics_session.js --scores 3325,1140,1185 --foot-only` (analytics collections are client write-only; OAuth required to read).
+- Without Firebase credentials, solo vs. bots still works — sufficient for core gameplay.
 
 ### Testing
 - `flutter test` runs the full unit/widget suite (~750 tests) and passes headlessly with no extra setup. Tests skip Firebase automatically under `FLUTTER_TEST`.

--- a/docs/firebase_agent_setup.md
+++ b/docs/firebase_agent_setup.md
@@ -11,7 +11,7 @@ This repo is **public**. Firebase secrets live only in **gitignored** local file
 | `.firebase/agent-config.json` | Non-secret metadata + script pointers |
 
 **Project:** `hand-foot-game-flutter`  
-**Account:** `ben@spurlock.app`
+**Account:** project owner Google account (see `firebase_get_environment` after MCP login)
 
 ## Firebase MCP (preferred in Cursor)
 

--- a/docs/firebase_agent_setup.md
+++ b/docs/firebase_agent_setup.md
@@ -1,0 +1,61 @@
+# Firebase access for agents (Cloud / local)
+
+This repo is **public**. Firebase secrets live only in **gitignored** local files. Never commit `.env`, `.firebase/firebase-tools-credentials.json`, or real `lib/firebase_options.dart`.
+
+## Quick start (already configured in this workspace)
+
+| File | Purpose |
+|------|---------|
+| `.env` | Flutter/web Firebase config + project IDs |
+| `.firebase/firebase-tools-credentials.json` | OAuth tokens for CLI/admin Firestore reads |
+| `.firebase/agent-config.json` | Non-secret metadata + script pointers |
+
+**Project:** `hand-foot-game-flutter`  
+**Account:** `ben@spurlock.app`
+
+## Firebase MCP (preferred in Cursor)
+
+1. `firebase_login` — complete browser auth if tokens expired
+2. `firebase_update_environment` with `active_project: hand-foot-game-flutter`, `project_dir: /workspace`
+3. `firebase_get_environment` — verify authenticated user + project
+
+Then refresh workspace copy:
+
+```bash
+./scripts/refresh_firebase_agent_credentials.sh
+```
+
+## Flutter / Dart scripts
+
+Apply real Firebase config to the stub `lib/firebase_options.dart`:
+
+```bash
+./scripts/setup_local_firebase.sh   # reads .env
+dart run scripts/export_analytics.dart --days 7 --include-raw
+```
+
+## Firestore analytics (important)
+
+Analytics collections (`game_sessions`, `bot_decisions`, `game_events`, `performance_metrics`) are **write-only** from the client SDK. Agents must read via:
+
+- OAuth credentials in `.firebase/firebase-tools-credentials.json`, or
+- Firebase MCP after login, or
+- `scripts/query_analytics_session.js` (Node, uses stored OAuth)
+
+```bash
+node scripts/query_analytics_session.js --scores 3325,1140,1185
+node scripts/query_analytics_session.js --session <sessionId> --foot-only
+```
+
+## Token expiry
+
+Access tokens last ~1 hour. The `refresh_token` in the credentials file is long-lived. If queries fail with 401:
+
+1. Re-run Firebase MCP `firebase_login` (paste new auth code)
+2. `./scripts/refresh_firebase_agent_credentials.sh`
+
+## Security checklist
+
+- [ ] `.env` and `.firebase/*credentials*` are gitignored
+- [ ] Do not paste tokens into PRs, issues, or commits
+- [ ] Restore stub config before committing Flutter changes: `git checkout lib/firebase_options.dart`

--- a/lib/ai/bot_config.dart
+++ b/lib/ai/bot_config.dart
@@ -62,6 +62,12 @@ class BotConfig {
   /// In foot phase, become urgent about discards at this threshold
   static const int footPhaseUrgencyThreshold = 5;
 
+  /// In foot phase, force melding (all personalities) at this hand size
+  static const int footPhaseAggressiveMeldingThreshold = 8;
+
+  /// Opponent book count that triggers foot-phase panic melding
+  static const int footPhaseOpponentBookPanicThreshold = 4;
+
   // ===== WILD CARD MANAGEMENT =====
 
   /// Threshold to consider discarding wild cards

--- a/lib/ai/bot_end_game_manager.dart
+++ b/lib/ai/bot_end_game_manager.dart
@@ -261,20 +261,25 @@ class BotEndGameManager {
       return _handleBookCompletion(bot, controller);
     }
 
-    // Can't complete books easily - hold cards and wait
-    if (bot.currentHand.length <= 3) {
+    // Can't complete books easily - try melding in meld phase, discard later
+    if (gameState.turnPhase == TurnPhase.meld) {
       final cardsToAdd = _findCardsToAddToExistingMelds(bot, controller);
       if (cardsToAdd.isNotEmpty) {
         return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
       }
+
+      final possibleMelds = controller.findPossibleMelds(bot);
+      if (possibleMelds.isNotEmpty) {
+        return BotDecision(
+          action: 'createMeld',
+          data: _findBestBookPotentialMeld(possibleMelds),
+        );
+      }
+
+      return BotDecision(action: 'noMeld');
     }
 
-    // Emergency case - hand empty but can't go out
-    if (bot.currentHand.isEmpty && !bot.canGoOut) {
-      return BotDecision(action: 'error');
-    }
-
-    // Default: discard conservatively
+    // Default: discard conservatively in discard phase
     final cardToDiscard = _chooseCardToDiscard(bot);
     return BotDecision(action: 'discard', data: cardToDiscard);
   }

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -630,13 +630,6 @@ class EnhancedBotAI {
         return _executeDumpStrategy(bot, context);
       }
 
-      if (bot.hasPickedUpFoot) {
-        final footRush = _handleFootPhaseMeldDecision(bot, context);
-        if (footRush != null) {
-          return footRush;
-        }
-      }
-
       final rushCardsToAdd = _filterWildCardAdditions(
         _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
         bot,
@@ -1742,13 +1735,6 @@ class EnhancedBotAI {
     if (bot.hasPickedUpFoot &&
         handSize >= BotConfig.footPhaseAggressiveMeldingThreshold) {
       return false;
-    }
-
-    // ADAPTIVE PERSONALITY FIX: Be much more aggressive in foot phase
-    if (personality == BotPersonality.adaptive &&
-        bot.hasPickedUpFoot &&
-        handSize >= 8) {
-      return false; // Never hold 8+ cards in foot phase for adaptive bots
     }
 
     // Don't hold if opponents are close to going out (competitive pressure)

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -507,6 +507,12 @@ class EnhancedBotAI {
       return BotDecision(action: 'noMeld');
     }
 
+    // PRIORITY 0b: Foot phase — melt large hands and complete book pairs (all personalities)
+    final footPhaseDecision = _handleFootPhaseMeldDecision(bot, context);
+    if (footPhaseDecision != null) {
+      return footPhaseDecision;
+    }
+
     // EMERGENCY PROTOCOLS: Check for catastrophic hand size failures FIRST
     // BUT: Give bots grace period early in round when large hands are normal
     // AND: Require minimum turns before emergency can activate
@@ -573,33 +579,7 @@ class EnhancedBotAI {
     }
 
     // ADAPTIVE PERSONALITY FIX: Force aggressive melding in foot phase with large hands
-    final personality = _personalityManager.getPersonality(bot.id);
-    if (personality == BotPersonality.adaptive &&
-        bot.hasPickedUpFoot &&
-        handSize >= 10) {
-      // Adaptive bots should never hold 10+ cards in foot phase
-      final possibleMelds = _getCachedPossibleMelds(bot, context);
-      if (possibleMelds.isNotEmpty) {
-        DebugLogger.botDebug(
-          bot.id,
-          bot.name,
-          'ADAPTIVE FIX: Force melding in foot phase with $handSize cards',
-        );
-        return BotDecision(
-          action: 'createMeld',
-          data: _selectBestNewMeld(bot, possibleMelds),
-        );
-      }
-
-      final cardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
-        bot,
-        (context.controller as GameController?) ??
-            (throw StateError('Controller required for meld analysis')),
-      );
-      if (cardsToAdd.isNotEmpty) {
-        return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
-      }
-    }
+    // (covered for all personalities by _handleFootPhaseMeldDecision above)
 
     // Check for end game decisions (after emergency protocols)
     final controller = context.controller as GameController?;
@@ -645,9 +625,16 @@ class EnhancedBotAI {
 
     // AGGRESSIVE FIX: Dramatically reduce strategic holding to prevent accumulation
     // Opponents on foot are racing to go out — stop hoarding and melt hand down
-    if (_opponentOnFootPressure(context, bot) && !bot.hasPickedUpFoot) {
-      if (_shouldExecuteDumpStrategy(bot, context)) {
+    if (_opponentOnFootPressure(context, bot)) {
+      if (!bot.hasPickedUpFoot && _shouldExecuteDumpStrategy(bot, context)) {
         return _executeDumpStrategy(bot, context);
+      }
+
+      if (bot.hasPickedUpFoot) {
+        final footRush = _handleFootPhaseMeldDecision(bot, context);
+        if (footRush != null) {
+          return footRush;
+        }
       }
 
       final rushCardsToAdd = _filterWildCardAdditions(
@@ -1751,6 +1738,12 @@ class EnhancedBotAI {
       return false;
     }
 
+    // Never hold large hands on foot — must melt down to go out (all personalities)
+    if (bot.hasPickedUpFoot &&
+        handSize >= BotConfig.footPhaseAggressiveMeldingThreshold) {
+      return false;
+    }
+
     // ADAPTIVE PERSONALITY FIX: Be much more aggressive in foot phase
     if (personality == BotPersonality.adaptive &&
         bot.hasPickedUpFoot &&
@@ -2232,7 +2225,9 @@ class EnhancedBotAI {
       criticalSituation = true;
     }
     // 3. End game - need to complete books to go out
-    else if (bot.hasPickedUpFoot && bot.currentHand.length <= 6) {
+    else if (bot.hasPickedUpFoot &&
+        bot.currentHand.length <=
+            BotConfig.footPhaseAggressiveMeldingThreshold + 2) {
       final hasCleanBook = bot.hasCleanBook;
       final hasDirtyBook = bot.hasDirtyBook;
 
@@ -2724,6 +2719,157 @@ class EnhancedBotAI {
     }
 
     return null;
+  }
+
+  /// Foot-phase melding for all personalities: melt large hands and complete book pairs.
+  BotDecision? _handleFootPhaseMeldDecision(
+    Player bot,
+    BotGameContext context,
+  ) {
+    if (!bot.hasPickedUpFoot) {
+      return null;
+    }
+
+    final handSize = bot.currentHand.length;
+    final controller = context.controller as GameController?;
+    if (controller == null) {
+      return null;
+    }
+
+    // Always try to complete the missing clean/dirty book type first
+    final bookRush = _rushToCompleteRequiredBooks(bot, context);
+    if (bookRush != null) {
+      return bookRush;
+    }
+
+    // Opponent close to going out — stop hoarding and melt the foot hand
+    if (_opponentThreateningGoOut(context.gameState, bot)) {
+      final forced = _forceFootPhaseMeld(
+        bot,
+        context,
+        prioritizeMissingBookType: true,
+      );
+      if (forced != null) {
+        return forced;
+      }
+    }
+
+    // Large foot hand: every personality must meld (not just adaptive at 10+)
+    if (handSize >= BotConfig.footPhaseAggressiveMeldingThreshold) {
+      return _forceFootPhaseMeld(bot, context, prioritizeMissingBookType: true);
+    }
+
+    return null;
+  }
+
+  /// Force a meld/add in foot when hand is large or books are incomplete.
+  BotDecision? _forceFootPhaseMeld(
+    Player bot,
+    BotGameContext context, {
+    bool prioritizeMissingBookType = false,
+  }) {
+    final controller = context.controller as GameController?;
+    if (controller == null) {
+      return null;
+    }
+
+    final needsClean = !bot.hasCleanBook;
+    final needsDirty = !bot.hasDirtyBook;
+
+    // Have dirty books but need clean — build a naturals-only lane, not more dirty piles
+    if (prioritizeMissingBookType && needsClean && bot.hasDirtyBook) {
+      final cleanMelds = _getCachedPossibleMelds(
+        bot,
+        context,
+      ).where((meld) => !meld.any((card) => card.isWild)).toList();
+      if (cleanMelds.isNotEmpty) {
+        DebugLogger.botDebug(
+          bot.id,
+          bot.name,
+          'FOOT: creating clean meld — have dirty books but need clean book',
+        );
+        return BotDecision(
+          action: 'createMeld',
+          data: _selectBestNewMeld(bot, cleanMelds),
+        );
+      }
+
+      final naturalAdditions =
+          _filterWildCardAdditions(
+            _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
+            bot,
+          ).where((addition) {
+            final meldIndex = addition['meldIndex'] as int;
+            final meld = bot.melds[meldIndex];
+            return meld.cards.length < GameConfig.bookSize &&
+                !meld.cards.any((card) => card.isWild);
+          }).toList();
+      if (naturalAdditions.isNotEmpty) {
+        return BotDecision(action: 'addToMeld', data: naturalAdditions.first);
+      }
+    }
+
+    // Need dirty book but have clean — allow wild-heavy melds
+    if (prioritizeMissingBookType && needsDirty && bot.hasCleanBook) {
+      final dirtyMelds = _getCachedPossibleMelds(
+        bot,
+        context,
+      ).where((meld) => meld.any((card) => card.isWild)).toList();
+      if (dirtyMelds.isNotEmpty) {
+        return BotDecision(
+          action: 'createMeld',
+          data: _selectBestNewMeld(bot, dirtyMelds),
+        );
+      }
+    }
+
+    final cardsToAdd = _filterWildCardAdditions(
+      _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
+      bot,
+    );
+    if (cardsToAdd.isNotEmpty) {
+      return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+    }
+
+    final possibleMelds = _getCachedPossibleMelds(bot, context);
+    if (possibleMelds.isNotEmpty) {
+      return BotDecision(
+        action: 'createMeld',
+        data: _selectBestNewMeld(bot, possibleMelds),
+      );
+    }
+
+    return null;
+  }
+
+  /// True when an opponent is close to ending the round (human going out).
+  bool _opponentThreateningGoOut(GameState gameState, Player bot) {
+    for (final opponent in gameState.players) {
+      if (opponent.id == bot.id) {
+        continue;
+      }
+
+      final opponentBooks = opponent.melds
+          .where((m) => m.cards.length >= GameConfig.bookSize)
+          .length;
+
+      if (opponent.canGoOutWithBooks && opponent.currentHand.length <= 10) {
+        return true;
+      }
+
+      if (opponentBooks >= BotConfig.footPhaseOpponentBookPanicThreshold &&
+          opponent.currentHand.length <= 10) {
+        return true;
+      }
+
+      if (opponent.hasPickedUpFoot &&
+          opponentBooks >= 2 &&
+          opponent.currentHand.length <= 8) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   // Getters for testing and debugging

--- a/scripts/query_analytics_session.js
+++ b/scripts/query_analytics_session.js
@@ -81,7 +81,9 @@ async function refreshAccessToken(creds) {
 
   creds.tokens.access_token = result.access_token;
   creds.tokens.expires_at = Date.now() + result.expires_in * 1000;
-  fs.writeFileSync(CREDS_PATH, JSON.stringify(creds, null, '\t'));
+  fs.writeFileSync(CREDS_PATH, JSON.stringify(creds, null, '\t'), {
+    mode: 0o600,
+  });
   return result.access_token;
 }
 

--- a/scripts/query_analytics_session.js
+++ b/scripts/query_analytics_session.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Query Firestore analytics using OAuth credentials from .firebase/firebase-tools-credentials.json
+ * Analytics collections are write-only from client SDK; this uses admin REST API with user OAuth.
+ */
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CREDS_PATH =
+  process.env.FIREBASE_CREDENTIALS_FILE ||
+  path.join(REPO_ROOT, '.firebase/firebase-tools-credentials.json');
+const PROJECT_ID =
+  process.env.FIREBASE_PROJECT_ID || 'hand-foot-game-flutter';
+
+function parseArgs(argv) {
+  const args = { scores: null, session: null, footOnly: false, limit: 5 };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--scores' && argv[i + 1]) {
+      args.scores = argv[++i].split(',').map((s) => parseInt(s.trim(), 10));
+    } else if (argv[i] === '--session' && argv[i + 1]) {
+      args.session = argv[++i];
+    } else if (argv[i] === '--foot-only') {
+      args.footOnly = true;
+    } else if (argv[i] === '--limit' && argv[i + 1]) {
+      args.limit = parseInt(argv[++i], 10);
+    }
+  }
+  return args;
+}
+
+function loadCreds() {
+  const raw = fs.readFileSync(CREDS_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function httpsRequest(options, body) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve(JSON.parse(data || '{}'));
+        } else {
+          reject(new Error(`HTTP ${res.statusCode}: ${data}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+async function refreshAccessToken(creds) {
+  const refreshToken = creds.tokens?.refresh_token;
+  if (!refreshToken) throw new Error('No refresh_token in credentials file');
+
+  const body = new URLSearchParams({
+    client_id:
+      '563584335869-fgrhgmd47bqnekij5i8b5pr03ho849e6.apps.googleusercontent.com',
+    client_secret: 'j9iVZfS8kkCEFUPaAeJV0sAi',
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  }).toString();
+
+  const result = await httpsRequest(
+    {
+      hostname: 'oauth2.googleapis.com',
+      path: '/token',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    },
+    body,
+  );
+
+  creds.tokens.access_token = result.access_token;
+  creds.tokens.expires_at = Date.now() + result.expires_in * 1000;
+  fs.writeFileSync(CREDS_PATH, JSON.stringify(creds, null, '\t'));
+  return result.access_token;
+}
+
+async function getAccessToken(creds) {
+  const expiresAt = creds.tokens?.expires_at || 0;
+  if (creds.tokens?.access_token && Date.now() < expiresAt - 60000) {
+    return creds.tokens.access_token;
+  }
+  return refreshAccessToken(creds);
+}
+
+function firestoreValueToJs(v) {
+  if (v == null) return null;
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.integerValue !== undefined) return parseInt(v.integerValue, 10);
+  if (v.doubleValue !== undefined) return parseFloat(v.doubleValue);
+  if (v.booleanValue !== undefined) return v.booleanValue;
+  if (v.timestampValue !== undefined) return v.timestampValue;
+  if (v.arrayValue) {
+    return (v.arrayValue.values || []).map(firestoreValueToJs);
+  }
+  if (v.mapValue) {
+    const out = {};
+    for (const [k, val] of Object.entries(v.mapValue.fields || {})) {
+      out[k] = firestoreValueToJs(val);
+    }
+    return out;
+  }
+  return v;
+}
+
+function docToObject(doc) {
+  const data = { _id: doc.name.split('/').pop() };
+  for (const [k, v] of Object.entries(doc.fields || {})) {
+    data[k] = firestoreValueToJs(v);
+  }
+  return data;
+}
+
+async function listCollection(accessToken, collection, pageSize = 300) {
+  const all = [];
+  let pageToken = null;
+  do {
+    const path =
+      `/v1/projects/${PROJECT_ID}/databases/(default)/documents/${collection}` +
+      `?pageSize=${pageSize}` +
+      (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : '');
+    const result = await httpsRequest({
+      hostname: 'firestore.googleapis.com',
+      path,
+      method: 'GET',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    all.push(...(result.documents || []).map(docToObject));
+    pageToken = result.nextPageToken;
+  } while (pageToken);
+  return all;
+}
+
+async function runStructuredQuery(accessToken, collection, field, op, value) {
+  const body = JSON.stringify({
+    structuredQuery: {
+      from: [{ collectionId: collection }],
+      where: {
+        fieldFilter: {
+          field: { fieldPath: field },
+          op,
+          value,
+        },
+      },
+      limit: 20,
+    },
+  });
+
+  const result = await httpsRequest(
+    {
+      hostname: 'firestore.googleapis.com',
+      path: `/v1/projects/${PROJECT_ID}/databases/(default)/documents:runQuery`,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    },
+    body,
+  );
+
+  return result
+    .filter((row) => row.document)
+    .map((row) => docToObject(row.document));
+}
+
+function scoresMatch(sessionScores, targetScores) {
+  if (!sessionScores || !targetScores) return false;
+  const a = [...sessionScores].sort((x, y) => y - x);
+  const b = [...targetScores].sort((x, y) => y - x);
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const creds = loadCreds();
+  const accessToken = await getAccessToken(creds);
+
+  let sessionId = args.session;
+
+  if (!sessionId) {
+    console.log('Fetching recent game_sessions...');
+    const sessions = await listCollection(accessToken, 'game_sessions', 200);
+    sessions.sort((a, b) => {
+      const ta = a.startTime || a.endTime || '';
+      const tb = b.startTime || b.endTime || '';
+      return tb.localeCompare(ta);
+    });
+
+    let match = null;
+    if (args.scores) {
+      match = sessions.find((s) => scoresMatch(s.finalScores, args.scores));
+    }
+    if (!match) {
+      match = sessions.find((s) => s.status === 'completed');
+    }
+    if (!match) {
+      console.error('No matching session found');
+      process.exit(1);
+    }
+    sessionId = match._id;
+    console.log('Session:', sessionId);
+    console.log(JSON.stringify(match, null, 2));
+  }
+
+  console.log('\nFetching bot_decisions for session...');
+  const allDecisions = await listCollection(accessToken, 'bot_decisions', 500);
+  let decisions = allDecisions.filter((d) => d.sessionId === sessionId);
+  if (args.footOnly) {
+    decisions = decisions.filter((d) => d.botHasPickedUpFoot === true);
+  }
+  decisions.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+
+  console.log(`Found ${decisions.length} bot decisions`);
+  for (const d of decisions.slice(-args.limit * 10)) {
+    console.log(
+      `- [R${d.round}] ${d.botId} (${d.botPersonality}): ${d.decision} | foot=${d.botHasPickedUpFoot} hand=${d.botHandSize} books=${d.botBookCount} | ${d.reasoning}`,
+    );
+  }
+
+  console.log('\nFetching game_events for session...');
+  const allEvents = await listCollection(accessToken, 'game_events', 500);
+  const events = allEvents
+    .filter((e) => e.sessionId === sessionId)
+    .sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+  console.log(`Found ${events.length} game events`);
+  for (const e of events.slice(-30)) {
+    console.log(`- ${e.eventType} | ${e.playerId} | ${JSON.stringify(e.eventData || {})}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('Query failed:', err.message);
+  process.exit(1);
+});

--- a/scripts/refresh_firebase_agent_credentials.sh
+++ b/scripts/refresh_firebase_agent_credentials.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Refresh Firebase OAuth credentials for agent/CLI use.
+# Copies the MCP/CLI credential store into the gitignored workspace copy.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="${FIREBASE_TOOLS_CONFIG:-$HOME/.config/configstore/firebase-tools.json}"
+DEST="$REPO_ROOT/.firebase/firebase-tools-credentials.json"
+
+if [[ ! -f "$SRC" ]]; then
+  echo "❌ No Firebase credentials found at: $SRC"
+  echo "   Log in via Firebase MCP (firebase_login) or run: firebase login"
+  exit 1
+fi
+
+mkdir -p "$REPO_ROOT/.firebase"
+cp "$SRC" "$DEST"
+chmod 600 "$DEST"
+
+echo "✅ Refreshed workspace Firebase credentials"
+echo "   Source: $SRC"
+echo "   Dest:   $DEST"
+echo "   Active project: hand-foot-game-flutter (set via MCP or firebase use)"

--- a/test/ai/bot_end_game_test.dart
+++ b/test/ai/bot_end_game_test.dart
@@ -227,9 +227,12 @@ void main() {
           botPlayer,
           gameController,
         );
-        // End game manager may decide to discard penalty cards even with many cards
+        // In meld phase without book completion path, may meld or pass
         if (decision != null) {
-          expect(decision.action, anyOf(['discard', 'createMeld']));
+          expect(
+            decision.action,
+            anyOf(['noMeld', 'discard', 'createMeld', 'addToMeld']),
+          );
         }
       });
     });

--- a/test/ai/bot_foot_phase_melding_test.dart
+++ b/test/ai/bot_foot_phase_melding_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_config.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Foot phase melding improvements', () {
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player human;
+    late Player bot;
+
+    setUp(() {
+      botAI = EnhancedBotAI(seed: 42);
+      human = Player(id: '1', name: 'You', type: PlayerType.human);
+      bot = Player(id: '2', name: 'Carl', type: PlayerType.bot);
+      gameController = GameController(players: [human, bot], seed: 42);
+      gameController.initializeGame();
+      botAI.assignPersonality(bot.id, BotPersonality.conservative);
+      bot.hasPlayedDown = true;
+      bot.hasPickedUpFoot = true;
+      gameController.gameState.currentPlayerIndex = 1;
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+    });
+
+    void dealBotFoot(List<PlayingCard> cards) {
+      bot.foot.clear();
+      bot.foot.addAll(cards);
+    }
+
+    test('conservative bot melds instead of holding with 10+ foot cards', () {
+      dealBotFoot([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.four),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.five),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.six),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.six),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+      ]);
+      bot.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+      );
+
+      expect(
+        bot.currentHand.length,
+        greaterThanOrEqualTo(BotConfig.footPhaseAggressiveMeldingThreshold),
+      );
+
+      final decision = botAI.makeDecision(bot, gameController);
+
+      expect(decision.action, isNot('noMeld'));
+      expect(
+        decision.action,
+        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+      );
+    });
+
+    test(
+      'bot on foot with dirty books creates clean meld when naturals available',
+      () {
+        // Alex-style: two dirty books, missing clean book
+        dealBotFoot([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.four),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.four),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.three),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.three),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.three),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.three),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.three),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+        ]);
+
+        final dirtySeven = Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.two),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+        ])!;
+        final dirtyNine = Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+        ])!;
+        bot.melds.addAll([dirtySeven, dirtyNine]);
+
+        expect(bot.hasDirtyBook, isTrue);
+        expect(bot.hasCleanBook, isFalse);
+
+        final decision = botAI.makeDecision(bot, gameController);
+
+        expect(decision.action, isNot('noMeld'));
+        if (decision.action == 'createMeld') {
+          final meld = decision.data as List<PlayingCard>;
+          expect(meld.any((c) => c.isWild), isFalse);
+        }
+      },
+    );
+
+    test('bot on foot melds aggressively when human threatens go-out', () {
+      human.hasPickedUpFoot = true;
+      human.foot.clear();
+      human.foot.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.joker),
+      ]);
+      human.melds.addAll([
+        Meld.createMeld(
+          List.generate(
+            7,
+            (i) => PlayingCard(suit: Suit.values[i % 4], rank: CardRank.four),
+          ),
+        )!,
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.five),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.five),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+        ])!,
+        Meld.createMeld(
+          List.generate(
+            7,
+            (i) => PlayingCard(suit: Suit.values[i % 4], rank: CardRank.king),
+          ),
+        )!,
+        Meld.createMeld(
+          List.generate(
+            7,
+            (i) => PlayingCard(suit: Suit.values[i % 4], rank: CardRank.seven),
+          ),
+        )!,
+      ]);
+
+      dealBotFoot([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.ten),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ten),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ten),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.eight),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
+      ]);
+      bot.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+      );
+
+      final decision = botAI.makeDecision(bot, gameController);
+
+      expect(decision.action, isNot('noMeld'));
+      expect(
+        decision.action,
+        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two related improvements from analyzing the latest solo game (session `session_17836311659865986`, round 1 scores 3325 / 1140 / 1185):

### 1. Firebase agent credentials workflow
- Gitignored `.env` + `.firebase/` OAuth setup for agents
- `scripts/query_analytics_session.js` for paginated Firestore analytics reads
- `docs/firebase_agent_setup.md` + AGENTS.md pointers

### 2. Bot foot-phase logic fixes (Alex & Carl)

**Firestore findings:**
- Alex (adaptive): reached foot with **10 cards** and **2 dirty books** but no clean book — couldn't go out
- Carl (conservative): **drew from deck** repeatedly in foot with 11–13 cards; ended with **1 book** and 4–6 cards
- Both personalities only had aggressive foot melding for adaptive at 10+ cards; conservative could still hold

**Code changes:**
- `_handleFootPhaseMeldDecision` — all personalities force meld at 8+ foot cards
- `_forceFootPhaseMeld` — when only dirty books exist, prioritize **clean naturals-only** melds
- `_opponentThreateningGoOut` — meld aggressively when human has 4+ books / near go-out
- Opponent-on-foot pressure now applies when bot is **already on foot**
- `handleEndGame` no longer returns `discard` during **meld phase** (was a bug)
- New tests in `test/ai/bot_foot_phase_melding_test.dart`

All 768 tests pass; `flutter analyze` clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3b7fd72-02dc-4604-a7da-8f59808fbbd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3b7fd72-02dc-4604-a7da-8f59808fbbd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Firebase agent setup guide and an updated multiplayer/Firebase section
  * Added a `.env.example` template for local configuration and OAuth credential guidance
* **New Features**
  * Added a script to refresh Firebase CLI OAuth credentials for local agent use
  * Added a CLI to query session analytics and bot decisions from Firestore
* **Improvements**
  * Upgraded bot foot-phase strategy, including forced melding and opponent threat handling
  * Refined end-game fallback behavior and introduced new melding thresholds
* **Tests**
  * Added foot-phase melding test coverage and broadened an end-game test assertion set
<!-- end of auto-generated comment: release notes by coderabbit.ai -->