### PR TITLE
Fix round not resetting after bot goes out

### DIFF
--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -2577,6 +2577,14 @@ class EnhancedBotAI {
     GameState gameState,
     Player human,
   ) {
+    // Must draw before melding — pressure tactics cannot skip the draw phase.
+    if (gameState.turnPhase == TurnPhase.draw) {
+      if (!gameState.hasDrawnFromDeck) {
+        return BotDecision(action: 'drawFromDeck');
+      }
+      return null;
+    }
+
     // Strategy: Play down immediately, rush to foot, go out ASAP to prevent human accumulation
 
     if (!bot.hasPlayedDown) {

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -2580,6 +2580,10 @@ class EnhancedBotAI {
     // Must draw before melding — pressure tactics cannot skip the draw phase.
     if (gameState.turnPhase == TurnPhase.draw) {
       if (!gameState.hasDrawnFromDeck) {
+        // Prefer discard pile when unlockable to speed up the game.
+        if (gameState.discardPile.length >= 4 && context.canUnlockDiscard()) {
+          return BotDecision(action: 'drawFromDiscard');
+        }
         return BotDecision(action: 'drawFromDeck');
       }
       return null;
@@ -2650,14 +2654,6 @@ class EnhancedBotAI {
       if (cleanBooks == 0 || dirtyBooks == 0) {
         // Rush to complete missing book type
         return _rushToCompleteRequiredBooks(bot, context);
-      }
-    }
-
-    // Take discard pile aggressively to speed up game
-    if (gameState.turnPhase == TurnPhase.draw &&
-        gameState.discardPile.length >= 4) {
-      if (context.canUnlockDiscard()) {
-        return BotDecision(action: 'drawFromDiscard');
       }
     }
 

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -292,45 +292,7 @@ class GameController implements GameInterface {
 
       // Check if player went out (round or game ended)
       if (_gameState.phase != phaseBefore) {
-        if (_gameState.phase == GamePhase.roundEnd) {
-          _eventBus.publish(
-            PlayerWentOutEvent(roundNumber: roundBefore, player: player),
-          );
-
-          // Calculate round scores
-          final roundScores = <Player, int>{};
-          for (final p in _gameState.players) {
-            roundScores[p] = p.score;
-          }
-          _eventBus.publish(
-            RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
-          );
-        } else if (_gameState.phase == GamePhase.gameEnd) {
-          _eventBus.publish(
-            PlayerWentOutEvent(roundNumber: roundBefore, player: player),
-          );
-
-          final roundScores = <Player, int>{};
-          for (final p in _gameState.players) {
-            roundScores[p] = p.score;
-          }
-          _eventBus.publish(
-            RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
-          );
-
-          if (_gameState.winner != null) {
-            final finalScores = <Player, int>{};
-            for (final p in _gameState.players) {
-              finalScores[p] = p.score;
-            }
-            _eventBus.publish(
-              GameEndedEvent(
-                winner: _gameState.winner!,
-                finalScores: finalScores,
-              ),
-            );
-          }
-        }
+        _publishRoundOrGameEndEvents(player, roundBefore);
       }
     }
 
@@ -393,44 +355,7 @@ class GameController implements GameInterface {
 
       // Check if player went out (round or game ended)
       if (_gameState.phase != phaseBefore) {
-        if (_gameState.phase == GamePhase.roundEnd) {
-          _eventBus.publish(
-            PlayerWentOutEvent(roundNumber: roundBefore, player: player),
-          );
-
-          final roundScores = <Player, int>{};
-          for (final p in _gameState.players) {
-            roundScores[p] = p.score;
-          }
-          _eventBus.publish(
-            RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
-          );
-        } else if (_gameState.phase == GamePhase.gameEnd) {
-          _eventBus.publish(
-            PlayerWentOutEvent(roundNumber: roundBefore, player: player),
-          );
-
-          final roundScores = <Player, int>{};
-          for (final p in _gameState.players) {
-            roundScores[p] = p.score;
-          }
-          _eventBus.publish(
-            RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
-          );
-
-          if (_gameState.winner != null) {
-            final finalScores = <Player, int>{};
-            for (final p in _gameState.players) {
-              finalScores[p] = p.score;
-            }
-            _eventBus.publish(
-              GameEndedEvent(
-                winner: _gameState.winner!,
-                finalScores: finalScores,
-              ),
-            );
-          }
-        }
+        _publishRoundOrGameEndEvents(player, roundBefore);
       }
     }
 

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -156,40 +156,27 @@ class GameController implements GameInterface {
   }
 
   void _publishRoundOrGameEndEvents(Player player, int roundBefore) {
-    if (_gameState.phase == GamePhase.roundEnd) {
-      _eventBus.publish(
-        PlayerWentOutEvent(roundNumber: roundBefore, player: player),
-      );
+    final phase = _gameState.phase;
+    if (phase != GamePhase.roundEnd && phase != GamePhase.gameEnd) {
+      return;
+    }
 
-      final roundScores = <Player, int>{};
-      for (final p in _gameState.players) {
-        roundScores[p] = p.score;
-      }
-      _eventBus.publish(
-        RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
-      );
-    } else if (_gameState.phase == GamePhase.gameEnd) {
-      _eventBus.publish(
-        PlayerWentOutEvent(roundNumber: roundBefore, player: player),
-      );
+    _eventBus.publish(
+      PlayerWentOutEvent(roundNumber: roundBefore, player: player),
+    );
 
-      final roundScores = <Player, int>{};
-      for (final p in _gameState.players) {
-        roundScores[p] = p.score;
-      }
-      _eventBus.publish(
-        RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
-      );
+    final roundScores = <Player, int>{};
+    for (final p in _gameState.players) {
+      roundScores[p] = p.score;
+    }
+    _eventBus.publish(
+      RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
+    );
 
-      if (_gameState.winner != null) {
-        final finalScores = <Player, int>{};
-        for (final p in _gameState.players) {
-          finalScores[p] = p.score;
-        }
-        _eventBus.publish(
-          GameEndedEvent(winner: _gameState.winner!, finalScores: finalScores),
-        );
-      }
+    if (phase == GamePhase.gameEnd && _gameState.winner != null) {
+      _eventBus.publish(
+        GameEndedEvent(winner: _gameState.winner!, finalScores: roundScores),
+      );
     }
   }
 

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -142,25 +142,83 @@ class GameController implements GameInterface {
     return _gameState.canUnlockDiscard();
   }
 
+  /// Ends the current round when a player goes out and publishes UI events.
+  /// Safe to call multiple times — no-ops if the round already ended.
+  void endRoundForPlayer(Player player) {
+    if (_gameState.phase == GamePhase.roundEnd ||
+        _gameState.phase == GamePhase.gameEnd) {
+      return;
+    }
+
+    final roundBefore = _gameState.round;
+    _gameState.endRound();
+    _publishRoundOrGameEndEvents(player, roundBefore);
+  }
+
+  void _publishRoundOrGameEndEvents(Player player, int roundBefore) {
+    if (_gameState.phase == GamePhase.roundEnd) {
+      _eventBus.publish(
+        PlayerWentOutEvent(roundNumber: roundBefore, player: player),
+      );
+
+      final roundScores = <Player, int>{};
+      for (final p in _gameState.players) {
+        roundScores[p] = p.score;
+      }
+      _eventBus.publish(
+        RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
+      );
+    } else if (_gameState.phase == GamePhase.gameEnd) {
+      _eventBus.publish(
+        PlayerWentOutEvent(roundNumber: roundBefore, player: player),
+      );
+
+      final roundScores = <Player, int>{};
+      for (final p in _gameState.players) {
+        roundScores[p] = p.score;
+      }
+      _eventBus.publish(
+        RoundEndedEvent(roundNumber: roundBefore, roundScores: roundScores),
+      );
+
+      if (_gameState.winner != null) {
+        final finalScores = <Player, int>{};
+        for (final p in _gameState.players) {
+          finalScores[p] = p.score;
+        }
+        _eventBus.publish(
+          GameEndedEvent(winner: _gameState.winner!, finalScores: finalScores),
+        );
+      }
+    }
+  }
+
   @override
   bool discardCard(PlayingCard card) {
     final player = _gameState.currentPlayer;
+    final phaseBefore = _gameState.phase;
+    final roundBefore = _gameState.round;
     final result = _gameState.discard(card);
     _gameState.validateGameState();
 
     if (result) {
       _eventBus.publish(CardDiscardedEvent(card: card, player: player));
 
-      // Check if turn ended (player changed or phase changed)
-      final newPlayer = _gameState.currentPlayer;
-      if (newPlayer.id != player.id || _gameState.turnPhase == TurnPhase.draw) {
-        _eventBus.publish(
-          TurnEndedEvent(
-            turnNumber: _gameState.currentPlayerIndex,
-            nextPlayer: newPlayer,
-            player: player,
-          ),
-        );
+      if (_gameState.phase != phaseBefore) {
+        _publishRoundOrGameEndEvents(player, roundBefore);
+      } else {
+        // Check if turn ended (player changed or phase changed)
+        final newPlayer = _gameState.currentPlayer;
+        if (newPlayer.id != player.id ||
+            _gameState.turnPhase == TurnPhase.draw) {
+          _eventBus.publish(
+            TurnEndedEvent(
+              turnNumber: _gameState.currentPlayerIndex,
+              nextPlayer: newPlayer,
+              player: player,
+            ),
+          );
+        }
       }
     }
 

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -605,10 +605,13 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       }
 
       if (controller.gameState.phase == GamePhase.gameEnd) {
-        final players = ref.read(leaderboardProvider);
-        final winner = ref.read(gameWinnerProvider);
-        if (winner != null) {
-          _dialogManager.showGameEndDialog(winner, players);
+        if (!_gameEndDialogShown) {
+          final winner = ref.read(gameWinnerProvider);
+          if (winner != null) {
+            _gameEndDialogShown = true;
+            final players = ref.read(leaderboardProvider);
+            _dialogManager.showGameEndDialog(winner, players);
+          }
         }
         return;
       }

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -89,6 +89,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
   // Prevent multiple game end dialogs
   bool _gameEndDialogShown = false;
+  bool _isRoundTransitionInProgress = false;
 
   // Queue for bot turn processing to ensure one at a time
   bool _isBotTurnInProgress = false;
@@ -223,6 +224,13 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         _selectedCardIndices.clear();
         _viewingPlayerMelds = null;
         processCurrentPlayerTurn();
+      },
+      onRoundEndDetected: () {
+        _handleRoundTransition().catchError((error) {
+          DebugLogger.error(
+            'Error handling round transition from event: $error',
+          );
+        });
       },
     );
 
@@ -444,13 +452,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         .then((_) {
           _isBotTurnInProgress = false;
           DebugLogger.debug('Bot ${botPlayer.name} completed turn');
-          // Check if next player is also a bot - read directly from controller
-          if (mounted &&
-              controller.gameState.currentPlayer.type == PlayerType.bot) {
-            final nextPlayer = controller.gameState.currentPlayer;
-            DebugLogger.debug(
-              'Next player ${nextPlayer.name} is also a bot - processing immediately',
-            );
+          if (mounted) {
             processCurrentPlayerTurn();
           }
         })
@@ -485,6 +487,22 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           players.sort((a, b) => b.score.compareTo(a.score));
           _dialogManager.showGameEndDialog(winner, players);
         }
+        return;
+      }
+
+      // Handle round end before any turn processing — a bot who went out is
+      // still the current player, which otherwise triggers stuck-bot recovery.
+      if (gameState.phase == GamePhase.roundEnd) {
+        DebugLogger.debug(
+          'Round has ended - handling transition (Round ${gameState.round})',
+        );
+        _handleRoundTransition().catchError((error) {
+          DebugLogger.error('Error handling round transition: $error');
+        });
+        return;
+      }
+
+      if (_isRoundTransitionInProgress) {
         return;
       }
 
@@ -535,17 +553,6 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return;
       }
 
-      // Check for round end condition first
-      if (gameState.phase == GamePhase.roundEnd) {
-        DebugLogger.debug(
-          'Round has ended - handling transition (Round ${gameState.round})',
-        );
-        _handleRoundTransition().catchError((error) {
-          DebugLogger.error('Error handling round transition: $error');
-        });
-        return;
-      }
-
       // Human turn: Do nothing, wait for UI input
       if (currentPlayer.type == PlayerType.human ||
           currentPlayer.name == 'You') {
@@ -574,65 +581,66 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
   /// Handle complete round transition with proper state management
   Future<void> _handleRoundTransition() async {
-    final gameState = ref.read(currentGameStateProvider);
-    if (gameState?.phase != GamePhase.roundEnd) return;
-
-    DebugLogger.debug('Handling round transition - calculating scores');
-
-    // Brief pause to show scores
-    await Future.delayed(const Duration(seconds: 2));
-    if (_disposed || !mounted) return;
-
-    // Check if game should end (phase set to gameEnd by endRound() logic)
-    final updatedState = ref.read(currentGameStateProvider);
-    if (updatedState?.phase == GamePhase.gameEnd) {
-      final players = ref.read(leaderboardProvider);
-      final scores = players.map((p) => p.score).toList();
-      final highestScore = scores.isEmpty
-          ? 0
-          : scores.reduce((a, b) => a > b ? a : b);
-
-      DebugLogger.debug(
-        'Game end condition met - highest score: $highestScore',
-      );
-      final winner = ref.read(gameWinnerProvider);
-      if (winner != null) {
-        _dialogManager.showGameEndDialog(winner, players);
-      }
+    if (_isRoundTransitionInProgress) {
       return;
     }
 
-    // Continue to next round
+    final controller = _gameController;
+    if (controller == null) {
+      return;
+    }
+
+    if (controller.gameState.phase != GamePhase.roundEnd) {
+      return;
+    }
+
+    _isRoundTransitionInProgress = true;
+    DebugLogger.debug('Handling round transition - calculating scores');
+
     try {
-      final controller = _gameController;
-      if (controller != null) {
-        controller.nextRound();
-        final newState = ref.read(currentGameStateProvider);
-        DebugLogger.debug('Advanced to round ${newState?.round ?? 0}');
+      // Brief pause to show scores
+      await Future.delayed(const Duration(seconds: 2));
+      if (_disposed || !mounted) {
+        return;
+      }
 
-        if (mounted) {
-          // UI will update automatically via provider reactivity
-
-          // Clear any UI selections
-          _selectedCardIndices.clear();
-          _viewingPlayerMelds = null;
-
-          // Save game state after round transition (fire and forget)
-          _persistenceManager.saveGameState().catchError((error) {
-            DebugLogger.error(
-              'Error saving game state after round transition: $error',
-            );
-          });
-
-          // Resume game flow
-          processCurrentPlayerTurn();
+      if (controller.gameState.phase == GamePhase.gameEnd) {
+        final players = ref.read(leaderboardProvider);
+        final winner = ref.read(gameWinnerProvider);
+        if (winner != null) {
+          _dialogManager.showGameEndDialog(winner, players);
         }
+        return;
+      }
+
+      if (controller.gameState.phase != GamePhase.roundEnd) {
+        return;
+      }
+
+      controller.nextRound();
+      DebugLogger.debug('Advanced to round ${controller.gameState.round}');
+
+      if (mounted) {
+        _selectedCardIndices.clear();
+        _viewingPlayerMelds = null;
+
+        _persistenceManager.saveGameState().catchError((error) {
+          DebugLogger.error(
+            'Error saving game state after round transition: $error',
+          );
+        });
+
+        processCurrentPlayerTurn();
       }
     } catch (e) {
       DebugLogger.error('Error during round transition: $e');
-      _dialogManager.showErrorDialog(
-        'Error advancing to next round: ${e.toString()}',
-      );
+      if (mounted) {
+        _dialogManager.showErrorDialog(
+          'Error advancing to next round: ${e.toString()}',
+        );
+      }
+    } finally {
+      _isRoundTransitionInProgress = false;
     }
   }
 

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -59,6 +59,24 @@ class BotTurnManager {
     required this.logBotDecision,
   });
 
+  /// End the round when a bot goes out, publishing events for UI transition.
+  void endRoundForBot(Player botPlayer, {String? actionMessage}) {
+    final gameState = gameController.gameState;
+    if (gameState.phase == GamePhase.roundEnd ||
+        gameState.phase == GamePhase.gameEnd) {
+      return;
+    }
+
+    if (actionMessage != null) {
+      gameState.recentActions.add(
+        GameAction(message: actionMessage, playerName: botPlayer.name),
+      );
+    }
+
+    gameController.endRoundForPlayer(botPlayer);
+    onStateChanged();
+  }
+
   /// Helper method to assign bot personalities consistently
   void assignBotPersonalities() {
     final botPlayers = gameController.gameState.players
@@ -153,7 +171,19 @@ class BotTurnManager {
 
   /// SIMPLIFIED: Process bot turn iteratively to prevent stack overflow
   Future<void> processBotTurn(Player botPlayer) async {
-    if (_isProcessingBotTurn) return;
+    if (_isProcessingBotTurn) {
+      return;
+    }
+
+    final initialPhase = gameController.gameState.phase;
+    if (initialPhase == GamePhase.roundEnd ||
+        initialPhase == GamePhase.gameEnd) {
+      DebugLogger.debug(
+        'Skipping bot turn for ${botPlayer.name} - round/game already ended',
+      );
+      return;
+    }
+
     _isProcessingBotTurn = true;
 
     try {
@@ -301,7 +331,7 @@ class BotTurnManager {
           if (!success && gameState.deck.isEmpty) {
             // Handle empty deck - end round early
             DebugLogger.debug('Deck empty during bot draw - ending round');
-            gameState.endRound();
+            endRoundForBot(botPlayer);
             return true;
           }
           break;
@@ -392,7 +422,10 @@ class BotTurnManager {
 
         case 'goOut':
           if (botPlayer.canGoOut) {
-            gameState.endRound();
+            endRoundForBot(
+              botPlayer,
+              actionMessage: '🎉 went out and ended the round!',
+            );
             success = true;
           } else if (botPlayer.canGoOutWithBooks &&
               botPlayer.currentHand.length == 1) {
@@ -482,7 +515,7 @@ class BotTurnManager {
         DebugLogger.debug('Bot ${player.name} picked up foot after melding');
       } else if (player.hasPickedUpFoot && player.canGoOut) {
         // Player went out
-        gameController.gameState.endRound();
+        endRoundForBot(player);
         DebugLogger.debug('Bot ${player.name} went out by melding');
       }
     }
@@ -502,7 +535,7 @@ class BotTurnManager {
     if (player.hasPickedUpFoot &&
         player.currentHand.isEmpty &&
         player.canGoOut) {
-      gameController.gameState.endRound();
+      endRoundForBot(player);
       DebugLogger.debug('Bot ${player.name} went out by discard');
     }
   }
@@ -555,7 +588,7 @@ class BotTurnManager {
         );
       }
       if (botPlayer.canGoOut) {
-        gameState.endRound();
+        endRoundForBot(botPlayer);
         onStateChanged();
         return;
       }
@@ -606,7 +639,7 @@ class BotTurnManager {
             if (!drawn && gameState.deck.isEmpty) {
               // Deck is empty - end round
               DebugLogger.debug('Ending round due to empty deck');
-              gameState.endRound();
+              endRoundForBot(botPlayer);
               return;
             }
           }
@@ -726,8 +759,10 @@ class BotTurnManager {
           DebugLogger.debug(
             'Bot ${botPlayer.name} forcing go out - empty hand with required books',
           );
-          gameState.endRound();
-          onStateChanged();
+          endRoundForBot(
+            botPlayer,
+            actionMessage: '🎉 went out and ended the round!',
+          );
           return;
         } else {
           // Bot has empty hand but can't go out - this is a critical game logic error
@@ -811,13 +846,10 @@ class BotTurnManager {
 
     // Option 3: Check if bot can go out (end round)
     if (botPlayer.canGoOut) {
-      gameController.gameState.recentActions.add(
-        GameAction(
-          message: 'went out and ended the round!',
-          playerName: playerName,
-        ),
+      endRoundForBot(
+        botPlayer,
+        actionMessage: '🎉 went out and ended the round!',
       );
-      gameController.gameState.endRound();
       return;
     }
 
@@ -907,13 +939,10 @@ class BotTurnManager {
 
       // STEP 5: Check if bot can go out (end game)
       if (botPlayer.canGoOut) {
-        gameState.recentActions.add(
-          GameAction(
-            message: 'went out and ended the round!',
-            playerName: botPlayer.name,
-          ),
+        endRoundForBot(
+          botPlayer,
+          actionMessage: '🎉 went out and ended the round!',
         );
-        gameState.endRound();
         return;
       }
 

--- a/lib/screens/managers/event_based_game_state_manager.dart
+++ b/lib/screens/managers/event_based_game_state_manager.dart
@@ -17,6 +17,7 @@ class EventBasedGameStateManager {
   final Function() onTurnEnd; // Separate callback for turn end events
   final Function() onGameEnd;
   final Function() onRoundEnd;
+  final Function() onRoundEndDetected;
 
   final List<StreamSubscription> _subscriptions = [];
   bool _isDisposed = false;
@@ -28,6 +29,7 @@ class EventBasedGameStateManager {
     required this.onTurnEnd,
     required this.onGameEnd,
     required this.onRoundEnd,
+    required this.onRoundEndDetected,
   }) {
     _subscribeToEvents();
   }
@@ -96,17 +98,19 @@ class EventBasedGameStateManager {
   }
 
   void _handleRoundEnd() {
-    if (gameController.gameState.phase == GamePhase.roundEnd) {
-      DebugLogger.debug('Handling round end from event');
+    final phase = gameController.gameState.phase;
+    if (phase == GamePhase.gameEnd) {
+      DebugLogger.debug('Handling game end from round ended event');
+      onGameEnd();
+      return;
+    }
 
-      // Check if game should end
-      if (gameController.gameState.phase == GamePhase.gameEnd) {
-        onGameEnd();
-        return;
-      }
-
-      // Round transition will be handled by RoundStartedEvent
+    if (phase == GamePhase.roundEnd) {
+      DebugLogger.debug(
+        'Handling round end from event - triggering transition',
+      );
       onStateChanged();
+      onRoundEndDetected();
     }
   }
 

--- a/test/ai/bot_turn_manager_execution_test.dart
+++ b/test/ai/bot_turn_manager_execution_test.dart
@@ -130,6 +130,67 @@ void main() {
       expect(melded, isTrue);
       expect(botPlayer.melds.first.cards.length, greaterThan(meldSizeBefore));
     });
+
+    test('endRoundForBot ends round and is idempotent', () {
+      _setupBotToGoOut(botPlayer);
+      var stateChangedCount = 0;
+      turnManager = BotTurnManager(
+        gameController: gameController,
+        botAI: EnhancedBotAI(seed: 454749),
+        onStateChanged: () {
+          stateChangedCount++;
+        },
+        logHumanAction: (_) {},
+        logBotDecision:
+            ({
+              required String botId,
+              required String decision,
+              required String reasoning,
+              Map<String, dynamic>? context,
+            }) {},
+      );
+
+      turnManager.endRoundForBot(botPlayer);
+
+      expect(gameController.gameState.phase, GamePhase.roundEnd);
+      expect(gameController.gameState.round, 2);
+      expect(stateChangedCount, 1);
+
+      turnManager.endRoundForBot(botPlayer);
+
+      expect(gameController.gameState.phase, GamePhase.roundEnd);
+      expect(gameController.gameState.round, 2);
+      expect(stateChangedCount, 1);
+    });
+
+    test('goOut decision ends round through endRoundForBot', () {
+      _setupBotToGoOut(botPlayer);
+
+      final success = turnManager.executeBotDecision(
+        BotDecision(action: 'goOut'),
+        botPlayer,
+      );
+
+      expect(success, isTrue);
+      expect(gameController.gameState.phase, GamePhase.roundEnd);
+      expect(gameController.gameState.round, 2);
+    });
+
+    test('error recovery ends round when bot can go out', () {
+      _setupBotToGoOut(botPlayer);
+      botPlayer.hand.clear();
+      botPlayer.foot.clear();
+      gameController.gameState.turnPhase = TurnPhase.draw;
+
+      final success = turnManager.executeBotDecision(
+        BotDecision(action: 'error'),
+        botPlayer,
+      );
+
+      expect(success, isTrue);
+      expect(gameController.gameState.phase, GamePhase.roundEnd);
+      expect(gameController.gameState.round, 2);
+    });
   });
 
   group('EnhancedBotAI error propagation', () {
@@ -161,4 +222,35 @@ void main() {
       expect(decision.action, equals('error'));
     });
   });
+}
+
+void _setupBotToGoOut(Player player) {
+  player.hand.clear();
+  player.foot.clear();
+  player.melds.clear();
+
+  player.melds.add(
+    Meld.createMeld([
+      const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+      const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+      const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+      const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+      const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+      const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+      const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+    ])!,
+  );
+  player.melds.add(
+    Meld.createMeld([
+      const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+      const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+      const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+      const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+      const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+      const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+      const PlayingCard(rank: CardRank.joker),
+    ])!,
+  );
+  player.hasPlayedDown = true;
+  player.hasPickedUpFoot = true;
 }

--- a/test/ai/enhanced_bot_ai_test.dart
+++ b/test/ai/enhanced_bot_ai_test.dart
@@ -21,7 +21,7 @@ void main() {
         Player(id: '2', name: 'Bot', type: PlayerType.bot),
       ];
 
-      gameController = GameController(players: players);
+      gameController = GameController(players: players, seed: 42);
       gameController.initializeGame();
       botPlayer = players[1];
     });

--- a/test/game/bot_go_out_round_transition_regression_test.dart
+++ b/test/game/bot_go_out_round_transition_regression_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/game/events/game_event.dart';
+import 'package:hand_foot_game_flutter/game/events/game_event_bus.dart';
 import 'package:hand_foot_game_flutter/game/game_controller.dart';
 import 'package:hand_foot_game_flutter/models/card.dart';
 import 'package:hand_foot_game_flutter/models/game_state.dart';
@@ -6,40 +8,79 @@ import 'package:hand_foot_game_flutter/models/meld.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 
 void main() {
-  group('Bot go out round transition regression', () {
-    test('endRoundForPlayer advances to roundEnd and increments round', () {
-      final human = Player(id: '1', name: 'You', type: PlayerType.human);
-      final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
-      final controller = GameController(players: [human, rita]);
-      controller.initializeGame();
+  group('GameController round transition regression', () {
+    test(
+      'endRoundForPlayer advances to roundEnd and publishes RoundEndedEvent',
+      () async {
+        final eventBus = GameEventBus();
+        final roundEndedEvents = <RoundEndedEvent>[];
+        final subscription = eventBus.subscribe((event) {
+          if (event is RoundEndedEvent) {
+            roundEndedEvents.add(event);
+          }
+        });
+        addTearDown(subscription.cancel);
 
-      _setupPlayerToGoOut(rita);
-      controller.gameState.currentPlayerIndex = 1;
+        final human = Player(id: '1', name: 'You', type: PlayerType.human);
+        final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
+        final controller = GameController(
+          players: [human, rita],
+          eventBus: eventBus,
+        );
+        controller.initializeGame();
 
-      controller.endRoundForPlayer(rita);
+        _setupPlayerToGoOut(rita);
+        controller.gameState.currentPlayerIndex = 1;
 
-      expect(controller.gameState.phase, GamePhase.roundEnd);
-      expect(controller.gameState.round, 2);
-    });
+        controller.endRoundForPlayer(rita);
+        await Future<void>.delayed(Duration.zero);
 
-    test('discardCard going out ends the round', () {
-      final human = Player(id: '1', name: 'You', type: PlayerType.human);
-      final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
-      final controller = GameController(players: [human, rita]);
-      controller.initializeGame();
+        expect(controller.gameState.phase, GamePhase.roundEnd);
+        expect(controller.gameState.round, 2);
+        expect(roundEndedEvents, hasLength(1));
+        expect(roundEndedEvents.single.roundNumber, 1);
+        expect(roundEndedEvents.single.roundScores[rita], rita.score);
+        expect(roundEndedEvents.single.roundScores[human], human.score);
+      },
+    );
 
-      _setupPlayerToGoOut(rita);
-      rita.foot.add(const PlayingCard(suit: Suit.hearts, rank: CardRank.ace));
-      controller.gameState.currentPlayerIndex = 1;
-      controller.gameState.turnPhase = TurnPhase.discard;
+    test(
+      'discardCard going out ends the round and publishes RoundEndedEvent',
+      () async {
+        final eventBus = GameEventBus();
+        final roundEndedEvents = <RoundEndedEvent>[];
+        final subscription = eventBus.subscribe((event) {
+          if (event is RoundEndedEvent) {
+            roundEndedEvents.add(event);
+          }
+        });
+        addTearDown(subscription.cancel);
 
-      final success = controller.discardCard(rita.foot.first);
+        final human = Player(id: '1', name: 'You', type: PlayerType.human);
+        final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
+        final controller = GameController(
+          players: [human, rita],
+          eventBus: eventBus,
+        );
+        controller.initializeGame();
 
-      expect(success, isTrue);
-      expect(controller.gameState.phase, GamePhase.roundEnd);
-    });
+        _setupPlayerToGoOut(rita);
+        rita.foot.add(const PlayingCard(suit: Suit.hearts, rank: CardRank.ace));
+        controller.gameState.currentPlayerIndex = 1;
+        controller.gameState.turnPhase = TurnPhase.discard;
 
-    test('nextRound clears melds and deals fresh cards after bot goes out', () {
+        final success = controller.discardCard(rita.foot.first);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(success, isTrue);
+        expect(controller.gameState.phase, GamePhase.roundEnd);
+        expect(roundEndedEvents, hasLength(1));
+        expect(roundEndedEvents.single.roundNumber, 1);
+        expect(roundEndedEvents.single.roundScores[rita], rita.score);
+      },
+    );
+
+    test('nextRound clears melds and deals fresh cards for all players', () {
       final human = Player(id: '1', name: 'You', type: PlayerType.human);
       final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
       final alex = Player(id: '3', name: 'Alex', type: PlayerType.bot);
@@ -49,6 +90,14 @@ void main() {
       _setupPlayerToGoOut(rita);
       human.hasPlayedDown = true;
       human.hasPickedUpFoot = true;
+      human.hand.clear();
+      human.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.five),
+        ])!,
+      );
       for (int i = 0; i < 11; i++) {
         human.foot.add(
           const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
@@ -61,6 +110,7 @@ void main() {
       expect(controller.gameState.phase, GamePhase.roundEnd);
       expect(controller.gameState.round, 2);
       expect(rita.melds, isNotEmpty);
+      expect(human.melds, isNotEmpty);
 
       controller.nextRound();
 
@@ -70,28 +120,96 @@ void main() {
       expect(human.melds, isEmpty);
       expect(rita.hand.length, 11);
       expect(rita.foot.length, 11);
+      expect(human.hand.length, 11);
+      expect(human.foot.length, 11);
       expect(rita.hasPlayedDown, isFalse);
       expect(rita.hasPickedUpFoot, isFalse);
+      expect(human.hasPlayedDown, isFalse);
+      expect(human.hasPickedUpFoot, isFalse);
     });
 
-    test('endRoundForPlayer is idempotent when round already ended', () {
+    test('endRoundForPlayer is idempotent when round already ended', () async {
+      final eventBus = GameEventBus();
+      final roundEndedEvents = <RoundEndedEvent>[];
+      final subscription = eventBus.subscribe((event) {
+        if (event is RoundEndedEvent) {
+          roundEndedEvents.add(event);
+        }
+      });
+      addTearDown(subscription.cancel);
+
+      final human = Player(id: '1', name: 'You', type: PlayerType.human);
       final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
       final controller = GameController(
-        players: [
-          Player(id: '1', name: 'You', type: PlayerType.human),
-          rita,
-        ],
+        players: [human, rita],
+        eventBus: eventBus,
       );
       controller.initializeGame();
       _setupPlayerToGoOut(rita);
+      controller.gameState.currentPlayerIndex = 1;
+      controller.gameState.turnPhase = TurnPhase.discard;
 
       controller.endRoundForPlayer(rita);
-      expect(controller.gameState.round, 2);
+      await Future<void>.delayed(Duration.zero);
+
+      final snapshot = _RoundEndSnapshot.capture(controller, roundEndedEvents);
 
       controller.endRoundForPlayer(rita);
-      expect(controller.gameState.round, 2);
+      await Future<void>.delayed(Duration.zero);
+
+      snapshot.assertUnchanged(controller, roundEndedEvents);
     });
   });
+}
+
+class _RoundEndSnapshot {
+  final GamePhase phase;
+  final int round;
+  final List<int> scores;
+  final int currentPlayerIndex;
+  final TurnPhase turnPhase;
+  final int recentActionCount;
+  final int roundEndedEventCount;
+
+  _RoundEndSnapshot({
+    required this.phase,
+    required this.round,
+    required this.scores,
+    required this.currentPlayerIndex,
+    required this.turnPhase,
+    required this.recentActionCount,
+    required this.roundEndedEventCount,
+  });
+
+  factory _RoundEndSnapshot.capture(
+    GameController controller,
+    List<RoundEndedEvent> roundEndedEvents,
+  ) {
+    final gameState = controller.gameState;
+    return _RoundEndSnapshot(
+      phase: gameState.phase,
+      round: gameState.round,
+      scores: gameState.players.map((player) => player.score).toList(),
+      currentPlayerIndex: gameState.currentPlayerIndex,
+      turnPhase: gameState.turnPhase,
+      recentActionCount: gameState.recentActions.length,
+      roundEndedEventCount: roundEndedEvents.length,
+    );
+  }
+
+  void assertUnchanged(
+    GameController controller,
+    List<RoundEndedEvent> roundEndedEvents,
+  ) {
+    final gameState = controller.gameState;
+    expect(gameState.phase, phase);
+    expect(gameState.round, round);
+    expect(gameState.players.map((player) => player.score).toList(), scores);
+    expect(gameState.currentPlayerIndex, currentPlayerIndex);
+    expect(gameState.turnPhase, turnPhase);
+    expect(gameState.recentActions.length, recentActionCount);
+    expect(roundEndedEvents.length, roundEndedEventCount);
+  }
 }
 
 void _setupPlayerToGoOut(Player player) {

--- a/test/game/bot_go_out_round_transition_regression_test.dart
+++ b/test/game/bot_go_out_round_transition_regression_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Bot go out round transition regression', () {
+    test('endRoundForPlayer advances to roundEnd and increments round', () {
+      final human = Player(id: '1', name: 'You', type: PlayerType.human);
+      final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
+      final controller = GameController(players: [human, rita]);
+      controller.initializeGame();
+
+      _setupPlayerToGoOut(rita);
+      controller.gameState.currentPlayerIndex = 1;
+
+      controller.endRoundForPlayer(rita);
+
+      expect(controller.gameState.phase, GamePhase.roundEnd);
+      expect(controller.gameState.round, 2);
+    });
+
+    test('discardCard going out ends the round', () {
+      final human = Player(id: '1', name: 'You', type: PlayerType.human);
+      final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
+      final controller = GameController(players: [human, rita]);
+      controller.initializeGame();
+
+      _setupPlayerToGoOut(rita);
+      rita.foot.add(const PlayingCard(suit: Suit.hearts, rank: CardRank.ace));
+      controller.gameState.currentPlayerIndex = 1;
+      controller.gameState.turnPhase = TurnPhase.discard;
+
+      final success = controller.discardCard(rita.foot.first);
+
+      expect(success, isTrue);
+      expect(controller.gameState.phase, GamePhase.roundEnd);
+    });
+
+    test('nextRound clears melds and deals fresh cards after bot goes out', () {
+      final human = Player(id: '1', name: 'You', type: PlayerType.human);
+      final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
+      final alex = Player(id: '3', name: 'Alex', type: PlayerType.bot);
+      final controller = GameController(players: [human, rita, alex]);
+      controller.initializeGame();
+
+      _setupPlayerToGoOut(rita);
+      human.hasPlayedDown = true;
+      human.hasPickedUpFoot = true;
+      for (int i = 0; i < 11; i++) {
+        human.foot.add(
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+        );
+      }
+
+      controller.gameState.currentPlayerIndex = 1;
+      controller.endRoundForPlayer(rita);
+
+      expect(controller.gameState.phase, GamePhase.roundEnd);
+      expect(controller.gameState.round, 2);
+      expect(rita.melds, isNotEmpty);
+
+      controller.nextRound();
+
+      expect(controller.gameState.phase, GamePhase.playing);
+      expect(controller.gameState.round, 2);
+      expect(rita.melds, isEmpty);
+      expect(human.melds, isEmpty);
+      expect(rita.hand.length, 11);
+      expect(rita.foot.length, 11);
+      expect(rita.hasPlayedDown, isFalse);
+      expect(rita.hasPickedUpFoot, isFalse);
+    });
+
+    test('endRoundForPlayer is idempotent when round already ended', () {
+      final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
+      final controller = GameController(
+        players: [
+          Player(id: '1', name: 'You', type: PlayerType.human),
+          rita,
+        ],
+      );
+      controller.initializeGame();
+      _setupPlayerToGoOut(rita);
+
+      controller.endRoundForPlayer(rita);
+      expect(controller.gameState.round, 2);
+
+      controller.endRoundForPlayer(rita);
+      expect(controller.gameState.round, 2);
+    });
+  });
+}
+
+void _setupPlayerToGoOut(Player player) {
+  player.hand.clear();
+  player.foot.clear();
+  player.melds.clear();
+
+  final cleanBook = Meld.createMeld([
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+  ])!;
+
+  final dirtyBook = Meld.createMeld([
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+    const PlayingCard(rank: CardRank.joker),
+  ])!;
+
+  player.melds.add(cleanBook);
+  player.melds.add(dirtyBook);
+  player.hasPlayedDown = true;
+  player.hasPickedUpFoot = true;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a bot (e.g. Rita) went out and ended the round, the UI showed "ROUND 2" and the went-out banner, but the table never reset — melds, hands, and turn state from round 1 persisted. The exported game state confirmed the game was stuck in `roundEnd` with Rita still as the current player.

## Root cause

Two issues combined:

1. **Turn processing order bug:** `processCurrentPlayerTurn()` ran "stuck bot recovery" *before* checking `GamePhase.roundEnd`. After a bot went out, that bot remained the current player, so recovery kept re-queuing Rita instead of advancing to the next round.

2. **Missing round-end events:** Bot force-completion paths called `gameState.endRound()` directly, bypassing `GameController` event publishing. The UI never received `RoundEndedEvent`, and `discardCard` also did not publish round-end events when a discard ended the round.

## Fix

- Check `roundEnd` / `gameEnd` **before** stuck-bot recovery in `processCurrentPlayerTurn()`
- Add `GameController.endRoundForPlayer()` to centralize round end + event publishing
- Route all bot round-end paths through `endRoundForBot()` helper
- Publish round-end events from `discardCard` when phase changes
- Wire `RoundEndedEvent` to trigger `_handleRoundTransition()` via `onRoundEndDetected`
- Always call `processCurrentPlayerTurn()` after bot turns complete (not only when next player is a bot)
- Add regression tests for bot go-out → nextRound flow

## Testing

- `flutter analyze` — clean
- `flutter test` — 772 tests passed
- New: `test/game/bot_go_out_round_transition_regression_test.dart`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bfc694c-0c94-4929-90f4-c6c67c20594d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bfc694c-0c94-4929-90f4-c6c67c20594d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-of-round and game-end handling for players and bots, including accurate “went out” and completion event notifications.
  * Prevented duplicate or mistimed turn-ended notifications during round/game transitions.
  * Added guarded, idempotent round-ending to avoid re-entrancy across bot go-out, recovery, and emergency flows.
* **New Features**
  * Refined round-transition flow with a brief score display and cleaner progression to the next round or game-end dialog.
  * Centralized bot round-ending behavior with optional user-visible action messaging.
* **Tests**
  * Added regression and execution tests for bot go-out transitions, next-round state resets, and idempotent end-round behavior.
* **Refactor**
  * Improved enhanced bot draw-phase sequencing to better follow Hand & Foot turn order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->