### PR TITLE
Wire Firestore analytics quick wins for richer gameplay data

### DIFF
--- a/docs/analytics_guide.md
+++ b/docs/analytics_guide.md
@@ -61,6 +61,8 @@ Map<String, dynamic> privacyInfo = AnalyticsConfigService.getPrivacyInfo();
     "conservative": 1
   },
   gameSeed: 123456, // For reproducible game analysis
+  appVersion: "1.0.0",
+  botAiVersion: "2026.07-human-patterns",
   finalScores: [1250, 980, 750],
   winnerId: "player_1",
   sessionDuration: 1800,
@@ -84,6 +86,9 @@ Map<String, dynamic> privacyInfo = AnalyticsConfigService.getPrivacyInfo();
   botId: "bot_1",
   botPersonality: "aggressive",
   decision: "takePile",
+  drawSource: "discard",
+  appVersion: "1.0.0",
+  botAiVersion: "2026.07-human-patterns",
   reasoning: "Pile contains valuable cards for book completion",
   confidence: 0.8,
   gameSeed: 123456, // Same seed for reproducible analysis
@@ -103,11 +108,54 @@ Map<String, dynamic> privacyInfo = AnalyticsConfigService.getPrivacyInfo();
   eventType: "meld_created",
   playerId: "player_1",
   playerType: "human",
+  drawSource: "deck",  // deck | discard | unlock (when applicable)
+  appVersion: "1.0.0",
+  botAiVersion: "2026.07-human-patterns",
   success: true,
   eventData: {
     cardCount: 5,
     pointValue: 150
   }
+}
+```
+
+### turn_summaries
+```firestore
+{
+  sessionId: "session_1640995200000",
+  timestamp: timestamp,
+  turnNumber: 12,
+  playerId: "player_1",
+  playerType: "human",
+  round: 2,
+  actionCount: 4,
+  drawSources: ["deck"],
+  meldsCreated: 1,
+  discardedRank: "five",
+  handSizeAtEnd: 11,
+  nextPlayerId: "bot_1",
+  appVersion: "1.0.0",
+  botAiVersion: "2026.07-human-patterns"
+}
+```
+
+### decision_outcomes
+```firestore
+{
+  sessionId: "session_1640995200000",
+  timestamp: timestamp,
+  recordType: "outcome",
+  botId: "bot_1",
+  originalDecision: "discardCard",
+  outcome: "opponent_took_discard",  // or opponent_unlocked | discard_not_taken
+  turnsLater: 0,
+  outcomeContext: {
+    cardRank: "seven",
+    discarderId: "bot_1",
+    takerId: "player_1"
+  },
+  appVersion: "1.0.0",
+  botAiVersion: "2026.07-human-patterns"
 }
 ```
 

--- a/docs/firebase_agent_setup.md
+++ b/docs/firebase_agent_setup.md
@@ -52,11 +52,11 @@ node scripts/query_analytics_session.js --session <sessionId> --turn-summaries -
 
 | Field | Collections | Values |
 |-------|-------------|--------|
-| `appVersion` | all | e.g. `1.0.0` (sync with pubspec.yaml) |
+| `appVersion` | all | e.g. `1.0.0` (from package metadata at runtime) |
 | `botAiVersion` | all | e.g. `2026.07-human-patterns` — bump when bot AI changes |
 | `drawSource` | `game_events`, `bot_decisions` | `deck`, `discard`, `unlock` |
-| `turn_summaries` | per completed turn | `actionCount`, `drawSources`, `meldsCreated`, `discardedRank` |
-| `decision_outcomes` | after discards | `opponent_took_discard`, `opponent_unlocked`, `discard_not_taken` |
+| `actionCount`, `drawSources`, `meldsCreated`, `discardedRank` | `turn_summaries` | per completed turn |
+| `outcome` | `decision_outcomes` | `opponent_took_discard`, `opponent_unlocked`, `discard_not_taken` |
 
 ## Token expiry
 

--- a/docs/firebase_agent_setup.md
+++ b/docs/firebase_agent_setup.md
@@ -36,7 +36,7 @@ dart run scripts/export_analytics.dart --days 7 --include-raw
 
 ## Firestore analytics (important)
 
-Analytics collections (`game_sessions`, `bot_decisions`, `game_events`, `performance_metrics`) are **write-only** from the client SDK. Agents must read via:
+Analytics collections (`game_sessions`, `bot_decisions`, `game_events`, `performance_metrics`, `turn_summaries`, `decision_outcomes`) are **write-only** from the client SDK. Agents must read via:
 
 - OAuth credentials in `.firebase/firebase-tools-credentials.json`, or
 - Firebase MCP after login, or
@@ -45,7 +45,18 @@ Analytics collections (`game_sessions`, `bot_decisions`, `game_events`, `perform
 ```bash
 node scripts/query_analytics_session.js --scores 3325,1140,1185
 node scripts/query_analytics_session.js --session <sessionId> --foot-only
+node scripts/query_analytics_session.js --session <sessionId> --turn-summaries --decision-outcomes
 ```
+
+### New analytics fields (2026 quick wins)
+
+| Field | Collections | Values |
+|-------|-------------|--------|
+| `appVersion` | all | e.g. `1.0.0` (sync with pubspec.yaml) |
+| `botAiVersion` | all | e.g. `2026.07-human-patterns` — bump when bot AI changes |
+| `drawSource` | `game_events`, `bot_decisions` | `deck`, `discard`, `unlock` |
+| `turn_summaries` | per completed turn | `actionCount`, `drawSources`, `meldsCreated`, `discardedRank` |
+| `decision_outcomes` | after discards | `opponent_took_discard`, `opponent_unlocked`, `discard_not_taken` |
 
 ## Token expiry
 

--- a/lib/ai/bot_config.dart
+++ b/lib/ai/bot_config.dart
@@ -230,6 +230,9 @@ class BotConfig {
   /// Protection score to avoid discarding wilds
   static const int wildProtection = 200;
 
+  /// Bump when bot AI logic changes — stored on analytics docs for cross-version analysis.
+  static const String botAiVersion = '2026.07-human-patterns';
+
   // Prevent instantiation
   BotConfig._();
 }

--- a/lib/config/analytics_metadata.dart
+++ b/lib/config/analytics_metadata.dart
@@ -1,7 +1,17 @@
-/// Analytics version metadata — keep [appVersion] in sync with pubspec.yaml.
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Analytics version metadata loaded at runtime from package info.
 class AnalyticsMetadata {
-  /// App version for cross-session analytics (sync with pubspec.yaml `version`).
-  static const String appVersion = '1.0.0';
+  static String? _appVersion;
+
+  /// Loads [appVersion] from the platform package metadata.
+  static Future<void> initialize() async {
+    final info = await PackageInfo.fromPlatform();
+    _appVersion = info.version;
+  }
+
+  /// App version for cross-session analytics.
+  static String get appVersion => _appVersion ?? 'unknown';
 
   AnalyticsMetadata._();
 }

--- a/lib/config/analytics_metadata.dart
+++ b/lib/config/analytics_metadata.dart
@@ -6,8 +6,12 @@ class AnalyticsMetadata {
 
   /// Loads [appVersion] from the platform package metadata.
   static Future<void> initialize() async {
-    final info = await PackageInfo.fromPlatform();
-    _appVersion = info.version;
+    try {
+      final info = await PackageInfo.fromPlatform();
+      _appVersion = info.version;
+    } catch (_) {
+      _appVersion = null;
+    }
   }
 
   /// App version for cross-session analytics.

--- a/lib/config/analytics_metadata.dart
+++ b/lib/config/analytics_metadata.dart
@@ -1,0 +1,7 @@
+/// Analytics version metadata — keep [appVersion] in sync with pubspec.yaml.
+class AnalyticsMetadata {
+  /// App version for cross-session analytics (sync with pubspec.yaml `version`).
+  static const String appVersion = '1.0.0';
+
+  AnalyticsMetadata._();
+}

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -987,7 +987,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       _logHumanAction(
         action: 'unlockDiscardPile',
         reasoning: 'Human unlocked discard pile',
-        context: {'drawSource': 'unlock', 'cardsTaken': cardsBeforeUnlock},
+        context: {'cardsTaken': cardsBeforeUnlock},
       );
     } else {
       debugPrint('DEBUG: unlockDiscardPile returned false unexpectedly');

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -20,6 +20,8 @@ import '../widgets/compact_player_scores.dart';
 import '../widgets/game_action_buttons.dart';
 import '../theme/balatro_theme.dart';
 import '../services/game_analytics_logger.dart';
+import '../services/analytics_batcher.dart';
+import '../services/analytics_fields.dart';
 import 'main_menu_screen.dart';
 import '../utils/debug_logger.dart';
 import 'managers/bot_turn_manager.dart';
@@ -79,6 +81,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
   String? _analyticsSessionId;
   int _totalTurns = 0;
   int _actionSequenceNumber = 0; // Track action sequence within game
+  Map<String, BotPersonality> _sessionBotPersonalities = {};
 
   // Manager instances for better code organization
   late BotTurnManager _botTurnManager;
@@ -218,6 +221,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           final players = ref.read(leaderboardProvider);
           _dialogManager.showGameEndDialog(winner, players);
         }
+        _endAnalyticsSession();
       },
       onRoundEnd: () {
         // Clear UI selections and reset for next round
@@ -598,6 +602,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     DebugLogger.debug('Handling round transition - calculating scores');
 
     try {
+      await _logRoundEndAnalytics();
+
       // Brief pause to show scores
       await Future.delayed(const Duration(seconds: 2));
       if (_disposed || !mounted) {
@@ -974,9 +980,15 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       return;
     }
 
+    final cardsBeforeUnlock = gameState.discardPile.length;
     if (controller.unlockDiscardPile()) {
       // UI will update via Riverpod reactivity when DiscardPileUnlockedEvent fires
       debugPrint('DEBUG: Discard pile unlocked successfully');
+      _logHumanAction(
+        action: 'unlockDiscardPile',
+        reasoning: 'Human unlocked discard pile',
+        context: {'drawSource': 'unlock', 'cardsTaken': cardsBeforeUnlock},
+      );
     } else {
       debugPrint('DEBUG: unlockDiscardPile returned false unexpectedly');
       _dialogManager.showErrorDialog(
@@ -1266,6 +1278,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
               reasoning: 'Human discarded ${_selectedCards.first.compactName}',
               context: {
                 'card': _selectedCards.first.compactName,
+                'cardRank': _selectedCards.first.rank.name,
                 'transitioningToFoot': !humanPlayer.hasPickedUpFoot,
               },
             );
@@ -1320,6 +1333,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           reasoning: 'Human discarded ${_selectedCards.first.compactName}',
           context: {
             'card': _selectedCards.first.compactName,
+            'cardRank': _selectedCards.first.rank.name,
             'goingOut': willBeEmpty,
           },
         );
@@ -2259,6 +2273,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       }
 
       _actionSequenceNumber = 0; // Reset sequence counter for new game
+      _totalTurns = 0;
+      _sessionBotPersonalities = botPersonalities;
       _analyticsSessionId = await GameAnalyticsLogger.startGameSession(
         players: gameState.players,
         gameState: gameState,
@@ -2331,6 +2347,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         eventData: {
           'reasoning': reasoning,
           'context': context,
+          'drawSource': drawSourceFromAction(action),
 
           // Sequencing information
           'actionSequence': _actionSequenceNumber,
@@ -2407,6 +2424,79 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       );
     } catch (e) {
       DebugLogger.warning('Failed to log human action: $e');
+    }
+  }
+
+  /// Log per-bot performance metrics at round end.
+  Future<void> _logRoundEndAnalytics() async {
+    if (_analyticsSessionId == null) {
+      return;
+    }
+
+    try {
+      final controller = _gameController;
+      if (controller == null) {
+        return;
+      }
+
+      final gameState = controller.gameState;
+      final personalities = _sessionBotPersonalities.isNotEmpty
+          ? _sessionBotPersonalities
+          : GameAnalyticsLogger.sessionBotPersonalities;
+
+      for (final player in gameState.players.where(
+        (p) => p.type == PlayerType.bot,
+      )) {
+        final personality = personalities[player.id] ?? BotPersonality.adaptive;
+        await GameAnalyticsLogger.logBotPerformanceMetrics(
+          botId: player.id,
+          personality: personality,
+          gameState: gameState,
+          performanceMetrics: {
+            'roundScore': player.score.toDouble(),
+            'handSize': player.currentHand.length.toDouble(),
+            'meldCount': player.melds.length.toDouble(),
+          },
+        );
+      }
+
+      await AnalyticsBatcher.flushAllBatches();
+    } catch (e) {
+      DebugLogger.warning('Failed to log round-end analytics: $e');
+    }
+  }
+
+  /// End analytics session when the game completes.
+  Future<void> _endAnalyticsSession() async {
+    if (_analyticsSessionId == null) {
+      return;
+    }
+
+    try {
+      final controller = _gameController;
+      final gameState =
+          controller?.gameState ?? ref.read(currentGameStateProvider);
+      if (gameState == null) {
+        return;
+      }
+
+      final winner = ref.read(gameWinnerProvider);
+      final personalities = _sessionBotPersonalities.isNotEmpty
+          ? _sessionBotPersonalities
+          : GameAnalyticsLogger.sessionBotPersonalities;
+
+      await GameAnalyticsLogger.endGameSession(
+        gameState: gameState,
+        winnerId: winner?.id,
+        totalTurns: _totalTurns,
+        botPersonalities: personalities,
+      );
+      await AnalyticsBatcher.flushAllBatches();
+
+      _analyticsSessionId = null;
+      _sessionBotPersonalities = {};
+    } catch (e) {
+      DebugLogger.warning('Failed to end analytics session: $e');
     }
   }
 }

--- a/lib/services/analytics_fields.dart
+++ b/lib/services/analytics_fields.dart
@@ -2,13 +2,23 @@
 String? drawSourceFromAction(String action) {
   switch (action) {
     case 'drawFromDeck':
-      return 'deck';
+    case 'card_drawn':
+      {
+        return 'deck';
+      }
     case 'drawFromDiscard':
-      return 'discard';
+      {
+        return 'discard';
+      }
     case 'unlockDiscardPile':
-      return 'unlock';
+    case 'discard_pile_unlocked':
+      {
+        return 'unlock';
+      }
     default:
-      return null;
+      {
+        return null;
+      }
   }
 }
 
@@ -22,4 +32,11 @@ bool isMeldCreationAction(String action) {
 /// Whether an action/event type represents a discard.
 bool isDiscardAction(String action) {
   return action == 'discardCard';
+}
+
+/// Event-bus events already tracked via human/bot decision logs.
+bool shouldSkipEventBusTurnTracking(String eventType) {
+  return eventType == 'card_drawn' ||
+      eventType == 'meld_created' ||
+      eventType == 'discard_pile_unlocked';
 }

--- a/lib/services/analytics_fields.dart
+++ b/lib/services/analytics_fields.dart
@@ -1,0 +1,25 @@
+/// Normalized analytics field helpers.
+String? drawSourceFromAction(String action) {
+  switch (action) {
+    case 'drawFromDeck':
+      return 'deck';
+    case 'drawFromDiscard':
+      return 'discard';
+    case 'unlockDiscardPile':
+      return 'unlock';
+    default:
+      return null;
+  }
+}
+
+/// Whether an action/event type represents a meld creation.
+bool isMeldCreationAction(String action) {
+  return action == 'createMeld' ||
+      action == 'createMultipleMelds' ||
+      action == 'meld_created';
+}
+
+/// Whether an action/event type represents a discard.
+bool isDiscardAction(String action) {
+  return action == 'discardCard';
+}

--- a/lib/services/analytics_trackers.dart
+++ b/lib/services/analytics_trackers.dart
@@ -1,0 +1,182 @@
+import 'analytics_fields.dart';
+
+/// Tracks per-turn action metrics for [turn_summaries] collection.
+class TurnTracker {
+  int actionCount = 0;
+  final List<String> drawSources = [];
+  int meldsCreated = 0;
+  String? discardedRank;
+  int? handSizeAtEnd;
+  int? round;
+  String? playerId;
+  String? playerType;
+
+  void recordAction({
+    required String playerId,
+    required String action,
+    int? handSize,
+    int? round,
+    String? playerType,
+    String? discardedCardRank,
+  }) {
+    this.playerId = playerId;
+    this.round = round;
+    if (playerType != null) {
+      this.playerType = playerType;
+    }
+    actionCount++;
+    if (handSize != null) {
+      handSizeAtEnd = handSize;
+    }
+
+    final drawSource = drawSourceFromAction(action);
+    if (drawSource != null) {
+      drawSources.add(drawSource);
+    }
+    if (isMeldCreationAction(action)) {
+      meldsCreated++;
+    }
+    if (isDiscardAction(action) && discardedCardRank != null) {
+      discardedRank = discardedCardRank;
+    }
+  }
+
+  Map<String, dynamic> toSummary({
+    required int turnNumber,
+    String? nextPlayerId,
+    String? nextPlayerType,
+  }) {
+    return {
+      'playerId': playerId,
+      'playerType': playerType,
+      'turnNumber': turnNumber,
+      'round': round,
+      'actionCount': actionCount,
+      'drawSources': List<String>.from(drawSources),
+      'meldsCreated': meldsCreated,
+      'discardedRank': discardedRank,
+      'handSizeAtEnd': handSizeAtEnd,
+      'nextPlayerId': nextPlayerId,
+      'nextPlayerType': nextPlayerType,
+    };
+  }
+
+  void reset() {
+    actionCount = 0;
+    drawSources.clear();
+    meldsCreated = 0;
+    discardedRank = null;
+    handSizeAtEnd = null;
+    round = null;
+    playerId = null;
+    playerType = null;
+  }
+}
+
+/// Outcome of resolving a pending discard for [decision_outcomes] collection.
+class DiscardOutcomeResult {
+  final String discarderId;
+  final String outcome;
+  final int turnsLater;
+  final Map<String, dynamic> outcomeContext;
+
+  const DiscardOutcomeResult({
+    required this.discarderId,
+    required this.outcome,
+    required this.turnsLater,
+    required this.outcomeContext,
+  });
+}
+
+/// Tracks pending discards until an opponent takes, unlocks, or passes.
+class DiscardOutcomeTracker {
+  String? discarderId;
+  String? cardRank;
+  int? turnNumber;
+
+  bool get hasPending => discarderId != null && cardRank != null;
+
+  void registerDiscard({
+    required String discarderId,
+    required String cardRank,
+    required int turnNumber,
+  }) {
+    this.discarderId = discarderId;
+    this.cardRank = cardRank;
+    this.turnNumber = turnNumber;
+  }
+
+  DiscardOutcomeResult? onOpponentTookDiscard({
+    required String takerId,
+    required bool fromDeck,
+  }) {
+    if (!hasPending || fromDeck) {
+      return null;
+    }
+    if (takerId == discarderId) {
+      return null;
+    }
+
+    final result = DiscardOutcomeResult(
+      discarderId: discarderId!,
+      outcome: 'opponent_took_discard',
+      turnsLater: 0,
+      outcomeContext: {
+        'cardRank': cardRank,
+        'discarderId': discarderId,
+        'takerId': takerId,
+        'turnNumber': turnNumber,
+      },
+    );
+    clear();
+    return result;
+  }
+
+  DiscardOutcomeResult? onOpponentUnlocked({required String takerId}) {
+    if (!hasPending) {
+      return null;
+    }
+    if (takerId == discarderId) {
+      return null;
+    }
+
+    final result = DiscardOutcomeResult(
+      discarderId: discarderId!,
+      outcome: 'opponent_unlocked',
+      turnsLater: 0,
+      outcomeContext: {
+        'cardRank': cardRank,
+        'discarderId': discarderId,
+        'takerId': takerId,
+        'turnNumber': turnNumber,
+      },
+    );
+    clear();
+    return result;
+  }
+
+  DiscardOutcomeResult? onTurnEndedWithoutTake() {
+    if (!hasPending) {
+      return null;
+    }
+
+    final result = DiscardOutcomeResult(
+      discarderId: discarderId!,
+      outcome: 'discard_not_taken',
+      turnsLater: 1,
+      outcomeContext: {
+        'cardRank': cardRank,
+        'discarderId': discarderId,
+        'turnNumber': turnNumber,
+      },
+    );
+    clear();
+    return result;
+  }
+
+  void clear() {
+    discarderId = null;
+    cardRank = null;
+    turnNumber = null;
+  }
+}

--- a/lib/services/analytics_trackers.dart
+++ b/lib/services/analytics_trackers.dart
@@ -20,7 +20,9 @@ class TurnTracker {
     String? discardedCardRank,
   }) {
     this.playerId = playerId;
-    this.round = round;
+    if (round != null) {
+      this.round = round;
+    }
     if (playerType != null) {
       this.playerType = playerType;
     }
@@ -96,14 +98,21 @@ class DiscardOutcomeTracker {
 
   bool get hasPending => discarderId != null && cardRank != null;
 
-  void registerDiscard({
+  /// Resolves any existing pending discard as not taken before registering anew.
+  DiscardOutcomeResult? registerDiscard({
     required String discarderId,
     required String cardRank,
     required int turnNumber,
   }) {
+    DiscardOutcomeResult? superseded;
+    if (hasPending) {
+      superseded = onTurnEndedWithoutTake();
+    }
+
     this.discarderId = discarderId;
     this.cardRank = cardRank;
     this.turnNumber = turnNumber;
+    return superseded;
   }
 
   DiscardOutcomeResult? onOpponentTookDiscard({

--- a/lib/services/game_analytics_logger.dart
+++ b/lib/services/game_analytics_logger.dart
@@ -67,6 +67,7 @@ class GameAnalyticsLogger {
     bool analyticsEnabled = true,
     bool detailedLoggingEnabled = false,
   }) async {
+    await AnalyticsMetadata.initialize();
     _analyticsEnabled = analyticsEnabled;
     _detailedLoggingEnabled = detailedLoggingEnabled;
 
@@ -344,7 +345,7 @@ class GameAnalyticsLogger {
         turnCompletion: true, // Flush faster on turn completion
       );
 
-      _recordActionForTracking(
+      await _recordActionForTracking(
         playerId: botId,
         action: decision,
         playerType: PlayerType.bot.name,
@@ -413,15 +414,17 @@ class GameAnalyticsLogger {
         sanitizedEventData,
       );
 
-      _recordActionForTracking(
-        playerId: playerId,
-        action: eventType,
-        playerType: playerType?.name,
-        handSize: handSize,
-        round: round,
-        turnNumber: _extractTurnNumberFromEventData(sanitizedEventData),
-        discardedCardRank: discardedCardRank,
-      );
+      if (!shouldSkipEventBusTurnTracking(eventType)) {
+        await _recordActionForTracking(
+          playerId: playerId,
+          action: eventType,
+          playerType: playerType?.name,
+          handSize: handSize,
+          round: round,
+          turnNumber: _extractTurnNumberFromEventData(sanitizedEventData),
+          discardedCardRank: discardedCardRank,
+        );
+      }
 
       if (kDebugMode) {
         _logger.fine('🎯 Logged game event: $eventType for $playerId');
@@ -529,15 +532,20 @@ class GameAnalyticsLogger {
       return;
     }
 
-    final notTaken = _discardTracker.onTurnEndedWithoutTake();
-    if (notTaken != null) {
-      await logDecisionOutcome(
-        botId: notTaken.discarderId,
-        originalDecision: 'discardCard',
-        outcome: notTaken.outcome,
-        turnsLater: notTaken.turnsLater,
-        outcomeContext: notTaken.outcomeContext,
-      );
+    final endingPlayerId = event.player?.id;
+    final isDiscardOwnerTurnEnd =
+        endingPlayerId != null && endingPlayerId == _discardTracker.discarderId;
+    if (_discardTracker.hasPending && !isDiscardOwnerTurnEnd) {
+      final notTaken = _discardTracker.onTurnEndedWithoutTake();
+      if (notTaken != null) {
+        await logDecisionOutcome(
+          botId: notTaken.discarderId,
+          originalDecision: 'discardCard',
+          outcome: notTaken.outcome,
+          turnsLater: notTaken.turnsLater,
+          outcomeContext: notTaken.outcomeContext,
+        );
+      }
     }
 
     await _logTurnSummary(
@@ -640,7 +648,7 @@ class GameAnalyticsLogger {
     }
   }
 
-  static void _recordActionForTracking({
+  static Future<void> _recordActionForTracking({
     required String playerId,
     required String action,
     String? playerType,
@@ -648,7 +656,7 @@ class GameAnalyticsLogger {
     int? round,
     int? turnNumber,
     String? discardedCardRank,
-  }) {
+  }) async {
     _turnTracker.recordAction(
       playerId: playerId,
       action: action,
@@ -659,11 +667,20 @@ class GameAnalyticsLogger {
     );
 
     if (isDiscardAction(action) && discardedCardRank != null) {
-      _discardTracker.registerDiscard(
+      final superseded = _discardTracker.registerDiscard(
         discarderId: playerId,
         cardRank: discardedCardRank,
         turnNumber: turnNumber ?? 0,
       );
+      if (superseded != null) {
+        await logDecisionOutcome(
+          botId: superseded.discarderId,
+          originalDecision: 'discardCard',
+          outcome: superseded.outcome,
+          turnsLater: superseded.turnsLater,
+          outcomeContext: superseded.outcomeContext,
+        );
+      }
     }
   }
 

--- a/lib/services/game_analytics_logger.dart
+++ b/lib/services/game_analytics_logger.dart
@@ -67,9 +67,14 @@ class GameAnalyticsLogger {
     bool analyticsEnabled = true,
     bool detailedLoggingEnabled = false,
   }) async {
-    await AnalyticsMetadata.initialize();
     _analyticsEnabled = analyticsEnabled;
     _detailedLoggingEnabled = detailedLoggingEnabled;
+
+    try {
+      await AnalyticsMetadata.initialize();
+    } catch (e) {
+      _logger.warning('Failed to load app version metadata: $e');
+    }
 
     if (_analyticsEnabled) {
       _logger.info(

--- a/lib/services/game_analytics_logger.dart
+++ b/lib/services/game_analytics_logger.dart
@@ -5,9 +5,14 @@ import 'package:flutter/foundation.dart';
 import '../models/game_state.dart';
 import '../models/player.dart';
 import '../ai/bot_personality.dart';
+import '../ai/bot_config.dart';
+import '../config/analytics_metadata.dart';
+import '../game/events/game_event.dart';
 import 'firebase_service.dart';
 import 'device_service.dart';
 import 'analytics_batcher.dart';
+import 'analytics_fields.dart';
+import 'analytics_trackers.dart';
 
 /// Comprehensive game analytics logging service for bot performance analysis
 class GameAnalyticsLogger {
@@ -36,6 +41,8 @@ class GameAnalyticsLogger {
   static const String botDecisionsCollection = 'bot_decisions';
   static const String gameEventsCollection = 'game_events';
   static const String performanceMetricsCollection = 'performance_metrics';
+  static const String turnSummariesCollection = 'turn_summaries';
+  static const String decisionOutcomesCollection = 'decision_outcomes';
 
   // Privacy settings
   static bool _analyticsEnabled = true;
@@ -44,6 +51,16 @@ class GameAnalyticsLogger {
       false; // Disable reads for write-only mode
   static String? _currentSessionId;
   static DateTime? _sessionStartTime;
+  static Map<String, BotPersonality> _sessionBotPersonalities = {};
+  static final TurnTracker _turnTracker = TurnTracker();
+  static final DiscardOutcomeTracker _discardTracker = DiscardOutcomeTracker();
+
+  static Map<String, dynamic> _versionFields() {
+    return {
+      'appVersion': AnalyticsMetadata.appVersion,
+      'botAiVersion': BotConfig.botAiVersion,
+    };
+  }
 
   /// Initialize analytics logging with privacy controls
   static Future<void> initialize({
@@ -74,6 +91,11 @@ class GameAnalyticsLogger {
       final sessionId = _generateSessionId();
       _currentSessionId = sessionId;
       _sessionStartTime = DateTime.now();
+      _sessionBotPersonalities = Map<String, BotPersonality>.from(
+        botPersonalities ?? {},
+      );
+      _turnTracker.reset();
+      _discardTracker.clear();
 
       // Count bots by personality
       final botPersonalityCount = <String, int>{};
@@ -103,7 +125,7 @@ class GameAnalyticsLogger {
         'initialRound': gameState.round,
         'gameSeed': gameState.deck.seed, // Include seed for reproducibility
         'status': 'active',
-        'version': '1.0.0', // App version for tracking changes over time
+        ..._versionFields(),
       };
 
       final fs = firestore;
@@ -198,9 +220,17 @@ class GameAnalyticsLogger {
 
       _currentSessionId = null;
       _sessionStartTime = null;
+      _sessionBotPersonalities = {};
+      _turnTracker.reset();
+      _discardTracker.clear();
     } catch (e) {
       _logger.warning('Failed to end analytics session: $e');
     }
+  }
+
+  /// Bot personalities for the active session (for round-end metrics).
+  static Map<String, BotPersonality> get sessionBotPersonalities {
+    return Map<String, BotPersonality>.unmodifiable(_sessionBotPersonalities);
   }
 
   /// Log a detailed bot decision for analysis
@@ -227,10 +257,12 @@ class GameAnalyticsLogger {
         'botId': botId,
         'botPersonality': personality.name,
         'decision': decision,
+        'drawSource': drawSourceFromAction(decision),
         'reasoning': reasoning,
         'confidence': confidence,
         'alternativeActions': alternativeActions,
         'riskAssessment': riskAssessment,
+        ..._versionFields(),
 
         // Game context
         'round': gameState.round,
@@ -312,6 +344,19 @@ class GameAnalyticsLogger {
         turnCompletion: true, // Flush faster on turn completion
       );
 
+      _recordActionForTracking(
+        playerId: botId,
+        action: decision,
+        playerType: PlayerType.bot.name,
+        handSize: botPlayer.currentHand.length,
+        round: gameState.round,
+        turnNumber: (decisionContext?['turnNumber'] as num?)?.toInt(),
+        discardedCardRank:
+            isDiscardAction(decision) && gameState.discardPile.isNotEmpty
+            ? gameState.discardPile.last.rank.name
+            : null,
+      );
+
       if (kDebugMode) {
         _logger.fine(
           '🤖 Logged bot decision: $decision for $botId ($personality)',
@@ -346,9 +391,11 @@ class GameAnalyticsLogger {
         'eventType': eventType,
         'playerId': playerId,
         'playerType': playerType?.name,
+        'drawSource': drawSourceFromAction(eventType),
         'success': success,
         'errorMessage': errorMessage,
         'eventData': sanitizedEventData,
+        ..._versionFields(),
       };
 
       // Use batching for game events (high frequency)
@@ -357,6 +404,23 @@ class GameAnalyticsLogger {
         data: eventLogData,
         priority: false, // Game events can be batched
         turnCompletion: true, // Flush faster on turn completion
+      );
+
+      final handSize = _extractHandSizeFromEventData(sanitizedEventData);
+      final round = _extractRoundFromEventData(sanitizedEventData);
+      final discardedCardRank = _extractDiscardedRankFromEventData(
+        eventType,
+        sanitizedEventData,
+      );
+
+      _recordActionForTracking(
+        playerId: playerId,
+        action: eventType,
+        playerType: playerType?.name,
+        handSize: handSize,
+        round: round,
+        turnNumber: _extractTurnNumberFromEventData(sanitizedEventData),
+        discardedCardRank: discardedCardRank,
       );
 
       if (kDebugMode) {
@@ -386,6 +450,7 @@ class GameAnalyticsLogger {
         'botId': botId,
         'personality': personality.name,
         'round': gameState.round,
+        ..._versionFields(),
 
         // Performance metrics
         'metrics': performanceMetrics,
@@ -431,17 +496,19 @@ class GameAnalyticsLogger {
       final outcomeData = {
         'sessionId': _currentSessionId,
         'timestamp': FieldValue.serverTimestamp(),
+        'recordType': 'outcome',
         'botId': botId,
         'originalDecision': originalDecision,
         'outcome': outcome,
         'turnsLater': turnsLater,
         'outcomeScore': outcomeScore,
         'outcomeContext': outcomeContext,
+        ..._versionFields(),
       };
 
       // Use batching for decision outcomes (low frequency but can be batched)
       await AnalyticsBatcher.addToBatch(
-        collection: botDecisionsCollection,
+        collection: decisionOutcomesCollection,
         data: outcomeData,
         priority: false, // Decision outcomes can be batched
       );
@@ -454,6 +521,220 @@ class GameAnalyticsLogger {
     } catch (e) {
       _logger.warning('Failed to log decision outcome: $e');
     }
+  }
+
+  /// Finalize turn analytics: write turn summary and resolve pending discards.
+  static Future<void> finalizeTurn(TurnEndedEvent event) async {
+    if (!_analyticsEnabled || _currentSessionId == null) {
+      return;
+    }
+
+    final notTaken = _discardTracker.onTurnEndedWithoutTake();
+    if (notTaken != null) {
+      await logDecisionOutcome(
+        botId: notTaken.discarderId,
+        originalDecision: 'discardCard',
+        outcome: notTaken.outcome,
+        turnsLater: notTaken.turnsLater,
+        outcomeContext: notTaken.outcomeContext,
+      );
+    }
+
+    await _logTurnSummary(
+      turnNumber: event.turnNumber,
+      player: event.player,
+      nextPlayer: event.nextPlayer,
+    );
+
+    _turnTracker.reset();
+  }
+
+  /// Resolve discard outcomes when an opponent draws from the discard pile.
+  static Future<void> handleCardDrawnForOutcomes(CardDrawnEvent event) async {
+    if (!_analyticsEnabled || _currentSessionId == null) {
+      return;
+    }
+
+    final takerId = event.player?.id;
+    if (takerId == null) {
+      return;
+    }
+
+    final result = _discardTracker.onOpponentTookDiscard(
+      takerId: takerId,
+      fromDeck: event.fromDeck,
+    );
+    if (result != null) {
+      await logDecisionOutcome(
+        botId: result.discarderId,
+        originalDecision: 'discardCard',
+        outcome: result.outcome,
+        turnsLater: result.turnsLater,
+        outcomeContext: result.outcomeContext,
+      );
+    }
+  }
+
+  /// Resolve discard outcomes when an opponent unlocks the discard pile.
+  static Future<void> handleDiscardPileUnlockedForOutcomes(
+    DiscardPileUnlockedEvent event,
+  ) async {
+    if (!_analyticsEnabled || _currentSessionId == null) {
+      return;
+    }
+
+    final takerId = event.player?.id;
+    if (takerId == null) {
+      return;
+    }
+
+    final result = _discardTracker.onOpponentUnlocked(takerId: takerId);
+    if (result != null) {
+      await logDecisionOutcome(
+        botId: result.discarderId,
+        originalDecision: 'discardCard',
+        outcome: result.outcome,
+        turnsLater: result.turnsLater,
+        outcomeContext: result.outcomeContext,
+      );
+    }
+  }
+
+  static Future<void> _logTurnSummary({
+    required int turnNumber,
+    Player? player,
+    Player? nextPlayer,
+  }) async {
+    if (_turnTracker.actionCount == 0 && _turnTracker.playerId == null) {
+      return;
+    }
+
+    try {
+      final summaryData = {
+        'sessionId': _currentSessionId,
+        'timestamp': FieldValue.serverTimestamp(),
+        ..._versionFields(),
+        ..._turnTracker.toSummary(
+          turnNumber: turnNumber,
+          nextPlayerId: nextPlayer?.id,
+          nextPlayerType: nextPlayer?.type.name,
+        ),
+        'playerName': player?.name,
+        'nextPlayerName': nextPlayer?.name,
+      };
+
+      await AnalyticsBatcher.addToBatch(
+        collection: turnSummariesCollection,
+        data: summaryData,
+        priority: false,
+        turnCompletion: true,
+      );
+
+      if (kDebugMode) {
+        _logger.fine(
+          '📋 Logged turn summary: turn $turnNumber for ${player?.name}',
+        );
+      }
+    } catch (e) {
+      _logger.warning('Failed to log turn summary: $e');
+    }
+  }
+
+  static void _recordActionForTracking({
+    required String playerId,
+    required String action,
+    String? playerType,
+    int? handSize,
+    int? round,
+    int? turnNumber,
+    String? discardedCardRank,
+  }) {
+    _turnTracker.recordAction(
+      playerId: playerId,
+      action: action,
+      playerType: playerType,
+      handSize: handSize,
+      round: round,
+      discardedCardRank: discardedCardRank,
+    );
+
+    if (isDiscardAction(action) && discardedCardRank != null) {
+      _discardTracker.registerDiscard(
+        discarderId: playerId,
+        cardRank: discardedCardRank,
+        turnNumber: turnNumber ?? 0,
+      );
+    }
+  }
+
+  static int? _extractHandSizeFromEventData(Map<String, dynamic>? eventData) {
+    if (eventData == null) {
+      return null;
+    }
+    final handSize = eventData['handSize'];
+    if (handSize is int) {
+      return handSize;
+    }
+    if (handSize is num) {
+      return handSize.toInt();
+    }
+    return null;
+  }
+
+  static int? _extractRoundFromEventData(Map<String, dynamic>? eventData) {
+    if (eventData == null) {
+      return null;
+    }
+    final round = eventData['round'];
+    if (round is int) {
+      return round;
+    }
+    if (round is num) {
+      return round.toInt();
+    }
+    return null;
+  }
+
+  static int? _extractTurnNumberFromEventData(Map<String, dynamic>? eventData) {
+    if (eventData == null) {
+      return null;
+    }
+    final turnNumber = eventData['turnNumber'];
+    if (turnNumber is int) {
+      return turnNumber;
+    }
+    if (turnNumber is num) {
+      return turnNumber.toInt();
+    }
+    return null;
+  }
+
+  static String? _extractDiscardedRankFromEventData(
+    String eventType,
+    Map<String, dynamic>? eventData,
+  ) {
+    if (!isDiscardAction(eventType) || eventData == null) {
+      return null;
+    }
+
+    final cardRank = eventData['cardRank'];
+    if (cardRank is String) {
+      return cardRank;
+    }
+
+    final context = eventData['context'];
+    if (context is Map<String, dynamic>) {
+      final contextRank = context['cardRank'];
+      if (contextRank is String) {
+        return contextRank;
+      }
+      final card = context['card'];
+      if (card is String && card.isNotEmpty) {
+        return card.split(' ').first;
+      }
+    }
+
+    return null;
   }
 
   /// Get bot performance analytics (for debugging/development)

--- a/lib/services/game_event_listener.dart
+++ b/lib/services/game_event_listener.dart
@@ -3,6 +3,7 @@ import '../game/events/game_event.dart';
 import '../game/events/game_event_bus.dart';
 import '../utils/debug_logger.dart';
 import 'game_analytics_logger.dart';
+import 'analytics_batcher.dart';
 
 /// Service that listens to game events and handles logging and analytics.
 ///
@@ -38,6 +39,11 @@ class GameEventListener {
     _subscriptions.add(
       _eventBus.subscribeToType<TurnEndedEvent>(_handleTurnEnded),
     );
+    _subscriptions.add(
+      _eventBus.subscribeToType<DiscardPileUnlockedEvent>(
+        _handleDiscardPileUnlocked,
+      ),
+    );
   }
 
   /// Handle any game event for general logging
@@ -51,12 +57,15 @@ class GameEventListener {
   void _handleCardDrawn(CardDrawnEvent event) {
     if (_isDisposed) return;
 
+    GameAnalyticsLogger.handleCardDrawnForOutcomes(event);
+
     GameAnalyticsLogger.logGameEvent(
       eventType: 'card_drawn',
       playerId: event.player?.id ?? 'unknown',
       playerType: event.player?.type,
       eventData: {
         'from_deck': event.fromDeck,
+        'drawSource': event.fromDeck ? 'deck' : 'discard',
         'card_rank': event.card.rank.name,
         'card_suit': event.card.suit?.name ?? 'joker',
         'player_name': event.player?.name ?? 'unknown',
@@ -78,6 +87,25 @@ class GameEventListener {
           0,
           (sum, card) => sum + card.pointValue,
         ),
+        'player_name': event.player?.name ?? 'unknown',
+      },
+    );
+  }
+
+  /// Handle discard pile unlocked events for analytics
+  void _handleDiscardPileUnlocked(DiscardPileUnlockedEvent event) {
+    if (_isDisposed) return;
+
+    GameAnalyticsLogger.handleDiscardPileUnlockedForOutcomes(event);
+
+    GameAnalyticsLogger.logGameEvent(
+      eventType: 'discard_pile_unlocked',
+      playerId: event.player?.id ?? 'unknown',
+      playerType: event.player?.type,
+      eventData: {
+        'drawSource': 'unlock',
+        'cards_taken': event.cardsTaken.length,
+        'card_ranks': event.cardsTaken.map((c) => c.rank.name).toList(),
         'player_name': event.player?.name ?? 'unknown',
       },
     );
@@ -117,7 +145,9 @@ class GameEventListener {
   void _handleTurnEnded(TurnEndedEvent event) {
     if (_isDisposed) return;
 
-    // Could track turn duration, actions per turn, etc.
+    GameAnalyticsLogger.finalizeTurn(event);
+    AnalyticsBatcher.flushOnTurnCompletion();
+
     DebugLogger.debug(
       'Turn ended: ${event.player?.name} -> ${event.nextPlayer?.name ?? "none"}',
     );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import device_info_plus
 import firebase_analytics
 import firebase_auth
 import firebase_core
+import package_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
 
@@ -23,6 +24,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -419,26 +419,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -459,26 +459,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   nm:
     dependency: transitive
     description:
@@ -487,6 +487,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -736,10 +752,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -784,10 +800,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -853,5 +869,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.8.1 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   firebase_auth: ^6.0.1
   firebase_analytics: ^12.0.0
   device_info_plus: ^11.5.0
+  package_info_plus: ^8.3.0
   uuid: ^4.5.1
   connectivity_plus: ^6.1.5
   # 6.3.3+ requires Dart ^3.9.0. Pin 6.3.2 for SDK ^3.8.1 (CI) + FontWeight const fix

--- a/scripts/query_analytics_session.js
+++ b/scripts/query_analytics_session.js
@@ -15,7 +15,15 @@ const PROJECT_ID =
   process.env.FIREBASE_PROJECT_ID || 'hand-foot-game-flutter';
 
 function parseArgs(argv) {
-  const args = { scores: null, session: null, footOnly: false, limit: 5, recent: false };
+  const args = {
+    scores: null,
+    session: null,
+    footOnly: false,
+    limit: 5,
+    recent: false,
+    turnSummaries: false,
+    decisionOutcomes: false,
+  };
   for (let i = 2; i < argv.length; i++) {
     if (argv[i] === '--scores' && argv[i + 1]) {
       args.scores = argv[++i].split(',').map((s) => parseInt(s.trim(), 10));
@@ -27,6 +35,10 @@ function parseArgs(argv) {
       args.limit = parseInt(argv[++i], 10);
     } else if (argv[i] === '--recent') {
       args.recent = true;
+    } else if (argv[i] === '--turn-summaries') {
+      args.turnSummaries = true;
+    } else if (argv[i] === '--decision-outcomes') {
+      args.decisionOutcomes = true;
     }
   }
   return args;
@@ -288,8 +300,10 @@ async function main() {
 
   console.log(`Found ${decisions.length} bot decisions`);
   for (const d of decisions.slice(-args.limit * 10)) {
+    const drawSource = d.drawSource ? ` drawSource=${d.drawSource}` : '';
+    const version = d.botAiVersion ? ` ai=${d.botAiVersion}` : '';
     console.log(
-      `- [R${d.round}] ${d.botId} (${d.botPersonality}): ${d.decision} | foot=${d.botHasPickedUpFoot} hand=${d.botHandSize} books=${d.botBookCount} | ${d.reasoning}`,
+      `- [R${d.round}] ${d.botId} (${d.botPersonality}): ${d.decision}${drawSource}${version} | foot=${d.botHasPickedUpFoot} hand=${d.botHandSize} books=${d.botBookCount} | ${d.reasoning}`,
     );
   }
 
@@ -303,7 +317,46 @@ async function main() {
   events.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
   console.log(`Found ${events.length} game events`);
   for (const e of events.slice(-30)) {
-    console.log(`- ${e.eventType} | ${e.playerId} | ${JSON.stringify(e.eventData || {})}`);
+    const drawSource = e.drawSource ? ` drawSource=${e.drawSource}` : '';
+    console.log(
+      `- ${e.eventType}${drawSource} | ${e.playerId} | ${JSON.stringify(e.eventData || {})}`,
+    );
+  }
+
+  if (args.turnSummaries) {
+    console.log('\nFetching turn_summaries for session...');
+    const turns = await fetchBySessionId(
+      accessToken,
+      'turn_summaries',
+      sessionId,
+      500,
+    );
+    turns.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+    console.log(`Found ${turns.length} turn summaries`);
+    for (const t of turns.slice(-args.limit * 5)) {
+      console.log(
+        `- turn ${t.turnNumber} ${t.playerId} (${t.playerType}): actions=${t.actionCount} melds=${t.meldsCreated} draws=${JSON.stringify(t.drawSources || [])} discard=${t.discardedRank || 'none'}`,
+      );
+    }
+  }
+
+  if (args.decisionOutcomes) {
+    console.log('\nFetching decision_outcomes for session...');
+    const outcomes = await fetchBySessionId(
+      accessToken,
+      'decision_outcomes',
+      sessionId,
+      500,
+    );
+    outcomes.sort((a, b) =>
+      (a.timestamp || '').localeCompare(b.timestamp || ''),
+    );
+    console.log(`Found ${outcomes.length} decision outcomes`);
+    for (const o of outcomes.slice(-args.limit * 5)) {
+      console.log(
+        `- ${o.originalDecision} -> ${o.outcome} (${o.turnsLater} turns) | ${JSON.stringify(o.outcomeContext || {})}`,
+      );
+    }
   }
 }
 

--- a/test/services/analytics_quick_wins_test.dart
+++ b/test/services/analytics_quick_wins_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/services/analytics_fields.dart';
+import 'package:hand_foot_game_flutter/services/analytics_trackers.dart';
+
+void main() {
+  group('drawSourceFromAction', () {
+    test('maps draw actions to normalized drawSource', () {
+      expect(drawSourceFromAction('drawFromDeck'), 'deck');
+      expect(drawSourceFromAction('drawFromDiscard'), 'discard');
+      expect(drawSourceFromAction('unlockDiscardPile'), 'unlock');
+      expect(drawSourceFromAction('discardCard'), isNull);
+    });
+  });
+
+  group('TurnTracker', () {
+    test('accumulates actions and resets on clear', () {
+      final tracker = TurnTracker();
+
+      tracker.recordAction(
+        playerId: 'human_1',
+        action: 'drawFromDeck',
+        handSize: 12,
+        round: 1,
+        playerType: 'human',
+      );
+      tracker.recordAction(
+        playerId: 'human_1',
+        action: 'createMultipleMelds',
+        handSize: 8,
+        round: 1,
+        playerType: 'human',
+      );
+      tracker.recordAction(
+        playerId: 'human_1',
+        action: 'discardCard',
+        handSize: 7,
+        round: 1,
+        playerType: 'human',
+        discardedCardRank: 'five',
+      );
+
+      final summary = tracker.toSummary(
+        turnNumber: 3,
+        nextPlayerId: 'bot_1',
+        nextPlayerType: 'bot',
+      );
+
+      expect(summary['actionCount'], 3);
+      expect(summary['drawSources'], ['deck']);
+      expect(summary['meldsCreated'], 1);
+      expect(summary['discardedRank'], 'five');
+      expect(summary['handSizeAtEnd'], 7);
+      expect(summary['nextPlayerId'], 'bot_1');
+
+      tracker.reset();
+      expect(tracker.actionCount, 0);
+      expect(tracker.drawSources, isEmpty);
+    });
+  });
+
+  group('DiscardOutcomeTracker', () {
+    test('resolves opponent took discard', () {
+      final tracker = DiscardOutcomeTracker();
+      tracker.registerDiscard(
+        discarderId: 'bot_1',
+        cardRank: 'seven',
+        turnNumber: 5,
+      );
+
+      final result = tracker.onOpponentTookDiscard(
+        takerId: 'human_1',
+        fromDeck: false,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.outcome, 'opponent_took_discard');
+      expect(result.turnsLater, 0);
+      expect(result.outcomeContext['takerId'], 'human_1');
+      expect(tracker.hasPending, isFalse);
+    });
+
+    test('resolves opponent unlocked discard pile', () {
+      final tracker = DiscardOutcomeTracker();
+      tracker.registerDiscard(
+        discarderId: 'human_1',
+        cardRank: 'four',
+        turnNumber: 2,
+      );
+
+      final result = tracker.onOpponentUnlocked(takerId: 'bot_2');
+
+      expect(result, isNotNull);
+      expect(result!.outcome, 'opponent_unlocked');
+      expect(tracker.hasPending, isFalse);
+    });
+
+    test('resolves discard not taken on turn end', () {
+      final tracker = DiscardOutcomeTracker();
+      tracker.registerDiscard(
+        discarderId: 'bot_1',
+        cardRank: 'king',
+        turnNumber: 8,
+      );
+
+      final result = tracker.onTurnEndedWithoutTake();
+
+      expect(result, isNotNull);
+      expect(result!.outcome, 'discard_not_taken');
+      expect(result.turnsLater, 1);
+      expect(tracker.hasPending, isFalse);
+    });
+
+    test('ignores same-player discard take', () {
+      final tracker = DiscardOutcomeTracker();
+      tracker.registerDiscard(
+        discarderId: 'bot_1',
+        cardRank: 'ace',
+        turnNumber: 1,
+      );
+
+      final result = tracker.onOpponentTookDiscard(
+        takerId: 'bot_1',
+        fromDeck: false,
+      );
+
+      expect(result, isNull);
+      expect(tracker.hasPending, isTrue);
+    });
+  });
+}

--- a/test/services/analytics_quick_wins_test.dart
+++ b/test/services/analytics_quick_wins_test.dart
@@ -10,6 +10,20 @@ void main() {
       expect(drawSourceFromAction('unlockDiscardPile'), 'unlock');
       expect(drawSourceFromAction('discardCard'), isNull);
     });
+
+    test('maps event-bus action names to normalized drawSource', () {
+      expect(drawSourceFromAction('card_drawn'), 'deck');
+      expect(drawSourceFromAction('discard_pile_unlocked'), 'unlock');
+    });
+  });
+
+  group('shouldSkipEventBusTurnTracking', () {
+    test('skips duplicate event-bus turn metrics', () {
+      expect(shouldSkipEventBusTurnTracking('card_drawn'), isTrue);
+      expect(shouldSkipEventBusTurnTracking('meld_created'), isTrue);
+      expect(shouldSkipEventBusTurnTracking('discard_pile_unlocked'), isTrue);
+      expect(shouldSkipEventBusTurnTracking('player_went_out'), isFalse);
+    });
   });
 
   group('TurnTracker', () {
@@ -55,6 +69,23 @@ void main() {
       tracker.reset();
       expect(tracker.actionCount, 0);
       expect(tracker.drawSources, isEmpty);
+    });
+
+    test('does not clear round when a null round is recorded', () {
+      final tracker = TurnTracker();
+
+      tracker.recordAction(
+        playerId: 'human_1',
+        action: 'drawFromDeck',
+        round: 2,
+      );
+      tracker.recordAction(
+        playerId: 'human_1',
+        action: 'discardCard',
+        round: null,
+      );
+
+      expect(tracker.round, 2);
     });
   });
 
@@ -124,6 +155,28 @@ void main() {
       );
 
       expect(result, isNull);
+      expect(tracker.hasPending, isTrue);
+    });
+
+    test('resolves superseded pending discard before registering anew', () {
+      final tracker = DiscardOutcomeTracker();
+      tracker.registerDiscard(
+        discarderId: 'bot_1',
+        cardRank: 'seven',
+        turnNumber: 3,
+      );
+
+      final superseded = tracker.registerDiscard(
+        discarderId: 'human_1',
+        cardRank: 'queen',
+        turnNumber: 4,
+      );
+
+      expect(superseded, isNotNull);
+      expect(superseded!.outcome, 'discard_not_taken');
+      expect(superseded.outcomeContext['cardRank'], 'seven');
+      expect(tracker.discarderId, 'human_1');
+      expect(tracker.cardRank, 'queen');
       expect(tracker.hasPending, isTrue);
     });
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the five Firestore analytics quick wins to store more useful, queryable gameplay data for human-vs-bot analysis.

## Changes

### Version metadata
- Added `AnalyticsMetadata.appVersion` and `BotConfig.botAiVersion`
- Propagated to `game_sessions`, `game_events`, `bot_decisions`, `turn_summaries`, `decision_outcomes`, and `performance_metrics`

### drawSource + unlock logging
- Normalized `drawSource` (`deck` / `discard` / `unlock`) on human and bot action logs
- Human `unlockDiscardPile` actions are now logged
- `GameEventListener` handles `DiscardPileUnlockedEvent` and enriches `card_drawn` events

### turn_summaries
- New `turn_summaries` collection written on every `TurnEndedEvent`
- Tracks per-turn `actionCount`, `drawSources`, `meldsCreated`, `discardedRank`, and `handSizeAtEnd`

### decision_outcomes
- Moved outcomes to dedicated `decision_outcomes` collection
- Tracks whether opponents took discards, unlocked the pile, or passed (`discard_not_taken`)

### Round/game lifecycle
- `logBotPerformanceMetrics` called at round end (before `nextRound()`)
- `endGameSession` called on game end so sessions are marked `completed`
- Analytics batches flush on turn and round boundaries

## New files
- `lib/config/analytics_metadata.dart`
- `lib/services/analytics_fields.dart`
- `lib/services/analytics_trackers.dart`
- `test/services/analytics_quick_wins_test.dart`

## Query examples

```bash
node scripts/query_analytics_session.js --session <id> --turn-summaries --decision-outcomes
```

## Testing

- `dart format .`
- `flutter analyze` — zero issues
- `flutter test` — full suite passes (including 6 new analytics unit tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f567afcd-69b5-497f-8192-d1e4a3c931ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f567afcd-69b5-497f-8192-d1e4a3c931ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced game analytics with app and bot version metadata.
  * Added turn summaries and decision outcome tracking (including round-end and game-end persistence).
  * Improved analytics capturing for draw sources, meld/discard outcomes, and per-bot personality mapping.
  * Analytics now flushes automatically at turn and game completion.

* **Documentation**
  * Updated analytics schema and setup guide with new collections and added version metadata fields.

* **Tests**
  * Expanded coverage for draw-source mapping, turn summary generation, and discard outcome tracking/resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->