### PR TITLE
Foot-phase bot AI improvements from Firestore session analysis

### DIFF
--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -2746,7 +2746,23 @@ class EnhancedBotAI {
 
     // Large foot hand: every personality must meld (not just adaptive at 10+)
     if (handSize >= BotConfig.footPhaseAggressiveMeldingThreshold) {
-      return _forceFootPhaseMeld(bot, context, prioritizeMissingBookType: true);
+      final forced = _forceFootPhaseMeld(
+        bot,
+        context,
+        prioritizeMissingBookType: true,
+      );
+      if (forced != null) {
+        return forced;
+      }
+
+      // Foot hoarding fallback (session_17836311659865986): any meld beats drawing again
+      final anyMelds = _getCachedPossibleMelds(bot, context);
+      if (anyMelds.isNotEmpty) {
+        return BotDecision(
+          action: 'createMeld',
+          data: _selectBestNewMeld(bot, anyMelds),
+        );
+      }
     }
 
     return null;
@@ -2813,15 +2829,41 @@ class EnhancedBotAI {
       }
     }
 
-    final cardsToAdd = _filterWildCardAdditions(
+    var cardsToAdd = _filterWildCardAdditions(
       _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
       bot,
     );
+
+    // Alex-style foot failure: hoarding on dirty books while clean book still missing
+    if (prioritizeMissingBookType && needsClean && bot.hasDirtyBook) {
+      cardsToAdd = cardsToAdd.where((addition) {
+        final meldIndex = addition['meldIndex'] as int;
+        final card = addition['card'] as PlayingCard;
+        final meld = bot.melds[meldIndex];
+        if (meld.cards.length >= GameConfig.bookSize) {
+          return false;
+        }
+        if (card.isWild) {
+          return false;
+        }
+        return !meld.cards.any((existing) => existing.isWild);
+      }).toList();
+    }
+
     if (cardsToAdd.isNotEmpty) {
       return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
     }
 
-    final possibleMelds = _getCachedPossibleMelds(bot, context);
+    var possibleMelds = _getCachedPossibleMelds(bot, context);
+    if (prioritizeMissingBookType && needsClean && bot.hasDirtyBook) {
+      final cleanOnly = possibleMelds
+          .where((meld) => !meld.any((card) => card.isWild))
+          .toList();
+      if (cleanOnly.isNotEmpty) {
+        possibleMelds = cleanOnly;
+      }
+    }
+
     if (possibleMelds.isNotEmpty) {
       return BotDecision(
         action: 'createMeld',

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -2252,6 +2252,26 @@ class EnhancedBotAI {
     return result;
   }
 
+  /// When dirty books exist but a clean book is still required, only add naturals
+  /// to incomplete, non-wild melds — never inflate dirty piles toward completion.
+  List<Map<String, dynamic>> _filterCleanBookPriorityAdditions(
+    Player bot,
+    List<Map<String, dynamic>> additions,
+  ) {
+    return additions.where((addition) {
+      final meldIndex = addition['meldIndex'] as int;
+      final card = addition['card'] as PlayingCard;
+      final meld = bot.melds[meldIndex];
+      if (meld.cards.length >= GameConfig.bookSize) {
+        return false;
+      }
+      if (card.isWild) {
+        return false;
+      }
+      return !meld.cards.any((existing) => existing.isWild);
+    }).toList();
+  }
+
   /// Helper method to randomly select from a list of equally good options
   /// Adds decision variability to make bot behavior less predictable
   T? _selectRandomly<T>(List<T> options) {
@@ -2732,8 +2752,11 @@ class EnhancedBotAI {
       return bookRush;
     }
 
-    // Opponent close to going out — stop hoarding and melt the foot hand
-    if (_opponentThreateningGoOut(context.gameState, bot)) {
+    // Opponent close to going out or large foot hand — melt aggressively
+    final needsForcedMeld =
+        _opponentThreateningGoOut(context.gameState, bot) ||
+        handSize >= BotConfig.footPhaseAggressiveMeldingThreshold;
+    if (needsForcedMeld) {
       final forced = _forceFootPhaseMeld(
         bot,
         context,
@@ -2744,18 +2767,8 @@ class EnhancedBotAI {
       }
     }
 
-    // Large foot hand: every personality must meld (not just adaptive at 10+)
+    // Large foot hand: any meld beats drawing again
     if (handSize >= BotConfig.footPhaseAggressiveMeldingThreshold) {
-      final forced = _forceFootPhaseMeld(
-        bot,
-        context,
-        prioritizeMissingBookType: true,
-      );
-      if (forced != null) {
-        return forced;
-      }
-
-      // Foot hoarding fallback (session_17836311659865986): any meld beats drawing again
       final anyMelds = _getCachedPossibleMelds(bot, context);
       if (anyMelds.isNotEmpty) {
         return BotDecision(
@@ -2781,9 +2794,16 @@ class EnhancedBotAI {
 
     final needsClean = !bot.hasCleanBook;
     final needsDirty = !bot.hasDirtyBook;
+    final shouldPreferCleanOverDirty =
+        prioritizeMissingBookType && needsClean && bot.hasDirtyBook;
+
+    final filteredAdditions = _filterWildCardAdditions(
+      _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
+      bot,
+    );
 
     // Have dirty books but need clean — build a naturals-only lane, not more dirty piles
-    if (prioritizeMissingBookType && needsClean && bot.hasDirtyBook) {
+    if (shouldPreferCleanOverDirty) {
       final cleanMelds = _getCachedPossibleMelds(
         bot,
         context,
@@ -2800,16 +2820,10 @@ class EnhancedBotAI {
         );
       }
 
-      final naturalAdditions =
-          _filterWildCardAdditions(
-            _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
-            bot,
-          ).where((addition) {
-            final meldIndex = addition['meldIndex'] as int;
-            final meld = bot.melds[meldIndex];
-            return meld.cards.length < GameConfig.bookSize &&
-                !meld.cards.any((card) => card.isWild);
-          }).toList();
+      final naturalAdditions = _filterCleanBookPriorityAdditions(
+        bot,
+        filteredAdditions,
+      );
       if (naturalAdditions.isNotEmpty) {
         return BotDecision(action: 'addToMeld', data: naturalAdditions.first);
       }
@@ -2829,33 +2843,16 @@ class EnhancedBotAI {
       }
     }
 
-    var cardsToAdd = _filterWildCardAdditions(
-      _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
-      bot,
-    );
-
-    // Alex-style foot failure: hoarding on dirty books while clean book still missing
-    if (prioritizeMissingBookType && needsClean && bot.hasDirtyBook) {
-      cardsToAdd = cardsToAdd.where((addition) {
-        final meldIndex = addition['meldIndex'] as int;
-        final card = addition['card'] as PlayingCard;
-        final meld = bot.melds[meldIndex];
-        if (meld.cards.length >= GameConfig.bookSize) {
-          return false;
-        }
-        if (card.isWild) {
-          return false;
-        }
-        return !meld.cards.any((existing) => existing.isWild);
-      }).toList();
-    }
+    var cardsToAdd = shouldPreferCleanOverDirty
+        ? _filterCleanBookPriorityAdditions(bot, filteredAdditions)
+        : filteredAdditions;
 
     if (cardsToAdd.isNotEmpty) {
       return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
     }
 
     var possibleMelds = _getCachedPossibleMelds(bot, context);
-    if (prioritizeMissingBookType && needsClean && bot.hasDirtyBook) {
+    if (shouldPreferCleanOverDirty) {
       final cleanOnly = possibleMelds
           .where((meld) => !meld.any((card) => card.isWild))
           .toList();

--- a/scripts/query_analytics_session.js
+++ b/scripts/query_analytics_session.js
@@ -145,9 +145,19 @@ async function listCollection(accessToken, collection, pageSize = 300) {
   return all;
 }
 
-async function runStructuredQuery(accessToken, collection, field, op, value, limit = 500) {
-  const body = JSON.stringify({
-    structuredQuery: {
+async function runStructuredQuery(
+  accessToken,
+  collection,
+  field,
+  op,
+  value,
+  limit = 500,
+) {
+  const all = [];
+  let lastDoc = null;
+
+  while (true) {
+    const structuredQuery = {
       from: [{ collectionId: collection }],
       where: {
         fieldFilter: {
@@ -157,26 +167,69 @@ async function runStructuredQuery(accessToken, collection, field, op, value, lim
         },
       },
       limit,
-    },
-  });
+    };
+    if (lastDoc) {
+      structuredQuery.startAt = {
+        values: [{ referenceValue: lastDoc.name }],
+        before: false,
+      };
+    }
 
-  const result = await httpsRequest(
-    {
-      hostname: 'firestore.googleapis.com',
-      path: `/v1/projects/${PROJECT_ID}/databases/(default)/documents:runQuery`,
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
+    const body = JSON.stringify({ structuredQuery });
+    const result = await httpsRequest(
+      {
+        hostname: 'firestore.googleapis.com',
+        path: `/v1/projects/${PROJECT_ID}/databases/(default)/documents:runQuery`,
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
       },
-    },
-    body,
-  );
+      body,
+    );
 
-  return result
-    .filter((row) => row.document)
-    .map((row) => docToObject(row.document));
+    const docs = result
+      .filter((row) => row.document)
+      .map((row) => row.document);
+    if (docs.length === 0) {
+      break;
+    }
+
+    all.push(...docs.map(docToObject));
+    if (docs.length < limit) {
+      break;
+    }
+
+    console.warn(
+      `Warning: structured query for ${collection} hit limit ${limit}; fetching more...`,
+    );
+    lastDoc = docs[docs.length - 1];
+  }
+
+  return all;
+}
+
+async function fetchBySessionId(
+  accessToken,
+  collection,
+  sessionId,
+  structuredLimit,
+) {
+  let docs = await runStructuredQuery(
+    accessToken,
+    collection,
+    'sessionId',
+    'EQUAL',
+    { stringValue: sessionId },
+    structuredLimit,
+  );
+  if (docs.length === 0) {
+    const allDocs = await listCollection(accessToken, collection, 500);
+    docs = allDocs.filter((d) => d.sessionId === sessionId);
+  }
+  return docs;
 }
 
 function scoresMatch(sessionScores, targetScores) {
@@ -212,9 +265,6 @@ async function main() {
     if (!match && args.recent) {
       match = sessions[0];
     }
-    if (!match && sessions.length > 0) {
-      match = sessions[0];
-    }
     if (!match) {
       console.error('No matching session found');
       process.exit(1);
@@ -225,18 +275,12 @@ async function main() {
   }
 
   console.log('\nFetching bot_decisions for session...');
-  let decisions = await runStructuredQuery(
+  let decisions = await fetchBySessionId(
     accessToken,
     'bot_decisions',
-    'sessionId',
-    'EQUAL',
-    { stringValue: sessionId },
+    sessionId,
     1000,
   );
-  if (decisions.length === 0) {
-    const allDecisions = await listCollection(accessToken, 'bot_decisions', 500);
-    decisions = allDecisions.filter((d) => d.sessionId === sessionId);
-  }
   if (args.footOnly) {
     decisions = decisions.filter((d) => d.botHasPickedUpFoot === true);
   }
@@ -250,18 +294,12 @@ async function main() {
   }
 
   console.log('\nFetching game_events for session...');
-  let events = await runStructuredQuery(
+  let events = await fetchBySessionId(
     accessToken,
     'game_events',
-    'sessionId',
-    'EQUAL',
-    { stringValue: sessionId },
+    sessionId,
     500,
   );
-  if (events.length === 0) {
-    const allEvents = await listCollection(accessToken, 'game_events', 500);
-    events = allEvents.filter((e) => e.sessionId === sessionId);
-  }
   events.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
   console.log(`Found ${events.length} game events`);
   for (const e of events.slice(-30)) {

--- a/scripts/query_analytics_session.js
+++ b/scripts/query_analytics_session.js
@@ -15,7 +15,7 @@ const PROJECT_ID =
   process.env.FIREBASE_PROJECT_ID || 'hand-foot-game-flutter';
 
 function parseArgs(argv) {
-  const args = { scores: null, session: null, footOnly: false, limit: 5 };
+  const args = { scores: null, session: null, footOnly: false, limit: 5, recent: false };
   for (let i = 2; i < argv.length; i++) {
     if (argv[i] === '--scores' && argv[i + 1]) {
       args.scores = argv[++i].split(',').map((s) => parseInt(s.trim(), 10));
@@ -25,6 +25,8 @@ function parseArgs(argv) {
       args.footOnly = true;
     } else if (argv[i] === '--limit' && argv[i + 1]) {
       args.limit = parseInt(argv[++i], 10);
+    } else if (argv[i] === '--recent') {
+      args.recent = true;
     }
   }
   return args;
@@ -143,7 +145,7 @@ async function listCollection(accessToken, collection, pageSize = 300) {
   return all;
 }
 
-async function runStructuredQuery(accessToken, collection, field, op, value) {
+async function runStructuredQuery(accessToken, collection, field, op, value, limit = 500) {
   const body = JSON.stringify({
     structuredQuery: {
       from: [{ collectionId: collection }],
@@ -154,7 +156,7 @@ async function runStructuredQuery(accessToken, collection, field, op, value) {
           value,
         },
       },
-      limit: 20,
+      limit,
     },
   });
 
@@ -207,6 +209,12 @@ async function main() {
     if (!match) {
       match = sessions.find((s) => s.status === 'completed');
     }
+    if (!match && args.recent) {
+      match = sessions[0];
+    }
+    if (!match && sessions.length > 0) {
+      match = sessions[0];
+    }
     if (!match) {
       console.error('No matching session found');
       process.exit(1);
@@ -217,8 +225,18 @@ async function main() {
   }
 
   console.log('\nFetching bot_decisions for session...');
-  const allDecisions = await listCollection(accessToken, 'bot_decisions', 500);
-  let decisions = allDecisions.filter((d) => d.sessionId === sessionId);
+  let decisions = await runStructuredQuery(
+    accessToken,
+    'bot_decisions',
+    'sessionId',
+    'EQUAL',
+    { stringValue: sessionId },
+    1000,
+  );
+  if (decisions.length === 0) {
+    const allDecisions = await listCollection(accessToken, 'bot_decisions', 500);
+    decisions = allDecisions.filter((d) => d.sessionId === sessionId);
+  }
   if (args.footOnly) {
     decisions = decisions.filter((d) => d.botHasPickedUpFoot === true);
   }
@@ -232,10 +250,19 @@ async function main() {
   }
 
   console.log('\nFetching game_events for session...');
-  const allEvents = await listCollection(accessToken, 'game_events', 500);
-  const events = allEvents
-    .filter((e) => e.sessionId === sessionId)
-    .sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+  let events = await runStructuredQuery(
+    accessToken,
+    'game_events',
+    'sessionId',
+    'EQUAL',
+    { stringValue: sessionId },
+    500,
+  );
+  if (events.length === 0) {
+    const allEvents = await listCollection(accessToken, 'game_events', 500);
+    events = allEvents.filter((e) => e.sessionId === sessionId);
+  }
+  events.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
   console.log(`Found ${events.length} game events`);
   for (const e of events.slice(-30)) {
     console.log(`- ${e.eventType} | ${e.playerId} | ${JSON.stringify(e.eventData || {})}`);

--- a/test/ai/bot_foot_phase_melding_test.dart
+++ b/test/ai/bot_foot_phase_melding_test.dart
@@ -157,6 +157,9 @@ void main() {
           ])!,
         ]);
 
+        expect(bot.hasDirtyBook, isTrue);
+        expect(bot.hasCleanBook, isFalse);
+
         final decision = botAI.makeDecision(bot, gameController);
 
         expect(decision.action, isNot('noMeld'));

--- a/test/ai/bot_foot_phase_melding_test.dart
+++ b/test/ai/bot_foot_phase_melding_test.dart
@@ -118,6 +118,59 @@ void main() {
       },
     );
 
+    test(
+      'adaptive bot avoids inflating dirty books when clean book still needed',
+      () {
+        botAI.assignPersonality(bot.id, BotPersonality.adaptive);
+
+        dealBotFoot([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.four),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.four),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.ten),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+        ]);
+
+        bot.melds.addAll([
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.two),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+          ])!,
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.nine),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+          ])!,
+        ]);
+
+        final decision = botAI.makeDecision(bot, gameController);
+
+        expect(decision.action, isNot('noMeld'));
+        if (decision.action == 'createMeld') {
+          final meld = decision.data as List<PlayingCard>;
+          expect(meld.any((c) => c.isWild), isFalse);
+        } else if (decision.action == 'addToMeld') {
+          final addition = decision.data as Map<String, dynamic>;
+          final card = addition['card'] as PlayingCard;
+          expect(card.isWild, isFalse);
+        }
+      },
+    );
+
     test('bot on foot melds aggressively when human threatens go-out', () {
       human.hasPickedUpFoot = true;
       human.foot.clear();

--- a/test/regression/firestore_session_17836311659865986_test.dart
+++ b/test/regression/firestore_session_17836311659865986_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_config.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+/// Regression tests from Firestore session_17836311659865986 (gameSeed 782846).
+///
+/// Round 1 scores: human 3325, Alex (adaptive) 1140, Carl (conservative) 1185.
+/// Failure modes: foot hoarding, dirty-book inflation, draw loops with 10+ cards.
+void main() {
+  group('Firestore session_17836311659865986 regressions', () {
+    const sessionSeed = 782846;
+
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player human;
+    late Player carl;
+    late Player alex;
+
+    setUp(() {
+      botAI = EnhancedBotAI(seed: sessionSeed);
+      human = Player(id: '1', name: 'You', type: PlayerType.human);
+      carl = Player(id: '3', name: 'Carl', type: PlayerType.bot);
+      alex = Player(id: '2', name: 'Alex', type: PlayerType.bot);
+      gameController = GameController(
+        players: [human, alex, carl],
+        seed: sessionSeed,
+      );
+      gameController.initializeGame();
+      botAI.assignPersonality(carl.id, BotPersonality.conservative);
+      botAI.assignPersonality(alex.id, BotPersonality.adaptive);
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+    });
+
+    void setupFootPlayer(Player bot, List<PlayingCard> footCards) {
+      bot.hasPlayedDown = true;
+      bot.hasPickedUpFoot = true;
+      bot.foot.clear();
+      bot.foot.addAll(footCards);
+      gameController.gameState.currentPlayerIndex = gameController
+          .gameState
+          .players
+          .indexWhere((p) => p.id == bot.id);
+    }
+
+    test(
+      'Carl conservative melds on foot with 11 cards (session draw-loop fix)',
+      () {
+        setupFootPlayer(carl, [
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.four),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.five),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.six),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.six),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.eight),
+        ]);
+        carl.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+          ])!,
+        );
+
+        expect(
+          carl.currentHand.length,
+          greaterThanOrEqualTo(BotConfig.footPhaseAggressiveMeldingThreshold),
+        );
+
+        final decision = botAI.makeDecision(carl, gameController);
+
+        expect(decision.action, isNot('noMeld'));
+        expect(
+          decision.action,
+          anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+        );
+      },
+    );
+
+    test('Alex adaptive builds clean book instead of growing dirty piles', () {
+      setupFootPlayer(alex, [
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.four),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.four),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.nine),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ten),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+      ]);
+      alex.melds.addAll([
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.two),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+        ])!,
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+        ])!,
+      ]);
+
+      final decision = botAI.makeDecision(alex, gameController);
+
+      expect(decision.action, isNot('noMeld'));
+      if (decision.action == 'createMeld') {
+        final meld = decision.data as List<PlayingCard>;
+        expect(meld.any((c) => c.isWild), isFalse);
+      }
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Session analyzed

- **sessionId:** `session_17836311659865986`
- **gameSeed:** `782846`
- **Round 1 scores:** human 3325, Alex (adaptive) 1140, Carl (conservative) 1185
- **Note:** Session was `active` at query time (no completed sessions in analytics); data sourced from prior Firestore analysis of 22 foot-phase `bot_decisions`.

## Failure patterns found

| Bot | Issue |
|-----|-------|
| **Alex (adaptive)** | Foot hoarding (10+ cards) with 2 dirty books and no clean book; kept adding to dirty seven/nine piles instead of building a clean meld |
| **Carl (conservative)** | Repeated `drawFromDeck` in foot with 11–13 cards; only 1 book at round end |
| **Human** | Went out with 2 cards and 5+ books while bots held 8–10 cards |

## AI changes

### `lib/ai/enhanced_bot_ai.dart`
- **`_forceFootPhaseMeld()` / `_handleFootPhaseMeldDecision()`:** When `prioritizeMissingBookType` needs a clean book and the bot already has a dirty book, filter `addToMeld` to exclude wilds and additions that complete dirty books; prefer naturals-only `createMeld` options.
- **Foot hoarding fallback:** If hand ≥ 8 (`footPhaseAggressiveMeldingThreshold`) and `_forceFootPhaseMeld` returns null, try any possible meld before allowing a draw/noMeld loop.
- **PR review follow-up:** Hoisted single `_forceFootPhaseMeld` call for opponent-threat + large-hand paths; extracted `_filterCleanBookPriorityAdditions` to dedupe meld-analysis work.

### `scripts/query_analytics_session.js`
- Added `--recent` flag for structured JSON summary
- Structured Firestore queries filtered by `sessionId` for `bot_decisions` and `game_events`
- Falls back to full collection list when structured query returns empty
- Defaults to most recent session by `startTime` only when `--recent` is passed
- **PR review follow-up:** Paginates structured queries when limit is hit; extracted `fetchBySessionId` helper

## Regression tests

- `test/ai/bot_foot_phase_melding_test.dart` — adaptive bot avoids inflating dirty books when clean book still needed (with book-state preconditions)
- `test/regression/firestore_session_17836311659865986_test.dart` — seed `782846` regressions for Carl (11-card foot stall) and Alex (clean book over dirty piles)

## Quality checks

- `dart format .` ✓
- `flutter analyze` — zero issues ✓
- `flutter test` — all affected tests passed ✓
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c30-2f51-73da-975e-babefc9a51a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c30-2f51-73da-975e-babefc9a51a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved adaptive bot foot-phase melding to better handle urgent meld situations and avoid creating/expanding invalid melds.
  - Tightened “clean book still needed” logic so the bot preferentially builds clean melds and avoids adding wild cards when inappropriate.
  - Enhanced analytics session retrieval with more dependable matching and pagination.
- **New Features**
  - Added a `--recent` option to select the most recent analytics session when no exact match is found.
- **Tests**
  - Added a unit test covering adaptive bot behavior for clean-book priorities.
  - Added a Firestore regression test for meld-phase decision correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->