### PR TITLE
Add session info to game menu for Firestore lookup

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/mobile_status_bar.dart';
 import '../widgets/collapsible_recent_actions.dart';
 import '../widgets/compact_player_scores.dart';
 import '../widgets/game_action_buttons.dart';
+import '../widgets/game_session_info_menu.dart';
 import '../theme/balatro_theme.dart';
 import '../services/game_analytics_logger.dart';
 import '../services/analytics_batcher.dart';
@@ -1723,12 +1724,21 @@ class _GameScreenState extends ConsumerState<GameScreen> {
                     case 'how_to_play':
                       _dialogManager.showHowToPlayDialog();
                       break;
+                    case GameSessionInfoMenu.copyValue:
+                      GameSessionInfoMenu.copyToClipboard(
+                        context,
+                        _soloSessionInfo(gameState),
+                      );
+                      break;
                     case 'main_menu':
                       _returnToMainMenu();
                       break;
                   }
                 },
                 itemBuilder: (BuildContext context) => [
+                  ...GameSessionInfoMenu.buildItems(
+                    _soloSessionInfo(gameState),
+                  ),
                   const PopupMenuItem<String>(
                     value: 'new_game',
                     child: Row(
@@ -2193,6 +2203,13 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           ),
         ),
       ),
+    );
+  }
+
+  GameSessionInfo _soloSessionInfo(GameState gameState) {
+    return GameSessionInfo(
+      analyticsSessionId: _analyticsSessionId,
+      gameSeed: gameState.deck.seed?.toString(),
     );
   }
 

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/mobile_status_bar.dart';
 import '../widgets/collapsible_recent_actions.dart';
 import '../widgets/compact_player_scores.dart';
 import '../widgets/game_action_buttons.dart';
+import '../widgets/game_app_bar.dart';
 import '../widgets/game_session_info_menu.dart';
 import '../theme/balatro_theme.dart';
 import '../services/game_analytics_logger.dart';
@@ -1658,22 +1659,11 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         decoration: const BoxDecoration(gradient: BalatroTheme.primaryGradient),
         child: Scaffold(
           backgroundColor: Colors.transparent,
-          appBar: AppBar(
-            title: ShaderMask(
-              shaderCallback: (bounds) => const LinearGradient(
-                colors: [BalatroTheme.neonPink, BalatroTheme.glowColor],
-              ).createShader(bounds),
-              child: Text(
-                'HAND & FOOT',
-                style: Theme.of(
-                  context,
-                ).textTheme.displayMedium?.copyWith(color: Colors.white),
-              ),
-            ),
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            actions: [
-              // Scoreboard button
+          appBar: GameAppBar(
+            gameState: gameState,
+            isMultiplayer: false,
+            sessionInfo: _soloSessionInfo(gameState),
+            additionalActions: [
               IconButton(
                 icon: const Icon(
                   Icons.leaderboard,
@@ -1684,127 +1674,25 @@ class _GameScreenState extends ConsumerState<GameScreen> {
                   _dialogManager.showScoreboard();
                 },
               ),
-              Container(
-                margin: const EdgeInsets.all(8),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 6,
-                ),
-                decoration: BalatroTheme.glowDecoration(
-                  glowColor: BalatroTheme.neonGreen,
-                  backgroundColor: BalatroTheme.darkPurple,
-                ),
-                child: Text(
-                  'ROUND ${gameState.round}',
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    color: BalatroTheme.neonGreen,
-                  ),
-                ),
-              ),
-              PopupMenuButton<String>(
-                onSelected: (String value) {
-                  switch (value) {
-                    case 'new_game':
-                      _dialogManager.showNewGameConfirmation(_startNewGame);
-                      break;
-                    case 'copy_seed':
-                      _persistenceManager.copySeedToClipboard(context);
-                      break;
-                    case 'export_game':
-                      _persistenceManager.copyGameStateToClipboard(context);
-                      break;
-                    case 'load_game':
-                      _dialogManager.showLoadGameDialog(
-                        (inputText) => _persistenceManager.loadGameFromJson(
-                          inputText,
-                          context,
-                        ),
-                      );
-                      break;
-                    case 'how_to_play':
-                      _dialogManager.showHowToPlayDialog();
-                      break;
-                    case GameSessionInfoMenu.copyValue:
-                      GameSessionInfoMenu.copyToClipboard(
-                        context,
-                        _soloSessionInfo(gameState),
-                      );
-                      break;
-                    case 'main_menu':
-                      _returnToMainMenu();
-                      break;
-                  }
-                },
-                itemBuilder: (BuildContext context) => [
-                  const PopupMenuItem<String>(
-                    value: 'new_game',
-                    child: Row(
-                      children: [
-                        Icon(Icons.refresh, color: Colors.red),
-                        SizedBox(width: 8),
-                        Text('New Game'),
-                      ],
-                    ),
-                  ),
-                  const PopupMenuDivider(),
-                  const PopupMenuItem<String>(
-                    value: 'copy_seed',
-                    child: Row(
-                      children: [
-                        Icon(Icons.copy, color: Colors.orange),
-                        SizedBox(width: 8),
-                        Text('Copy Seed'),
-                      ],
-                    ),
-                  ),
-                  const PopupMenuItem<String>(
-                    value: 'export_game',
-                    child: Row(
-                      children: [
-                        Icon(Icons.download, color: Colors.green),
-                        SizedBox(width: 8),
-                        Text('Export Game'),
-                      ],
-                    ),
-                  ),
-                  const PopupMenuItem<String>(
-                    value: 'load_game',
-                    child: Row(
-                      children: [
-                        Icon(Icons.upload, color: Colors.blue),
-                        SizedBox(width: 8),
-                        Text('Load Game'),
-                      ],
-                    ),
-                  ),
-                  const PopupMenuDivider(),
-                  const PopupMenuItem<String>(
-                    value: 'how_to_play',
-                    child: Row(
-                      children: [
-                        Icon(Icons.help_outline, color: Colors.purple),
-                        SizedBox(width: 8),
-                        Text('How to Play'),
-                      ],
-                    ),
-                  ),
-                  const PopupMenuDivider(),
-                  const PopupMenuItem<String>(
-                    value: 'main_menu',
-                    child: Row(
-                      children: [
-                        Icon(Icons.home, color: BalatroTheme.neonBlue),
-                        SizedBox(width: 8),
-                        Text('Main Menu'),
-                      ],
-                    ),
-                  ),
-                  ...GameSessionInfoMenu.buildItems(
-                    _soloSessionInfo(gameState),
-                  ),
-                ],
-              ),
             ],
+            onNewGame: () {
+              _dialogManager.showNewGameConfirmation(_startNewGame);
+            },
+            onCopySeed: () {
+              _persistenceManager.copySeedToClipboard(context);
+            },
+            onExportGame: () {
+              _persistenceManager.copyGameStateToClipboard(context);
+            },
+            onLoadGame: () {
+              _dialogManager.showLoadGameDialog(
+                (inputText) =>
+                    _persistenceManager.loadGameFromJson(inputText, context),
+              );
+            },
+            onHowToPlay: () {
+              _dialogManager.showHowToPlayDialog();
+            },
           ),
           body: Column(
             children: [
@@ -2208,7 +2096,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
   GameSessionInfo _soloSessionInfo(GameState gameState) {
     return GameSessionInfo(
-      analyticsSessionId: _analyticsSessionId,
+      analyticsSessionId:
+          _analyticsSessionId ?? GameAnalyticsLogger.currentSessionId,
       gameSeed: gameState.deck.seed?.toString(),
     );
   }

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1736,9 +1736,6 @@ class _GameScreenState extends ConsumerState<GameScreen> {
                   }
                 },
                 itemBuilder: (BuildContext context) => [
-                  ...GameSessionInfoMenu.buildItems(
-                    _soloSessionInfo(gameState),
-                  ),
                   const PopupMenuItem<String>(
                     value: 'new_game',
                     child: Row(
@@ -1801,6 +1798,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
                         Text('Main Menu'),
                       ],
                     ),
+                  ),
+                  ...GameSessionInfoMenu.buildItems(
+                    _soloSessionInfo(gameState),
                   ),
                 ],
               ),

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -5,6 +5,7 @@ import '../models/game_state.dart';
 import '../game/enhanced_multiplayer_controller.dart';
 import '../widgets/compact_player_scores.dart';
 import '../widgets/game_app_bar.dart';
+import '../widgets/game_session_info_menu.dart';
 import '../widgets/game_action_buttons.dart';
 import '../widgets/melds_section.dart';
 import '../widgets/collapsible_recent_actions.dart';
@@ -413,6 +414,10 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
               isMultiplayer: true,
               connectionStream: _gameController.connectionStream,
               isOnline: _gameController.isOnline,
+              sessionInfo: GameSessionInfo(
+                gameId: _gameController.gameId,
+                playerId: _gameController.userId,
+              ),
               onLeaveGame: () => Navigator.pop(context),
             ),
             body: Column(

--- a/lib/widgets/game_app_bar.dart
+++ b/lib/widgets/game_app_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../theme/balatro_theme.dart';
 import '../models/game_state.dart';
 import '../screens/main_menu_screen.dart';
+import 'game_session_info_menu.dart';
 
 class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
   final GameState gameState;
@@ -14,6 +15,7 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
   final VoidCallback? onLoadGame;
   final VoidCallback? onHowToPlay;
   final VoidCallback? onLeaveGame;
+  final GameSessionInfo? sessionInfo;
 
   const GameAppBar({
     super.key,
@@ -27,6 +29,7 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.onLoadGame,
     this.onHowToPlay,
     this.onLeaveGame,
+    this.sessionInfo,
   });
 
   @override
@@ -131,12 +134,20 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
               case 'leave_game':
                 onLeaveGame?.call();
                 break;
+              case GameSessionInfoMenu.copyValue:
+                if (sessionInfo != null) {
+                  GameSessionInfoMenu.copyToClipboard(context, sessionInfo!);
+                }
+                break;
               case 'main_menu':
                 _returnToMainMenu(context);
                 break;
             }
           },
           itemBuilder: (BuildContext context) => [
+            if (sessionInfo != null) ...[
+              ...GameSessionInfoMenu.buildItems(sessionInfo!),
+            ],
             if (!isMultiplayer) ...[
               const PopupMenuItem<String>(
                 value: 'new_game',

--- a/lib/widgets/game_app_bar.dart
+++ b/lib/widgets/game_app_bar.dart
@@ -145,9 +145,6 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
             }
           },
           itemBuilder: (BuildContext context) => [
-            if (sessionInfo != null) ...[
-              ...GameSessionInfoMenu.buildItems(sessionInfo!),
-            ],
             if (!isMultiplayer) ...[
               const PopupMenuItem<String>(
                 value: 'new_game',
@@ -225,6 +222,9 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
                 ],
               ),
             ),
+            if (sessionInfo != null) ...[
+              ...GameSessionInfoMenu.buildItems(sessionInfo!),
+            ],
           ],
         ),
       ],

--- a/lib/widgets/game_app_bar.dart
+++ b/lib/widgets/game_app_bar.dart
@@ -16,6 +16,7 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
   final VoidCallback? onHowToPlay;
   final VoidCallback? onLeaveGame;
   final GameSessionInfo? sessionInfo;
+  final List<Widget> additionalActions;
 
   const GameAppBar({
     super.key,
@@ -30,6 +31,7 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.onHowToPlay,
     this.onLeaveGame,
     this.sessionInfo,
+    this.additionalActions = const [],
   });
 
   @override
@@ -54,6 +56,7 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: Colors.transparent,
       elevation: 0,
       actions: [
+        ...additionalActions,
         // Round indicator
         Container(
           margin: const EdgeInsets.all(8),
@@ -222,9 +225,8 @@ class GameAppBar extends StatelessWidget implements PreferredSizeWidget {
                 ],
               ),
             ),
-            if (sessionInfo != null) ...[
+            if (sessionInfo != null)
               ...GameSessionInfoMenu.buildItems(sessionInfo!),
-            ],
           ],
         ),
       ],

--- a/lib/widgets/game_session_info_menu.dart
+++ b/lib/widgets/game_session_info_menu.dart
@@ -62,73 +62,28 @@ class GameSessionInfo {
 /// Shared menu section for session / Firestore lookup info (solo + multiplayer).
 class GameSessionInfoMenu {
   static const String copyValue = 'copy_session_info';
+  static const double _panelWidth = 252;
 
   static List<PopupMenuEntry<String>> buildItems(GameSessionInfo info) {
-    final sessionId =
-        info.analyticsSessionId ?? GameAnalyticsLogger.currentSessionId;
-
     return [
-      const PopupMenuItem<String>(
+      PopupMenuItem<String>(
         enabled: false,
-        height: 28,
-        child: Text(
-          'SESSION INFO',
-          style: TextStyle(
-            fontSize: 10,
-            fontWeight: FontWeight.bold,
-            letterSpacing: 0.8,
-            color: BalatroTheme.neonBlue,
-          ),
-        ),
+        padding: const EdgeInsets.fromLTRB(12, 10, 12, 4),
+        child: _SessionInfoPanel(info: info),
       ),
-      if (info.gameId != null) _infoLine('Game', info.gameId!, monospace: true),
-      if (sessionId != null) _infoLine('Session', _truncate(sessionId)),
-      _infoLine(
-        'App',
-        '${AnalyticsMetadata.appVersion} · ${BotConfig.botAiVersion}',
-      ),
-      if (info.gameSeed != null) _infoLine('Seed', info.gameSeed!),
-      const PopupMenuDivider(),
       const PopupMenuItem<String>(
         value: copyValue,
+        height: 40,
         child: Row(
           children: [
             Icon(Icons.copy_all, color: BalatroTheme.neonBlue, size: 18),
-            SizedBox(width: 8),
-            Text('Copy Session Info'),
+            SizedBox(width: 10),
+            Text('Copy IDs'),
           ],
         ),
       ),
       const PopupMenuDivider(),
     ];
-  }
-
-  static PopupMenuItem<String> _infoLine(
-    String label,
-    String value, {
-    bool monospace = false,
-  }) {
-    return PopupMenuItem<String>(
-      enabled: false,
-      height: 34,
-      child: Text(
-        '$label: $value',
-        style: TextStyle(
-          fontSize: 11,
-          color: Colors.white70,
-          fontFamily: monospace ? 'monospace' : null,
-        ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
-    );
-  }
-
-  static String _truncate(String value, {int maxLength = 22}) {
-    if (value.length <= maxLength) {
-      return value;
-    }
-    return '${value.substring(0, maxLength)}…';
   }
 
   static Future<void> copyToClipboard(
@@ -148,6 +103,98 @@ class GameSessionInfoMenu {
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+}
+
+class _SessionInfoPanel extends StatelessWidget {
+  final GameSessionInfo info;
+
+  const _SessionInfoPanel({required this.info});
+
+  static const TextStyle _labelStyle = TextStyle(
+    fontSize: 10,
+    fontWeight: FontWeight.w600,
+    letterSpacing: 0.4,
+    color: Colors.white38,
+  );
+
+  static const TextStyle _valueStyle = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w600,
+    color: Colors.white,
+    height: 1.25,
+  );
+
+  static const TextStyle _monoValueStyle = TextStyle(
+    fontSize: 10,
+    fontFamily: 'monospace',
+    color: Colors.white70,
+    height: 1.3,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final sessionId =
+        info.analyticsSessionId ?? GameAnalyticsLogger.currentSessionId;
+
+    return SizedBox(
+      width: GameSessionInfoMenu._panelWidth,
+      child: Container(
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.22),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: BalatroTheme.neonBlue.withValues(alpha: 0.22),
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'SUPPORT REFERENCE',
+              style: TextStyle(
+                fontSize: 9,
+                fontWeight: FontWeight.bold,
+                letterSpacing: 1.1,
+                color: BalatroTheme.neonBlue,
+              ),
+            ),
+            const SizedBox(height: 8),
+            if (info.gameId != null) ...[
+              const Text('Game ID', style: _labelStyle),
+              const SizedBox(height: 2),
+              Text(
+                info.gameId!,
+                style: _valueStyle.copyWith(
+                  fontFamily: 'monospace',
+                  fontSize: 18,
+                  color: BalatroTheme.neonGreen,
+                  letterSpacing: 1.5,
+                ),
+              ),
+              const SizedBox(height: 8),
+            ],
+            if (sessionId != null) ...[
+              const Text('Analytics session', style: _labelStyle),
+              const SizedBox(height: 2),
+              Text(
+                sessionId,
+                style: _monoValueStyle,
+                maxLines: 2,
+                softWrap: true,
+              ),
+              const SizedBox(height: 8),
+            ],
+            const Text('Versions', style: _labelStyle),
+            const SizedBox(height: 2),
+            Text('App ${AnalyticsMetadata.appVersion}', style: _valueStyle),
+            Text('Bot ${BotConfig.botAiVersion}', style: _monoValueStyle),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/game_session_info_menu.dart
+++ b/lib/widgets/game_session_info_menu.dart
@@ -66,9 +66,10 @@ class GameSessionInfoMenu {
 
   static List<PopupMenuEntry<String>> buildItems(GameSessionInfo info) {
     return [
+      const PopupMenuDivider(),
       PopupMenuItem<String>(
         enabled: false,
-        padding: const EdgeInsets.fromLTRB(12, 10, 12, 4),
+        padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
         child: _SessionInfoPanel(info: info),
       ),
       const PopupMenuItem<String>(
@@ -82,7 +83,6 @@ class GameSessionInfoMenu {
           ],
         ),
       ),
-      const PopupMenuDivider(),
     ];
   }
 

--- a/lib/widgets/game_session_info_menu.dart
+++ b/lib/widgets/game_session_info_menu.dart
@@ -35,12 +35,10 @@ class GameSessionInfo {
       lines.add('Firestore: ${FirebaseConstants.gamesCollection}/$gameId');
     }
 
-    final sessionId =
-        analyticsSessionId ?? GameAnalyticsLogger.currentSessionId;
-    if (sessionId != null) {
-      lines.add('Session: $sessionId');
+    if (analyticsSessionId != null) {
+      lines.add('Session: $analyticsSessionId');
       lines.add(
-        'Firestore: ${GameAnalyticsLogger.gameSessionsCollection}/$sessionId',
+        'Firestore: ${GameAnalyticsLogger.gameSessionsCollection}/$analyticsSessionId',
       );
     }
 
@@ -136,9 +134,6 @@ class _SessionInfoPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sessionId =
-        info.analyticsSessionId ?? GameAnalyticsLogger.currentSessionId;
-
     return SizedBox(
       width: GameSessionInfoMenu._panelWidth,
       child: Container(
@@ -178,11 +173,11 @@ class _SessionInfoPanel extends StatelessWidget {
               ),
               const SizedBox(height: 8),
             ],
-            if (sessionId != null) ...[
+            if (info.analyticsSessionId != null) ...[
               const Text('Analytics session', style: _labelStyle),
               const SizedBox(height: 2),
               Text(
-                sessionId,
+                info.analyticsSessionId!,
                 style: _monoValueStyle,
                 maxLines: 2,
                 softWrap: true,

--- a/lib/widgets/game_session_info_menu.dart
+++ b/lib/widgets/game_session_info_menu.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../ai/bot_config.dart';
+import '../config/analytics_metadata.dart';
+import '../services/firebase_constants.dart';
+import '../services/game_analytics_logger.dart';
+import '../theme/balatro_theme.dart';
+
+/// Identifiers shown in the game menu for Firestore lookup and support.
+class GameSessionInfo {
+  final String? gameId;
+  final String? analyticsSessionId;
+  final String? gameSeed;
+  final String? playerId;
+
+  const GameSessionInfo({
+    this.gameId,
+    this.analyticsSessionId,
+    this.gameSeed,
+    this.playerId,
+  });
+
+  bool get hasAnyInfo {
+    return gameId != null ||
+        analyticsSessionId != null ||
+        gameSeed != null ||
+        playerId != null;
+  }
+
+  String get clipboardText {
+    final lines = <String>[];
+
+    if (gameId != null) {
+      lines.add('Game ID: $gameId');
+      lines.add('Firestore: ${FirebaseConstants.gamesCollection}/$gameId');
+    }
+
+    final sessionId =
+        analyticsSessionId ?? GameAnalyticsLogger.currentSessionId;
+    if (sessionId != null) {
+      lines.add('Session: $sessionId');
+      lines.add(
+        'Firestore: ${GameAnalyticsLogger.gameSessionsCollection}/$sessionId',
+      );
+    }
+
+    lines.add('App: ${AnalyticsMetadata.appVersion}');
+    lines.add('Bot AI: ${BotConfig.botAiVersion}');
+
+    if (gameSeed != null) {
+      lines.add('Seed: $gameSeed');
+    }
+
+    if (playerId != null) {
+      lines.add('Player: $playerId');
+    }
+
+    return lines.join('\n');
+  }
+}
+
+/// Shared menu section for session / Firestore lookup info (solo + multiplayer).
+class GameSessionInfoMenu {
+  static const String copyValue = 'copy_session_info';
+
+  static List<PopupMenuEntry<String>> buildItems(GameSessionInfo info) {
+    final sessionId =
+        info.analyticsSessionId ?? GameAnalyticsLogger.currentSessionId;
+
+    return [
+      const PopupMenuItem<String>(
+        enabled: false,
+        height: 28,
+        child: Text(
+          'SESSION INFO',
+          style: TextStyle(
+            fontSize: 10,
+            fontWeight: FontWeight.bold,
+            letterSpacing: 0.8,
+            color: BalatroTheme.neonBlue,
+          ),
+        ),
+      ),
+      if (info.gameId != null) _infoLine('Game', info.gameId!, monospace: true),
+      if (sessionId != null) _infoLine('Session', _truncate(sessionId)),
+      _infoLine(
+        'App',
+        '${AnalyticsMetadata.appVersion} · ${BotConfig.botAiVersion}',
+      ),
+      if (info.gameSeed != null) _infoLine('Seed', info.gameSeed!),
+      const PopupMenuDivider(),
+      const PopupMenuItem<String>(
+        value: copyValue,
+        child: Row(
+          children: [
+            Icon(Icons.copy_all, color: BalatroTheme.neonBlue, size: 18),
+            SizedBox(width: 8),
+            Text('Copy Session Info'),
+          ],
+        ),
+      ),
+      const PopupMenuDivider(),
+    ];
+  }
+
+  static PopupMenuItem<String> _infoLine(
+    String label,
+    String value, {
+    bool monospace = false,
+  }) {
+    return PopupMenuItem<String>(
+      enabled: false,
+      height: 34,
+      child: Text(
+        '$label: $value',
+        style: TextStyle(
+          fontSize: 11,
+          color: Colors.white70,
+          fontFamily: monospace ? 'monospace' : null,
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  static String _truncate(String value, {int maxLength = 22}) {
+    if (value.length <= maxLength) {
+      return value;
+    }
+    return '${value.substring(0, maxLength)}…';
+  }
+
+  static Future<void> copyToClipboard(
+    BuildContext context,
+    GameSessionInfo info,
+  ) async {
+    await Clipboard.setData(ClipboardData(text: info.clipboardText));
+
+    if (!context.mounted) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: const Text('Session info copied to clipboard'),
+        backgroundColor: BalatroTheme.neonBlue,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+}

--- a/test/widgets/game_session_info_menu_test.dart
+++ b/test/widgets/game_session_info_menu_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/widgets/game_session_info_menu.dart';
+
+void main() {
+  group('GameSessionInfo', () {
+    test('clipboardText includes multiplayer game Firestore path', () {
+      const info = GameSessionInfo(gameId: 'ABCD', playerId: 'device-123');
+
+      final text = info.clipboardText;
+
+      expect(text, contains('Game ID: ABCD'));
+      expect(text, contains('Firestore: games/ABCD'));
+      expect(text, contains('Player: device-123'));
+      expect(text, contains('App:'));
+      expect(text, contains('Bot AI:'));
+    });
+
+    test('clipboardText includes solo session and seed', () {
+      const info = GameSessionInfo(
+        analyticsSessionId: 'session_1234567890',
+        gameSeed: '42',
+      );
+
+      final text = info.clipboardText;
+
+      expect(text, contains('Session: session_1234567890'));
+      expect(text, contains('Firestore: game_sessions/session_1234567890'));
+      expect(text, contains('Seed: 42'));
+    });
+  });
+}

--- a/test/widgets/game_session_info_menu_test.dart
+++ b/test/widgets/game_session_info_menu_test.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/widgets/game_session_info_menu.dart';
 
@@ -27,5 +29,102 @@ void main() {
       expect(text, contains('Firestore: game_sessions/session_1234567890'));
       expect(text, contains('Seed: 42'));
     });
+
+    test('clipboardText omits session when analyticsSessionId is null', () {
+      const info = GameSessionInfo(gameSeed: '42');
+
+      final text = info.clipboardText;
+
+      expect(text, isNot(contains('Session:')));
+      expect(text, isNot(contains('game_sessions/')));
+    });
   });
+
+  group('GameSessionInfoMenu', () {
+    String? clipboardText;
+
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      clipboardText = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (
+            MethodCall methodCall,
+          ) async {
+            if (methodCall.method == 'Clipboard.setData') {
+              clipboardText = methodCall.arguments['text'] as String;
+            }
+            return null;
+          });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    testWidgets('shows session labels and copies clipboardText on Copy IDs', (
+      WidgetTester tester,
+    ) async {
+      const info = GameSessionInfo(
+        analyticsSessionId: 'session_test_123',
+        gameSeed: '99',
+      );
+      await tester.pumpWidget(_TestMenuHost(info: info));
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(find.text('SUPPORT REFERENCE'), findsOneWidget);
+      expect(find.text('Analytics session'), findsOneWidget);
+      expect(find.text('session_test_123'), findsOneWidget);
+      expect(find.text('Versions'), findsOneWidget);
+      expect(find.text('Copy IDs'), findsOneWidget);
+
+      await tester.tap(find.text('Copy IDs'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, info.clipboardText);
+    });
+  });
+}
+
+class _TestMenuHost extends StatefulWidget {
+  final GameSessionInfo info;
+
+  const _TestMenuHost({required this.info});
+
+  @override
+  State<_TestMenuHost> createState() => _TestMenuHostState();
+}
+
+class _TestMenuHostState extends State<_TestMenuHost> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        key: _scaffoldKey,
+        appBar: AppBar(
+          actions: [
+            PopupMenuButton<String>(
+              onSelected: (String value) {
+                if (value == GameSessionInfoMenu.copyValue) {
+                  final scaffoldContext = _scaffoldKey.currentContext;
+                  if (scaffoldContext != null) {
+                    GameSessionInfoMenu.copyToClipboard(
+                      scaffoldContext,
+                      widget.info,
+                    );
+                  }
+                }
+              },
+              itemBuilder: (BuildContext context) => [
+                ...GameSessionInfoMenu.buildItems(widget.info),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Support Reference** card at the top of the in-game menu (⋮) for both solo and multiplayer, so players and support can quickly identify the Firestore document for the current game.

### Solo play
- Analytics **session ID** (`game_sessions/{sessionId}`) — wraps to two lines instead of truncating
- **App** and **bot AI** versions on separate lines
- **Copy IDs** copies all fields plus Firestore paths (seed included in clipboard only)

### Multiplayer
- **Game ID** (`games/{gameId}`) — large monospace display
- App/bot versions
- Player ID included in clipboard copy

## UI
- Single bordered card panel instead of multiple cramped disabled menu rows
- Clear label/value hierarchy with proper padding

## Test plan

- [x] `dart format .`
- [x] `flutter analyze` (zero issues)
- [x] `flutter test test/widgets/game_session_info_menu_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e37d1b9-8959-4bad-865d-74c1c66af5bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e37d1b9-8959-4bad-865d-74c1c66af5bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-game support reference panel in the app bar with session/game/player/seed details.
  * Added a “Copy IDs” option that copies the displayed reference info to the clipboard.
  * Added confirmation feedback after copying.
* **Bug Fixes**
  * Improved app bar integration so the session reference menu and extra actions are presented consistently.
* **Tests**
  * Added tests covering solo and multiplayer reference formatting and clipboard copy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->