### PR TITLE
Fix aggressive bot stalling on hand pile near foot transition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,32 @@ This is a Flutter (Dart) app — the **Hand & Foot** card game with AI bots and 
 - **Analytics queries:** `node scripts/query_analytics_session.js --scores 3325,1140,1185 --foot-only` (analytics collections are client write-only; OAuth required to read).
 - Without Firebase credentials, solo vs. bots still works — sufficient for core gameplay.
 
+### Investigating game data (use Firebase MCP)
+
+When a user asks about a **session**, **bot behavior**, **foot transitions**, **scores**, or other **production analytics**, use **Firebase MCP first** — do not guess from code alone.
+
+1. **Check MCP is ready** — `GetMcpTools` with server `Firebase`. If status is `loading`, wait and retry.
+2. **Authenticate / set project**
+   - `firebase_get_environment` — confirm `Authenticated User` and `Active Project ID`
+   - If unauthenticated: `firebase_login` (user pastes auth code), then `firebase_update_environment` with `project_dir: /workspace` and `active_project: <FIREBASE_PROJECT_ID>`
+   - If Cloud Agent injected `FIREBASE_TOOLS_CREDENTIALS_JSON`, copy it to `~/.config/configstore/firebase-tools.json`, then run `./scripts/refresh_firebase_agent_credentials.sh`
+3. **Query Firestore analytics** (preferred script after MCP auth):
+
+```bash
+node scripts/query_analytics_session.js --session <sessionId> --turn-summaries --decision-outcomes
+node scripts/query_analytics_session.js --session <sessionId> --foot-only
+node scripts/query_analytics_session.js --scores 3325,1140,1185
+```
+
+4. **Collections to use**
+   - `game_sessions` — seed, players, final scores, `botPerformance.hasPickedUpFoot`
+   - `bot_decisions` — per-turn AI choices, hand size, foot status, reasoning
+   - `game_events` / `turn_summaries` — turn-by-turn state snapshots
+
+5. **Repro hints** — `gameSeed` + `botAiVersion` on session docs allow correlating analytics with deterministic local tests.
+
+See `docs/firebase_agent_setup.md` and `docs/analytics_guide.md` for full details. Never commit or paste OAuth tokens, `.env`, or credential JSON.
+
 ### Testing
 - `flutter test` runs the full unit/widget suite (~750 tests) and passes headlessly with no extra setup. Tests skip Firebase automatically under `FLUTTER_TEST`.
 - `flutter analyze` must be clean (zero issues) — the repo enforces this.

--- a/lib/ai/bot_config.dart
+++ b/lib/ai/bot_config.dart
@@ -40,6 +40,9 @@ class BotConfig {
   /// Never stall on hand pile at or below this size — melt or discard to foot
   static const int handToFootCriticalHandSize = 4;
 
+  /// Extra hand-size margin for aggressive bots racing foot under opponent pressure
+  static const int handToFootRushAggressiveOpponentPressureMargin = 2;
+
   /// Emergency at this large hand size
   static const int largeHandEmergencyThreshold = 10;
 

--- a/lib/ai/bot_config.dart
+++ b/lib/ai/bot_config.dart
@@ -31,6 +31,15 @@ class BotConfig {
   /// Emergency transition at this card count
   static const int emergencyTransitionThreshold = 8;
 
+  /// Rush hand→foot when any opponent is on foot and hand is at or below this size
+  static const int handToFootRushOpponentOnFootThreshold = 8;
+
+  /// Aggressive bots rush hand→foot at or below this size even without opponent pressure
+  static const int handToFootRushAggressiveThreshold = 6;
+
+  /// Never stall on hand pile at or below this size — melt or discard to foot
+  static const int handToFootCriticalHandSize = 4;
+
   /// Emergency at this large hand size
   static const int largeHandEmergencyThreshold = 10;
 
@@ -251,7 +260,7 @@ class BotConfig {
   static const int humanLowRankDiscardBonus = 25;
 
   /// Bump when bot AI logic changes — stored on analytics docs for cross-version analysis.
-  static const String botAiVersion = '2026.07-human-patterns';
+  static const String botAiVersion = '2026.07-hand-foot-rush';
 
   // Prevent instantiation
   BotConfig._();

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -2146,56 +2146,134 @@ class EnhancedBotAI {
   /// Check if bot can play ALL cards to immediately transition to foot
   BotDecision? _checkCanPlayAllCards(Player bot, BotGameContext context) {
     final handSize = bot.currentHand.length;
-    if (handSize == 0) return null;
+    if (handSize == 0) {
+      return null;
+    }
 
-    // Get all cards we can potentially play
-    final possibleMelds = _getCachedPossibleMelds(bot, context);
     final controller = context.controller as GameController?;
-    if (controller == null) return null;
-    final cardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
-      bot,
-      controller,
-    );
-
-    // Calculate total playable cards
-    int totalPlayableCards = 0;
-    Set<PlayingCard> usedCards = {};
-
-    // Count cards that can be added to existing melds
-    for (final addition in cardsToAdd) {
-      final card = addition['card'] as PlayingCard;
-      if (!usedCards.contains(card)) {
-        usedCards.add(card);
-        totalPlayableCards++;
-      }
+    if (controller == null) {
+      return null;
     }
 
-    // Count cards that can form new melds (avoiding double-counting)
-    for (final meld in possibleMelds) {
-      int newCardsInMeld = 0;
-      for (final card in meld) {
-        if (!usedCards.contains(card)) {
-          usedCards.add(card);
-          newCardsInMeld++;
-        }
-      }
-      totalPlayableCards += newCardsInMeld;
-    }
-
-    // If we can play ALL cards, execute the strategy
-    if (totalPlayableCards >= handSize) {
-      // Prioritize adding to existing melds first
+    if (handSize == 1) {
+      final cardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
+        bot,
+        controller,
+      );
       if (cardsToAdd.isNotEmpty) {
         return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
       }
-      // Then create new melds
-      if (possibleMelds.isNotEmpty) {
-        final bestMeld = _meldAnalyzer.findBestMeld(possibleMelds, bot: bot);
-        return BotDecision(action: 'createMeld', data: bestMeld);
+    }
+
+    final meldIndexPlan = _findCompleteHandMeldIndexPlan(bot);
+    if (meldIndexPlan == null) {
+      return null;
+    }
+
+    final meldCards = meldIndexPlan
+        .map(
+          (indices) => indices.map((index) => bot.currentHand[index]).toList(),
+        )
+        .toList();
+
+    if (meldCards.length == 1) {
+      return BotDecision(action: 'createMeld', data: meldCards.first);
+    }
+
+    return BotDecision(action: 'createMultipleMelds', data: meldCards);
+  }
+
+  /// Builds index-based new-meld candidates, preserving duplicate-deck cards.
+  List<List<int>> _buildNewMeldIndexCandidates(Player bot) {
+    final hand = bot.currentHand;
+    final cardsByRank = <CardRank, List<int>>{};
+    final wildIndices = <int>[];
+
+    for (int i = 0; i < hand.length; i++) {
+      final card = hand[i];
+      if (card.isWild) {
+        wildIndices.add(i);
+      } else if (card.rank != CardRank.three) {
+        cardsByRank.putIfAbsent(card.rank, () => []).add(i);
       }
     }
 
-    return null;
+    final candidates = <List<int>>[];
+    for (final entry in cardsByRank.entries) {
+      final naturalIndices = entry.value;
+      if (naturalIndices.length >= GameConfig.minTotalCardsForMeld) {
+        candidates.add(List<int>.from(naturalIndices));
+        continue;
+      }
+
+      if (naturalIndices.length >= GameConfig.minNaturalCardsForMeld &&
+          wildIndices.isNotEmpty) {
+        final wildsNeeded =
+            GameConfig.minTotalCardsForMeld - naturalIndices.length;
+        final availableWilds = wildIndices.take(wildsNeeded).toList();
+        if (availableWilds.length == wildsNeeded) {
+          candidates.add([...naturalIndices, ...availableWilds]);
+        }
+      }
+    }
+
+    return candidates;
+  }
+
+  /// Returns disjoint meld index groups that consume the entire hand, if any.
+  List<List<int>>? _findCompleteHandMeldIndexPlan(Player bot) {
+    final handSize = bot.currentHand.length;
+    if (handSize == 0) {
+      return null;
+    }
+
+    final candidates = _buildNewMeldIndexCandidates(bot);
+    if (candidates.isEmpty) {
+      return null;
+    }
+
+    final usedIndices = <int>{};
+    final selectedMelds = <List<int>>[];
+    List<List<int>>? completePlan;
+
+    bool search(int candidateStart) {
+      if (usedIndices.length == handSize) {
+        completePlan = selectedMelds
+            .map((indices) => List<int>.from(indices))
+            .toList();
+        return true;
+      }
+
+      for (int i = candidateStart; i < candidates.length; i++) {
+        final meldIndices = candidates[i];
+        if (meldIndices.any(usedIndices.contains)) {
+          continue;
+        }
+
+        final cards = meldIndices
+            .map((index) => bot.currentHand[index])
+            .toList();
+        if (Meld.createMeld(cards) == null) {
+          continue;
+        }
+
+        selectedMelds.add(meldIndices);
+        usedIndices.addAll(meldIndices);
+        if (search(i + 1)) {
+          return true;
+        }
+        usedIndices.removeAll(meldIndices);
+        selectedMelds.removeLast();
+      }
+
+      return false;
+    }
+
+    if (!search(0)) {
+      return null;
+    }
+
+    return completePlan;
   }
 
   /// True when the bot should melt its hand pile down to pick up foot urgently.

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -518,6 +518,12 @@ class EnhancedBotAI {
       return BotDecision(action: 'noMeld');
     }
 
+    // PRIORITY 0a: Rush hand pile → foot before opponents go out
+    final handToFootRush = _makeHandToFootRushDecision(bot, context);
+    if (handToFootRush != null) {
+      return handToFootRush;
+    }
+
     // PRIORITY 0b: Foot phase — melt large hands and complete book pairs (all personalities)
     final footPhaseDecision = _handleFootPhaseMeldDecision(bot, context);
     if (footPhaseDecision != null) {
@@ -638,7 +644,10 @@ class EnhancedBotAI {
 
     // Human pattern: burst-meld at 15+ before foot-transition discard paths
     if (_shouldExecuteDumpStrategy(bot, context)) {
-      return _executeDumpStrategy(bot, context);
+      final dumpDecision = _executeDumpStrategy(bot, context);
+      if (dumpDecision.action != 'noMeld') {
+        return dumpDecision;
+      }
     }
 
     // Check for foot transition decisions
@@ -1785,6 +1794,17 @@ class EnhancedBotAI {
     // Don't hold if hand exceeds personality-based limit (adjusted for time pressure)
     if (handSize >= personalityHoldingLimit) return false;
 
+    // Never hold a tiny hand pile — finish the transition
+    if (!bot.hasPickedUpFoot) {
+      if (handSize <= BotConfig.handToFootCriticalHandSize) {
+        return false;
+      }
+      if (personality == BotPersonality.aggressive &&
+          handSize <= BotConfig.handToFootRushAggressiveThreshold) {
+        return false;
+      }
+    }
+
     // Race to foot when opponents are already on foot (human-style tempo play)
     if (_opponentOnFootPressure(context, bot) && !bot.hasPickedUpFoot) {
       return false;
@@ -1897,6 +1917,31 @@ class EnhancedBotAI {
     if (stillOnHandPile && wildCards.isNotEmpty && handSize <= 10) {
       // If we have wilds and are close to foot, dump everything we can
       if (dumpPotential >= 0.5) return true; // Even lower threshold with wilds
+    }
+
+    final personality = _personalityManager.getPersonality(bot.id);
+
+    // Never stall on a tiny hand pile
+    if (stillOnHandPile && handSize <= BotConfig.handToFootCriticalHandSize) {
+      return true;
+    }
+
+    // Opponent on foot — race to pick up foot before they go out
+    if (stillOnHandPile &&
+        _opponentOnFootPressure(context, bot) &&
+        handSize <= BotConfig.handToFootRushOpponentOnFootThreshold) {
+      return true;
+    }
+
+    // Aggressive bots transition earlier, especially under foot pressure
+    if (stillOnHandPile && personality == BotPersonality.aggressive) {
+      if (handSize <= BotConfig.handToFootRushAggressiveThreshold) {
+        return true;
+      }
+      if (_opponentOnFootPressure(context, bot) &&
+          handSize <= BotConfig.handToFootRushOpponentOnFootThreshold + 2) {
+        return true;
+      }
     }
 
     // Execute if we can go directly to foot
@@ -2144,6 +2189,100 @@ class EnhancedBotAI {
         final bestMeld = _meldAnalyzer.findBestMeld(possibleMelds, bot: bot);
         return BotDecision(action: 'createMeld', data: bestMeld);
       }
+    }
+
+    return null;
+  }
+
+  /// True when the bot should melt its hand pile down to pick up foot urgently.
+  bool _shouldRushHandToFoot(Player bot, BotGameContext context) {
+    if (!bot.hasPlayedDown || bot.hasPickedUpFoot) {
+      return false;
+    }
+
+    final handSize = bot.currentHand.length;
+    if (handSize == 0) {
+      return false;
+    }
+
+    if (handSize <= BotConfig.handToFootCriticalHandSize) {
+      return true;
+    }
+
+    if (_opponentOnFootPressure(context, bot) &&
+        handSize <= BotConfig.handToFootRushOpponentOnFootThreshold) {
+      return true;
+    }
+
+    final personality = _personalityManager.getPersonality(bot.id);
+    if (personality == BotPersonality.aggressive) {
+      if (handSize <= BotConfig.handToFootRushAggressiveThreshold) {
+        return true;
+      }
+      if (_opponentOnFootPressure(context, bot) &&
+          handSize <= BotConfig.handToFootRushOpponentOnFootThreshold + 2) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Melt the hand pile aggressively to reach foot before opponents go out.
+  BotDecision? _makeHandToFootRushDecision(Player bot, BotGameContext context) {
+    if (!_shouldRushHandToFoot(bot, context)) {
+      return null;
+    }
+
+    DebugLogger.botDebug(
+      bot.id,
+      bot.name,
+      'RUSH HAND→FOOT with ${bot.currentHand.length} cards',
+    );
+
+    final playAllDecision = _checkCanPlayAllCards(bot, context);
+    if (playAllDecision != null) {
+      return playAllDecision;
+    }
+
+    if (_shouldExecuteDumpStrategy(bot, context)) {
+      final dumpDecision = _executeDumpStrategy(bot, context);
+      if (dumpDecision.action != 'noMeld') {
+        return dumpDecision;
+      }
+    }
+
+    final controller = context.controller as GameController?;
+    if (controller == null) {
+      return null;
+    }
+
+    final cardsToAdd = _filterWildCardAdditions(
+      _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
+      bot,
+    );
+    if (cardsToAdd.isNotEmpty) {
+      return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+    }
+
+    final possibleMelds = _getCachedPossibleMelds(bot, context);
+    if (possibleMelds.isNotEmpty) {
+      return BotDecision(
+        action: 'createMeld',
+        data: _meldAnalyzer.findBestMeld(
+          possibleMelds,
+          bot: bot,
+          preferLarger: true,
+        ),
+      );
+    }
+
+    final footTransition = _footTransitionManager.handleFootTransition(
+      bot,
+      controller,
+    );
+    if (footTransition != null) {
+      return footTransition;
     }
 
     return null;

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import '../models/player.dart';
 import '../models/card.dart';
 import '../models/meld.dart';
@@ -1939,7 +1941,9 @@ class EnhancedBotAI {
         return true;
       }
       if (_opponentOnFootPressure(context, bot) &&
-          handSize <= BotConfig.handToFootRushOpponentOnFootThreshold + 2) {
+          handSize <=
+              BotConfig.handToFootRushOpponentOnFootThreshold +
+                  BotConfig.handToFootRushAggressiveOpponentPressureMargin) {
         return true;
       }
     }
@@ -2220,7 +2224,9 @@ class EnhancedBotAI {
         return true;
       }
       if (_opponentOnFootPressure(context, bot) &&
-          handSize <= BotConfig.handToFootRushOpponentOnFootThreshold + 2) {
+          handSize <=
+              BotConfig.handToFootRushOpponentOnFootThreshold +
+                  BotConfig.handToFootRushAggressiveOpponentPressureMargin) {
         return true;
       }
     }
@@ -3509,6 +3515,17 @@ class EnhancedBotAI {
   }
 
   // Getters for testing and debugging
+
+  @visibleForTesting
+  bool shouldRushHandToFoot(Player bot, BotGameContext context) {
+    return _shouldRushHandToFoot(bot, context);
+  }
+
+  @visibleForTesting
+  BotDecision? makeHandToFootRushDecision(Player bot, BotGameContext context) {
+    return _makeHandToFootRushDecision(bot, context);
+  }
+
   Map<String, OpponentAnalysis> get opponentAnalysis =>
       _gameAnalyzer.opponentAnalysis;
   BotPersonalityManager get personalityManager => _personalityManager;

--- a/test/ai/aggressive_hand_to_foot_rush_test.dart
+++ b/test/ai/aggressive_hand_to_foot_rush_test.dart
@@ -163,6 +163,38 @@ void main() {
           );
         },
       );
+
+      test(
+        'aggressive with opponent on foot rushes at margin threshold but not above',
+        () {
+          final rushAtMargin =
+              BotConfig.handToFootRushOpponentOnFootThreshold +
+              BotConfig.handToFootRushAggressiveOpponentPressureMargin;
+
+          configureBot(
+            personality: BotPersonality.aggressive,
+            handSize: rushAtMargin,
+            opponentOnFoot: true,
+          );
+          expect(
+            botAI.shouldRushHandToFoot(bot, context()),
+            isTrue,
+            reason:
+                'aggressive bots should rush at opponent margin $rushAtMargin',
+          );
+
+          configureBot(
+            personality: BotPersonality.aggressive,
+            handSize: rushAtMargin + 1,
+            opponentOnFoot: true,
+          );
+          expect(
+            botAI.shouldRushHandToFoot(bot, context()),
+            isFalse,
+            reason: 'aggressive bots should not rush above opponent margin',
+          );
+        },
+      );
     });
 
     group('makeHandToFootRushDecision', () {
@@ -222,6 +254,32 @@ void main() {
         configureBot(
           personality: BotPersonality.aggressive,
           handSize: BotConfig.handToFootRushAggressiveThreshold + 1,
+        );
+        expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+      });
+
+      test('aggressive opponent margin returns rush discard at 10 only', () {
+        final rushAtMargin =
+            BotConfig.handToFootRushOpponentOnFootThreshold +
+            BotConfig.handToFootRushAggressiveOpponentPressureMargin;
+
+        configureBot(
+          personality: BotPersonality.aggressive,
+          handSize: rushAtMargin,
+          opponentOnFoot: true,
+        );
+
+        final rushAtThreshold = botAI.makeHandToFootRushDecision(
+          bot,
+          context(),
+        );
+        expect(rushAtThreshold, isNotNull);
+        expect(rushAtThreshold!.action, equals('discard'));
+
+        configureBot(
+          personality: BotPersonality.aggressive,
+          handSize: rushAtMargin + 1,
+          opponentOnFoot: true,
         );
         expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
       });

--- a/test/ai/aggressive_hand_to_foot_rush_test.dart
+++ b/test/ai/aggressive_hand_to_foot_rush_test.dart
@@ -1,11 +1,14 @@
+@Tags(['aggressive_hand_to_foot_rush'])
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/ai/bot_config.dart';
+import 'package:hand_foot_game_flutter/ai/bot_game_context.dart';
 import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
 import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
 import 'package:hand_foot_game_flutter/game/game_controller.dart';
 import 'package:hand_foot_game_flutter/models/card.dart';
 import 'package:hand_foot_game_flutter/models/game_state.dart';
-import 'package:hand_foot_game_flutter/models/meld.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 
 void main() {
@@ -13,126 +16,315 @@ void main() {
     late EnhancedBotAI botAI;
     late GameController gameController;
     late Player human;
-    late Player bob;
+    late Player bot;
+
+    const unmeldedRanks = <CardRank>[
+      CardRank.four,
+      CardRank.five,
+      CardRank.six,
+      CardRank.seven,
+      CardRank.eight,
+      CardRank.nine,
+      CardRank.ten,
+      CardRank.jack,
+      CardRank.queen,
+      CardRank.ace,
+    ];
+
+    const unmeldedSuits = <Suit>[
+      Suit.hearts,
+      Suit.spades,
+      Suit.clubs,
+      Suit.diamonds,
+    ];
+
+    List<PlayingCard> unmeldedHand(int count) {
+      return List<PlayingCard>.generate(
+        count,
+        (index) => PlayingCard(
+          suit: unmeldedSuits[index % unmeldedSuits.length],
+          rank: unmeldedRanks[index % unmeldedRanks.length],
+        ),
+      );
+    }
+
+    void setOpponentOnFoot({required int footCardCount}) {
+      human.hasPickedUpFoot = true;
+      human.dealFoot(unmeldedHand(footCardCount));
+    }
+
+    void configureBot({
+      required BotPersonality personality,
+      required int handSize,
+      bool opponentOnFoot = false,
+      int opponentFootCards = 7,
+    }) {
+      botAI.assignPersonality(bot.id, personality);
+      bot.hand.clear();
+      bot.melds.clear();
+      bot.hand.addAll(unmeldedHand(handSize));
+      bot.hasPlayedDown = true;
+      bot.hasPickedUpFoot = false;
+      human.hasPickedUpFoot = false;
+      human.foot.clear();
+      if (opponentOnFoot) {
+        setOpponentOnFoot(footCardCount: opponentFootCards);
+      }
+      gameController.gameState.currentPlayerIndex = 1;
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+    }
+
+    BotGameContext context() =>
+        BotGameContext(gameController.gameState, gameController);
 
     setUp(() {
       botAI = EnhancedBotAI(seed: 577904);
       human = Player(id: 'human', name: 'You', type: PlayerType.human);
-      bob = Player(id: 'bob', name: 'Bob', type: PlayerType.bot);
-      gameController = GameController(players: [human, bob], seed: 577904);
+      bot = Player(id: 'bot', name: 'Bot', type: PlayerType.bot);
+      gameController = GameController(players: [human, bot], seed: 577904);
       gameController.initializeGame();
-      botAI.assignPersonality(bob.id, BotPersonality.aggressive);
-      bob.hasPlayedDown = true;
-      gameController.gameState.currentPlayerIndex = 1;
-      gameController.gameState.turnPhase = TurnPhase.meld;
-      gameController.gameState.hasDrawnFromDeck = true;
     });
 
-    test('melds instead of holding when opponent is on foot with 7 cards', () {
-      human.hasPickedUpFoot = true;
-      human.dealFoot([
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
-        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
-        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
-        const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
-        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
-        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
-      ]);
+    group('shouldRushHandToFoot boundaries', () {
+      test('critical hand size rushes at 4 but not 5', () {
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootCriticalHandSize,
+        );
+        expect(
+          botAI.shouldRushHandToFoot(bot, context()),
+          isTrue,
+          reason:
+              'critical threshold should rush at ${BotConfig.handToFootCriticalHandSize}',
+        );
 
-      bob.hand.clear();
-      bob.hand.addAll([
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
-        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
-        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
-        const PlayingCard(suit: Suit.diamonds, rank: CardRank.four),
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
-        const PlayingCard(suit: Suit.spades, rank: CardRank.five),
-        const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
-      ]);
-      bob.melds.add(
-        Meld.createMeld([
-          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
-          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
-          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
-        ])!,
-      );
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootCriticalHandSize + 1,
+        );
+        expect(
+          botAI.shouldRushHandToFoot(bot, context()),
+          isFalse,
+          reason:
+              'critical threshold should not rush above ${BotConfig.handToFootCriticalHandSize}',
+        );
+      });
 
-      expect(bob.currentHand.length, 7);
-      expect(human.hasPickedUpFoot, isTrue);
+      test('opponent-on-foot pressure rushes at 8 but not 9', () {
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootRushOpponentOnFootThreshold,
+          opponentOnFoot: true,
+        );
+        expect(
+          botAI.shouldRushHandToFoot(bot, context()),
+          isTrue,
+          reason:
+              'opponent foot pressure should rush at ${BotConfig.handToFootRushOpponentOnFootThreshold}',
+        );
 
-      final decision = botAI.makeDecision(bob, gameController);
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootRushOpponentOnFootThreshold + 1,
+          opponentOnFoot: true,
+        );
+        expect(
+          botAI.shouldRushHandToFoot(bot, context()),
+          isFalse,
+          reason:
+              'opponent foot pressure should not rush above ${BotConfig.handToFootRushOpponentOnFootThreshold}',
+        );
+      });
 
-      expect(decision.action, isNot('noMeld'));
-      expect(
-        decision.action,
-        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+      test(
+        'aggressive personality rushes at 6 but not 7 without opponent pressure',
+        () {
+          configureBot(
+            personality: BotPersonality.aggressive,
+            handSize: BotConfig.handToFootRushAggressiveThreshold,
+          );
+          expect(
+            botAI.shouldRushHandToFoot(bot, context()),
+            isTrue,
+            reason:
+                'aggressive bots should rush at ${BotConfig.handToFootRushAggressiveThreshold}',
+          );
+
+          configureBot(
+            personality: BotPersonality.aggressive,
+            handSize: BotConfig.handToFootRushAggressiveThreshold + 1,
+          );
+          expect(
+            botAI.shouldRushHandToFoot(bot, context()),
+            isFalse,
+            reason:
+                'aggressive bots should not rush above ${BotConfig.handToFootRushAggressiveThreshold} without pressure',
+          );
+        },
       );
     });
 
-    test('melds aggressively with 3 cards when opponent is on foot', () {
-      human.hasPickedUpFoot = true;
-      human.dealFoot([
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
-        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
-        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
-        const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
-        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
-      ]);
+    group('makeHandToFootRushDecision', () {
+      test('returns discard rush action below threshold, null above', () {
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootCriticalHandSize,
+        );
 
-      bob.hand.clear();
-      bob.hand.addAll([
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
-        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
-        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
-      ]);
-      bob.melds.add(
-        Meld.createMeld([
-          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
-          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
-          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
-        ])!,
-      );
+        final rushDecision = botAI.makeHandToFootRushDecision(bot, context());
+        expect(rushDecision, isNotNull);
+        expect(rushDecision!.action, equals('discard'));
+        expect(rushDecision.data, isA<PlayingCard>());
 
-      final decision = botAI.makeDecision(bob, gameController);
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootCriticalHandSize + 1,
+        );
+        expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+      });
 
-      expect(decision.action, isNot('noMeld'));
-      expect(
-        decision.action,
-        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
-      );
+      test('opponent pressure boundary returns rush discard at 8 only', () {
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootRushOpponentOnFootThreshold,
+          opponentOnFoot: true,
+        );
+
+        final rushAtThreshold = botAI.makeHandToFootRushDecision(
+          bot,
+          context(),
+        );
+        expect(rushAtThreshold, isNotNull);
+        expect(rushAtThreshold!.action, equals('discard'));
+
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootRushOpponentOnFootThreshold + 1,
+          opponentOnFoot: true,
+        );
+        expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+      });
+
+      test('aggressive boundary returns rush discard at 6 only', () {
+        configureBot(
+          personality: BotPersonality.aggressive,
+          handSize: BotConfig.handToFootRushAggressiveThreshold,
+        );
+
+        final rushAtThreshold = botAI.makeHandToFootRushDecision(
+          bot,
+          context(),
+        );
+        expect(rushAtThreshold, isNotNull);
+        expect(rushAtThreshold!.action, equals('discard'));
+
+        configureBot(
+          personality: BotPersonality.aggressive,
+          handSize: BotConfig.handToFootRushAggressiveThreshold + 1,
+        );
+        expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+      });
     });
 
-    test('aggressive bot with 5 cards melds without opponent on foot', () {
-      bob.hand.clear();
-      bob.hand.addAll([
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
-        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
-        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
-        const PlayingCard(suit: Suit.diamonds, rank: CardRank.four),
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
-      ]);
-      bob.melds.add(
-        Meld.createMeld([
-          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
-          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
-          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
-        ])!,
+    group('makeDecision integration', () {
+      test('uses hand-to-foot rush below opponent threshold, not above', () {
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootRushOpponentOnFootThreshold,
+          opponentOnFoot: true,
+        );
+
+        expect(botAI.makeHandToFootRushDecision(bot, context()), isNotNull);
+        final belowThresholdDecision = botAI.makeDecision(bot, gameController);
+        expect(belowThresholdDecision.action, equals('discard'));
+        expect(belowThresholdDecision.data, isA<PlayingCard>());
+
+        configureBot(
+          personality: BotPersonality.conservative,
+          handSize: BotConfig.handToFootRushOpponentOnFootThreshold + 1,
+          opponentOnFoot: true,
+        );
+
+        final aboveThresholdDecision = botAI.makeDecision(bot, gameController);
+        expect(
+          botAI.makeHandToFootRushDecision(bot, context()),
+          isNull,
+          reason: 'rush hook must be inactive above opponent threshold',
+        );
+        expect(
+          aboveThresholdDecision.action,
+          isNot('noMeld'),
+          reason: 'foot transition may still act above rush threshold',
+        );
+      });
+
+      test(
+        'aggressive bot rushes via makeDecision at 6 but rush hook is null at 7',
+        () {
+          configureBot(
+            personality: BotPersonality.aggressive,
+            handSize: BotConfig.handToFootRushAggressiveThreshold,
+          );
+
+          expect(botAI.makeHandToFootRushDecision(bot, context()), isNotNull);
+          final belowThresholdDecision = botAI.makeDecision(
+            bot,
+            gameController,
+          );
+          expect(belowThresholdDecision.action, equals('discard'));
+
+          configureBot(
+            personality: BotPersonality.aggressive,
+            handSize: BotConfig.handToFootRushAggressiveThreshold + 1,
+          );
+
+          expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+          final aboveThresholdDecision = botAI.makeDecision(
+            bot,
+            gameController,
+          );
+          expect(
+            aboveThresholdDecision.action,
+            isNot('noMeld'),
+            reason:
+                'foot transition may still discard above aggressive rush threshold',
+          );
+        },
       );
 
-      expect(bob.currentHand.length, 5);
-      expect(
-        bob.currentHand.length,
-        lessThanOrEqualTo(BotConfig.handToFootRushAggressiveThreshold),
-      );
+      test(
+        'critical hand rushes via makeDecision at 4 but rush hook is null at 5',
+        () {
+          configureBot(
+            personality: BotPersonality.conservative,
+            handSize: BotConfig.handToFootCriticalHandSize,
+          );
 
-      final decision = botAI.makeDecision(bob, gameController);
+          expect(botAI.makeHandToFootRushDecision(bot, context()), isNotNull);
+          final belowThresholdDecision = botAI.makeDecision(
+            bot,
+            gameController,
+          );
+          expect(belowThresholdDecision.action, equals('discard'));
 
-      expect(decision.action, isNot('noMeld'));
-      expect(
-        decision.action,
-        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+          configureBot(
+            personality: BotPersonality.conservative,
+            handSize: BotConfig.handToFootCriticalHandSize + 1,
+          );
+
+          expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+          final aboveThresholdDecision = botAI.makeDecision(
+            bot,
+            gameController,
+          );
+          expect(
+            aboveThresholdDecision.action,
+            isNot('noMeld'),
+            reason:
+                'foot transition may still discard above critical rush threshold',
+          );
+        },
       );
     });
   });

--- a/test/ai/aggressive_hand_to_foot_rush_test.dart
+++ b/test/ai/aggressive_hand_to_foot_rush_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_config.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Aggressive hand-to-foot rush', () {
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player human;
+    late Player bob;
+
+    setUp(() {
+      botAI = EnhancedBotAI(seed: 577904);
+      human = Player(id: 'human', name: 'You', type: PlayerType.human);
+      bob = Player(id: 'bob', name: 'Bob', type: PlayerType.bot);
+      gameController = GameController(players: [human, bob], seed: 577904);
+      gameController.initializeGame();
+      botAI.assignPersonality(bob.id, BotPersonality.aggressive);
+      bob.hasPlayedDown = true;
+      gameController.gameState.currentPlayerIndex = 1;
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+    });
+
+    test('melds instead of holding when opponent is on foot with 7 cards', () {
+      human.hasPickedUpFoot = true;
+      human.dealFoot([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+      ]);
+
+      bob.hand.clear();
+      bob.hand.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.four),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+      ]);
+      bob.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+      );
+
+      expect(bob.currentHand.length, 7);
+      expect(human.hasPickedUpFoot, isTrue);
+
+      final decision = botAI.makeDecision(bob, gameController);
+
+      expect(decision.action, isNot('noMeld'));
+      expect(
+        decision.action,
+        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+      );
+    });
+
+    test('melds aggressively with 3 cards when opponent is on foot', () {
+      human.hasPickedUpFoot = true;
+      human.dealFoot([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+      ]);
+
+      bob.hand.clear();
+      bob.hand.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+      ]);
+      bob.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+      );
+
+      final decision = botAI.makeDecision(bob, gameController);
+
+      expect(decision.action, isNot('noMeld'));
+      expect(
+        decision.action,
+        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+      );
+    });
+
+    test('aggressive bot with 5 cards melds without opponent on foot', () {
+      bob.hand.clear();
+      bob.hand.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.four),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+      ]);
+      bob.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+      );
+
+      expect(bob.currentHand.length, 5);
+      expect(
+        bob.currentHand.length,
+        lessThanOrEqualTo(BotConfig.handToFootRushAggressiveThreshold),
+      );
+
+      final decision = botAI.makeDecision(bob, gameController);
+
+      expect(decision.action, isNot('noMeld'));
+      expect(
+        decision.action,
+        anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
+      );
+    });
+  });
+}

--- a/test/ai/bot_wild_card_strategy_test.dart
+++ b/test/ai/bot_wild_card_strategy_test.dart
@@ -186,11 +186,16 @@ void main() {
         // Make decision
         final decision = botAI.makeDecision(botPlayer, gameController);
 
-        // Should create melds to clear hand
+        // Should create melds to clear the entire hand
         expect(
           decision.action,
-          equals('createMeld'),
-          reason: 'Bot should create melds with all cards to see foot',
+          equals('createMultipleMelds'),
+          reason: 'Bot should meld all cards to see foot',
+        );
+        final melds = decision.data as List<List<PlayingCard>>;
+        expect(
+          melds.expand((meld) => meld).length,
+          equals(botPlayer.currentHand.length),
         );
       });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes aggressive bots stalling on a small hand pile when opponents are already on foot, and hardens hand→foot "play all" meld planning for multi-deck hands.

## Changes

### Bot AI (`botAiVersion`: `2026.07-hand-foot-rush`)

- Hand-to-foot rush thresholds + aggressive opponent pressure margin constant
- `@visibleForTesting` rush hooks for boundary tests
- **`_checkCanPlayAllCards`** now builds disjoint hand-index meld plans and only returns when the entire hand is consumed (`createMeld` / `createMultipleMelds` / single-card `addToMeld`)

### Tests

- Boundary tests: critical 4/5, opponent 8/9, aggressive 6/7, aggressive+opponent 10/11
- Updated wild-card play-all test for `createMultipleMelds`

### Docs

- `AGENTS.md` — Firebase MCP workflow for investigating game data

## Validation

- `dart format .` — clean
- `flutter analyze lib test` — zero issues
- `flutter test` — 808 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a7cf1cb-de62-4059-81cc-6a4d5eade0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a7cf1cb-de62-4059-81cc-6a4d5eade0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Gameplay Improvements**
  * Enhanced bot strategy for hand-to-foot “rush” transitions, prioritizing rush decisions during the meld phase.
  * Improved responsiveness to opponents on foot, including tighter aggressive behavior and critical small-hand safeguards.
  * Updated bot AI version to the new hand-to-foot rush tuning.

* **Tests**
  * Added new test coverage for hand-to-foot rush thresholds and decision integration across conservative and aggressive scenarios.

* **Documentation**
  * Expanded analytics/reproducibility guidance in `AGENTS.md`, including when to use Firebase MCP and preferred queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->