### PR TITLE
Address PR #129 review feedback for analytics quick wins

### DIFF
--- a/docs/firebase_agent_setup.md
+++ b/docs/firebase_agent_setup.md
@@ -52,11 +52,11 @@ node scripts/query_analytics_session.js --session <sessionId> --turn-summaries -
 
 | Field | Collections | Values |
 |-------|-------------|--------|
-| `appVersion` | all | e.g. `1.0.0` (sync with pubspec.yaml) |
+| `appVersion` | all | e.g. `1.0.0` (from package metadata at runtime) |
 | `botAiVersion` | all | e.g. `2026.07-human-patterns` — bump when bot AI changes |
 | `drawSource` | `game_events`, `bot_decisions` | `deck`, `discard`, `unlock` |
-| `turn_summaries` | per completed turn | `actionCount`, `drawSources`, `meldsCreated`, `discardedRank` |
-| `decision_outcomes` | after discards | `opponent_took_discard`, `opponent_unlocked`, `discard_not_taken` |
+| `actionCount`, `drawSources`, `meldsCreated`, `discardedRank` | `turn_summaries` | per completed turn |
+| `outcome` | `decision_outcomes` | `opponent_took_discard`, `opponent_unlocked`, `discard_not_taken` |
 
 ## Token expiry
 

--- a/lib/config/analytics_metadata.dart
+++ b/lib/config/analytics_metadata.dart
@@ -1,7 +1,17 @@
-/// Analytics version metadata — keep [appVersion] in sync with pubspec.yaml.
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Analytics version metadata loaded at runtime from package info.
 class AnalyticsMetadata {
-  /// App version for cross-session analytics (sync with pubspec.yaml `version`).
-  static const String appVersion = '1.0.0';
+  static String? _appVersion;
+
+  /// Loads [appVersion] from the platform package metadata.
+  static Future<void> initialize() async {
+    final info = await PackageInfo.fromPlatform();
+    _appVersion = info.version;
+  }
+
+  /// App version for cross-session analytics.
+  static String get appVersion => _appVersion ?? 'unknown';
 
   AnalyticsMetadata._();
 }

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -987,7 +987,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       _logHumanAction(
         action: 'unlockDiscardPile',
         reasoning: 'Human unlocked discard pile',
-        context: {'drawSource': 'unlock', 'cardsTaken': cardsBeforeUnlock},
+        context: {'cardsTaken': cardsBeforeUnlock},
       );
     } else {
       debugPrint('DEBUG: unlockDiscardPile returned false unexpectedly');

--- a/lib/services/analytics_fields.dart
+++ b/lib/services/analytics_fields.dart
@@ -2,13 +2,23 @@
 String? drawSourceFromAction(String action) {
   switch (action) {
     case 'drawFromDeck':
-      return 'deck';
+    case 'card_drawn':
+      {
+        return 'deck';
+      }
     case 'drawFromDiscard':
-      return 'discard';
+      {
+        return 'discard';
+      }
     case 'unlockDiscardPile':
-      return 'unlock';
+    case 'discard_pile_unlocked':
+      {
+        return 'unlock';
+      }
     default:
-      return null;
+      {
+        return null;
+      }
   }
 }
 
@@ -22,4 +32,11 @@ bool isMeldCreationAction(String action) {
 /// Whether an action/event type represents a discard.
 bool isDiscardAction(String action) {
   return action == 'discardCard';
+}
+
+/// Event-bus events already tracked via human/bot decision logs.
+bool shouldSkipEventBusTurnTracking(String eventType) {
+  return eventType == 'card_drawn' ||
+      eventType == 'meld_created' ||
+      eventType == 'discard_pile_unlocked';
 }

--- a/lib/services/analytics_trackers.dart
+++ b/lib/services/analytics_trackers.dart
@@ -20,7 +20,9 @@ class TurnTracker {
     String? discardedCardRank,
   }) {
     this.playerId = playerId;
-    this.round = round;
+    if (round != null) {
+      this.round = round;
+    }
     if (playerType != null) {
       this.playerType = playerType;
     }
@@ -96,14 +98,21 @@ class DiscardOutcomeTracker {
 
   bool get hasPending => discarderId != null && cardRank != null;
 
-  void registerDiscard({
+  /// Resolves any existing pending discard as not taken before registering anew.
+  DiscardOutcomeResult? registerDiscard({
     required String discarderId,
     required String cardRank,
     required int turnNumber,
   }) {
+    DiscardOutcomeResult? superseded;
+    if (hasPending) {
+      superseded = onTurnEndedWithoutTake();
+    }
+
     this.discarderId = discarderId;
     this.cardRank = cardRank;
     this.turnNumber = turnNumber;
+    return superseded;
   }
 
   DiscardOutcomeResult? onOpponentTookDiscard({

--- a/lib/services/game_analytics_logger.dart
+++ b/lib/services/game_analytics_logger.dart
@@ -67,6 +67,7 @@ class GameAnalyticsLogger {
     bool analyticsEnabled = true,
     bool detailedLoggingEnabled = false,
   }) async {
+    await AnalyticsMetadata.initialize();
     _analyticsEnabled = analyticsEnabled;
     _detailedLoggingEnabled = detailedLoggingEnabled;
 
@@ -344,7 +345,7 @@ class GameAnalyticsLogger {
         turnCompletion: true, // Flush faster on turn completion
       );
 
-      _recordActionForTracking(
+      await _recordActionForTracking(
         playerId: botId,
         action: decision,
         playerType: PlayerType.bot.name,
@@ -413,15 +414,17 @@ class GameAnalyticsLogger {
         sanitizedEventData,
       );
 
-      _recordActionForTracking(
-        playerId: playerId,
-        action: eventType,
-        playerType: playerType?.name,
-        handSize: handSize,
-        round: round,
-        turnNumber: _extractTurnNumberFromEventData(sanitizedEventData),
-        discardedCardRank: discardedCardRank,
-      );
+      if (!shouldSkipEventBusTurnTracking(eventType)) {
+        await _recordActionForTracking(
+          playerId: playerId,
+          action: eventType,
+          playerType: playerType?.name,
+          handSize: handSize,
+          round: round,
+          turnNumber: _extractTurnNumberFromEventData(sanitizedEventData),
+          discardedCardRank: discardedCardRank,
+        );
+      }
 
       if (kDebugMode) {
         _logger.fine('🎯 Logged game event: $eventType for $playerId');
@@ -529,15 +532,20 @@ class GameAnalyticsLogger {
       return;
     }
 
-    final notTaken = _discardTracker.onTurnEndedWithoutTake();
-    if (notTaken != null) {
-      await logDecisionOutcome(
-        botId: notTaken.discarderId,
-        originalDecision: 'discardCard',
-        outcome: notTaken.outcome,
-        turnsLater: notTaken.turnsLater,
-        outcomeContext: notTaken.outcomeContext,
-      );
+    final endingPlayerId = event.player?.id;
+    final isDiscardOwnerTurnEnd =
+        endingPlayerId != null && endingPlayerId == _discardTracker.discarderId;
+    if (_discardTracker.hasPending && !isDiscardOwnerTurnEnd) {
+      final notTaken = _discardTracker.onTurnEndedWithoutTake();
+      if (notTaken != null) {
+        await logDecisionOutcome(
+          botId: notTaken.discarderId,
+          originalDecision: 'discardCard',
+          outcome: notTaken.outcome,
+          turnsLater: notTaken.turnsLater,
+          outcomeContext: notTaken.outcomeContext,
+        );
+      }
     }
 
     await _logTurnSummary(
@@ -640,7 +648,7 @@ class GameAnalyticsLogger {
     }
   }
 
-  static void _recordActionForTracking({
+  static Future<void> _recordActionForTracking({
     required String playerId,
     required String action,
     String? playerType,
@@ -648,7 +656,7 @@ class GameAnalyticsLogger {
     int? round,
     int? turnNumber,
     String? discardedCardRank,
-  }) {
+  }) async {
     _turnTracker.recordAction(
       playerId: playerId,
       action: action,
@@ -659,11 +667,20 @@ class GameAnalyticsLogger {
     );
 
     if (isDiscardAction(action) && discardedCardRank != null) {
-      _discardTracker.registerDiscard(
+      final superseded = _discardTracker.registerDiscard(
         discarderId: playerId,
         cardRank: discardedCardRank,
         turnNumber: turnNumber ?? 0,
       );
+      if (superseded != null) {
+        await logDecisionOutcome(
+          botId: superseded.discarderId,
+          originalDecision: 'discardCard',
+          outcome: superseded.outcome,
+          turnsLater: superseded.turnsLater,
+          outcomeContext: superseded.outcomeContext,
+        );
+      }
     }
   }
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import device_info_plus
 import firebase_analytics
 import firebase_auth
 import firebase_core
+import package_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
 
@@ -23,6 +24,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -419,26 +419,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -459,26 +459,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   nm:
     dependency: transitive
     description:
@@ -487,6 +487,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -736,10 +752,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -784,10 +800,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -853,5 +869,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.8.1 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   firebase_auth: ^6.0.1
   firebase_analytics: ^12.0.0
   device_info_plus: ^11.5.0
+  package_info_plus: ^8.3.0
   uuid: ^4.5.1
   connectivity_plus: ^6.1.5
   # 6.3.3+ requires Dart ^3.9.0. Pin 6.3.2 for SDK ^3.8.1 (CI) + FontWeight const fix

--- a/test/services/analytics_quick_wins_test.dart
+++ b/test/services/analytics_quick_wins_test.dart
@@ -10,6 +10,20 @@ void main() {
       expect(drawSourceFromAction('unlockDiscardPile'), 'unlock');
       expect(drawSourceFromAction('discardCard'), isNull);
     });
+
+    test('maps event-bus action names to normalized drawSource', () {
+      expect(drawSourceFromAction('card_drawn'), 'deck');
+      expect(drawSourceFromAction('discard_pile_unlocked'), 'unlock');
+    });
+  });
+
+  group('shouldSkipEventBusTurnTracking', () {
+    test('skips duplicate event-bus turn metrics', () {
+      expect(shouldSkipEventBusTurnTracking('card_drawn'), isTrue);
+      expect(shouldSkipEventBusTurnTracking('meld_created'), isTrue);
+      expect(shouldSkipEventBusTurnTracking('discard_pile_unlocked'), isTrue);
+      expect(shouldSkipEventBusTurnTracking('player_went_out'), isFalse);
+    });
   });
 
   group('TurnTracker', () {
@@ -55,6 +69,23 @@ void main() {
       tracker.reset();
       expect(tracker.actionCount, 0);
       expect(tracker.drawSources, isEmpty);
+    });
+
+    test('does not clear round when a null round is recorded', () {
+      final tracker = TurnTracker();
+
+      tracker.recordAction(
+        playerId: 'human_1',
+        action: 'drawFromDeck',
+        round: 2,
+      );
+      tracker.recordAction(
+        playerId: 'human_1',
+        action: 'discardCard',
+        round: null,
+      );
+
+      expect(tracker.round, 2);
     });
   });
 
@@ -124,6 +155,28 @@ void main() {
       );
 
       expect(result, isNull);
+      expect(tracker.hasPending, isTrue);
+    });
+
+    test('resolves superseded pending discard before registering anew', () {
+      final tracker = DiscardOutcomeTracker();
+      tracker.registerDiscard(
+        discarderId: 'bot_1',
+        cardRank: 'seven',
+        turnNumber: 3,
+      );
+
+      final superseded = tracker.registerDiscard(
+        discarderId: 'human_1',
+        cardRank: 'queen',
+        turnNumber: 4,
+      );
+
+      expect(superseded, isNotNull);
+      expect(superseded!.outcome, 'discard_not_taken');
+      expect(superseded.outcomeContext['cardRank'], 'seven');
+      expect(tracker.discarderId, 'human_1');
+      expect(tracker.cardRank, 'queen');
       expect(tracker.hasPending, isTrue);
     });
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses review feedback on #129. Each finding was verified against the PR branch; all items were still valid and are fixed here.

### Inline fixes

- **`docs/firebase_agent_setup.md`** — Corrected the analytics table so field names (`actionCount`, `drawSources`, etc. and `outcome`) are in the Field column and collection names (`turn_summaries`, `decision_outcomes`) are in the Collections column.
- **`lib/services/analytics_fields.dart`** — Added `card_drawn` → `deck` and `discard_pile_unlocked` → `unlock` mappings alongside existing camelCase actions; added `shouldSkipEventBusTurnTracking` helper; wrapped switch cases in braces.
- **`lib/services/analytics_trackers.dart`** — Guarded `round` assignment when null (matching `playerType`); `registerDiscard` now resolves a superseded pending discard before registering a new one.
- **`lib/services/game_analytics_logger.dart`** — Skipped `_recordActionForTracking` for `card_drawn`, `meld_created`, and `discard_pile_unlocked` event-bus events to avoid double-counting with human decision logs; deferred `discard_not_taken` resolution until a non-discarder turn boundary so `opponent_took_discard` / `opponent_unlocked` are not cleared early.

### Nitpick fixes

- **`lib/config/analytics_metadata.dart`** — `appVersion` now loaded at runtime via `package_info_plus` (`AnalyticsMetadata.initialize()` called from `GameAnalyticsLogger.initialize()`).
- **`lib/screens/game_screen.dart`** — Removed redundant `drawSource: 'unlock'` from unlock action context (top-level field already derived from action).
- **`lib/services/analytics_trackers.dart`** — Superseded pending discard handling coordinated with `finalizeTurn`.

## Validation

- `dart format .`
- `flutter analyze` — zero issues
- `flutter test` — full suite passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad26a520-97e1-4682-b0d0-a4da7926399e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad26a520-97e1-4682-b0d0-a4da7926399e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

