### PR TITLE
Fix Alex bot stuck without clean book when trying to go out

### DIFF
--- a/lib/ai/bot_end_game_manager.dart
+++ b/lib/ai/bot_end_game_manager.dart
@@ -244,10 +244,31 @@ class BotEndGameManager {
       }
     }
 
-    // Aggressive go-out under competitive pressure
+    // Missing a required book type — build the clean/dirty pair before shrinking hand
+    if (!bot.canGoOutWithBooks) {
+      final incompleteBookDecision = _handleIncompleteBookRequirements(
+        bot,
+        controller,
+        gameState.turnPhase,
+      );
+      if (incompleteBookDecision != null) {
+        return incompleteBookDecision;
+      }
+      // Dirty books but no clean book: never discard into an empty-hand trap
+      if (gameState.turnPhase == TurnPhase.discard &&
+          bot.currentHand.length <= 1 &&
+          bot.hasDirtyBook &&
+          !bot.hasCleanBook) {
+        return null;
+      }
+    }
+
+    // Aggressive go-out under competitive pressure (only when books are valid)
     if (_shouldGoOutAggressively(bot, gameState)) {
       final goOutDecision = _attemptAggressiveGoOut(bot, controller);
-      if (goOutDecision != null) return goOutDecision;
+      if (goOutDecision != null) {
+        return goOutDecision;
+      }
     }
 
     // Check if bot is in winning position (has required books and few cards)
@@ -518,7 +539,11 @@ class BotEndGameManager {
       }
     }
 
-    // Priority 2: Complete dirty books if no clean books possible
+    // Priority 2: Complete dirty books only when a clean book already exists
+    if (!bot.hasCleanBook) {
+      return null;
+    }
+
     for (int i = 0; i < bot.melds.length; i++) {
       final meld = bot.melds[i];
       if (meld.cards.length == 6 && !meld.isClean) {
@@ -549,10 +574,18 @@ class BotEndGameManager {
     Map<String, dynamic>? bestAddition;
     int bestScore = -1;
 
+    final needsCleanBook = !bot.hasCleanBook && bot.hasDirtyBook;
+
     for (final addition in cardsToAdd) {
       final meldIndex = addition['meldIndex'] as int;
       final meld = bot.melds[meldIndex];
       final card = addition['card'] as PlayingCard;
+
+      if (needsCleanBook) {
+        if (!meld.isClean || card.isWild) {
+          continue;
+        }
+      }
 
       // Base score on meld progress toward book status
       int score = meld.cards.length;
@@ -681,8 +714,80 @@ class BotEndGameManager {
     return sortedHand.first;
   }
 
+  /// Build toward the missing clean or dirty book before attempting to go out.
+  BotDecision? _handleIncompleteBookRequirements(
+    Player bot,
+    GameController controller,
+    TurnPhase turnPhase,
+  ) {
+    if (turnPhase != TurnPhase.meld) {
+      return null;
+    }
+
+    final needsClean = !bot.hasCleanBook;
+    final needsDirty = !bot.hasDirtyBook;
+    if (!needsClean && !needsDirty) {
+      return null;
+    }
+
+    if (needsClean) {
+      for (int i = 0; i < bot.melds.length; i++) {
+        final meld = bot.melds[i];
+        if (meld.isClean && meld.cards.length < BotConfig.bookSize) {
+          for (final card in bot.currentHand) {
+            if (!card.isWild && _canAddCardToMeld(card, meld)) {
+              return BotDecision(
+                action: 'addToMeld',
+                data: {'meldIndex': i, 'card': card},
+              );
+            }
+          }
+        }
+      }
+
+      final cleanMelds = controller
+          .findPossibleMelds(bot)
+          .where((meld) => !meld.any((card) => card.isWild))
+          .toList();
+      if (cleanMelds.isNotEmpty) {
+        return BotDecision(
+          action: 'createMeld',
+          data: _findBestBookPotentialMeld(cleanMelds),
+        );
+      }
+    }
+
+    if (needsDirty) {
+      final cardsToAdd = _findCardsToAddToExistingMelds(bot, controller);
+      for (final addition in cardsToAdd) {
+        final meldIndex = addition['meldIndex'] as int;
+        final meld = bot.melds[meldIndex];
+        if (!meld.isClean && meld.cards.length < BotConfig.bookSize) {
+          return BotDecision(action: 'addToMeld', data: addition);
+        }
+      }
+
+      final dirtyMelds = controller
+          .findPossibleMelds(bot)
+          .where((meld) => meld.any((card) => card.isWild))
+          .toList();
+      if (dirtyMelds.isNotEmpty) {
+        return BotDecision(
+          action: 'createMeld',
+          data: _findBestBookPotentialMeld(dirtyMelds),
+        );
+      }
+    }
+
+    return null;
+  }
+
   /// NEW: Check if bot should go out aggressively under pressure
   bool _shouldGoOutAggressively(Player bot, dynamic gameState) {
+    if (!bot.canGoOutWithBooks) {
+      return false;
+    }
+
     // Get human players
     final humanPlayers = gameState.players.where(
       (p) => p.type == PlayerType.human,
@@ -744,20 +849,21 @@ class BotEndGameManager {
       }
     }
 
-    // If we're close to books, try to complete them aggressively
-    if ((cleanBooks > 0 || dirtyBooks > 0) && bot.currentHand.length <= 3) {
-      // Try to complete the missing book type
+    // If we're close to books, try to complete the missing book type
+    if (cleanBooks > 0 || dirtyBooks > 0) {
       final needsClean = cleanBooks == 0;
       final needsDirty = dirtyBooks == 0;
+      final minMeldSize = needsClean && dirtyBooks > 0 ? 3 : 5;
 
       for (int i = 0; i < bot.melds.length; i++) {
         final meld = bot.melds[i];
-        if (meld.cards.length >= 5) {
-          // Near book - try to complete it
+        if (meld.cards.length >= minMeldSize &&
+            meld.cards.length < BotConfig.bookSize) {
           if ((needsClean && meld.isClean) || (needsDirty && !meld.isClean)) {
-            final addableCards = bot.currentHand.where(
-              (card) => meld.canAddCard(card),
-            );
+            final addableCards = bot.currentHand
+                .where((card) => meld.canAddCard(card))
+                .where((card) => needsClean ? !card.isWild : true)
+                .toList();
             if (addableCards.isNotEmpty) {
               return BotDecision(
                 action: 'addToMeld',
@@ -765,6 +871,19 @@ class BotEndGameManager {
               );
             }
           }
+        }
+      }
+
+      if (needsClean) {
+        final cleanMelds = controller
+            .findPossibleMelds(bot)
+            .where((meld) => !meld.any((card) => card.isWild))
+            .toList();
+        if (cleanMelds.isNotEmpty) {
+          return BotDecision(
+            action: 'createMeld',
+            data: _findBestBookPotentialMeld(cleanMelds),
+          );
         }
       }
     }

--- a/lib/ai/bot_end_game_manager.dart
+++ b/lib/ai/bot_end_game_manager.dart
@@ -22,6 +22,78 @@ class BotEndGameManager {
   BotEndGameManager({BotMeldAnalyzer? meldAnalyzer})
     : _meldAnalyzer = meldAnalyzer ?? BotMeldAnalyzer();
 
+  /// True when a meld would leave one card while the bot still cannot go out.
+  static bool leavesUnfinishableSingleCard(
+    Player bot, {
+    required int cardsRemoved,
+    Meld? projectedMeld,
+  }) {
+    if (!bot.hasPickedUpFoot || bot.canGoOutWithBooks) {
+      return false;
+    }
+
+    final remaining = bot.currentHand.length - cardsRemoved;
+    if (remaining != 1) {
+      return false;
+    }
+
+    final willHaveClean =
+        bot.hasCleanBook ||
+        (projectedMeld != null &&
+            projectedMeld.cards.length >= BotConfig.bookSize &&
+            projectedMeld.isClean);
+    final willHaveDirty =
+        bot.hasDirtyBook ||
+        (projectedMeld != null &&
+            projectedMeld.cards.length >= BotConfig.bookSize &&
+            !projectedMeld.isClean);
+
+    return !(willHaveClean && willHaveDirty);
+  }
+
+  static Meld? projectMeldAfterAdd(
+    Player bot,
+    int meldIndex,
+    PlayingCard card,
+  ) {
+    if (meldIndex < 0 || meldIndex >= bot.melds.length) {
+      return null;
+    }
+    final meld = bot.melds[meldIndex];
+    if (!meld.canAddCard(card)) {
+      return null;
+    }
+    return Meld.createMeld([...meld.cards, card]);
+  }
+
+  static bool isSafeAddToMeld(Player bot, Map<String, dynamic> addition) {
+    final meldIndex = addition['meldIndex'] as int?;
+    final card = addition['card'] as PlayingCard?;
+    if (meldIndex == null || card == null) {
+      return false;
+    }
+    final projected = projectMeldAfterAdd(bot, meldIndex, card);
+    return !leavesUnfinishableSingleCard(
+      bot,
+      cardsRemoved: 1,
+      projectedMeld: projected,
+    );
+  }
+
+  static bool isSafeCreateMeld(Player bot, List<PlayingCard> meldCards) {
+    if (meldCards.isEmpty) {
+      return false;
+    }
+    final projected = meldCards.length >= BotConfig.bookSize
+        ? Meld.createMeld(meldCards)
+        : null;
+    return !leavesUnfinishableSingleCard(
+      bot,
+      cardsRemoved: meldCards.length,
+      projectedMeld: projected,
+    );
+  }
+
   /// Calculate minimum number of turns needed for bot to go out.
   /// Returns -1 if bot cannot go out (doesn't have required books).
   int calculateTurnsToGoOut(Player bot, GameController controller) {
@@ -285,16 +357,18 @@ class BotEndGameManager {
     // Can't complete books easily - try melding in meld phase, discard later
     if (gameState.turnPhase == TurnPhase.meld) {
       final cardsToAdd = _findCardsToAddToExistingMelds(bot, controller);
-      if (cardsToAdd.isNotEmpty) {
-        return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+      for (final addition in cardsToAdd) {
+        if (isSafeAddToMeld(bot, addition)) {
+          return BotDecision(action: 'addToMeld', data: addition);
+        }
       }
 
       final possibleMelds = controller.findPossibleMelds(bot);
       if (possibleMelds.isNotEmpty) {
-        return BotDecision(
-          action: 'createMeld',
-          data: _findBestBookPotentialMeld(possibleMelds),
-        );
+        final bestMeld = _findBestBookPotentialMeld(possibleMelds);
+        if (isSafeCreateMeld(bot, bestMeld)) {
+          return BotDecision(action: 'createMeld', data: bestMeld);
+        }
       }
 
       return BotDecision(action: 'noMeld');
@@ -736,10 +810,11 @@ class BotEndGameManager {
         if (meld.isClean && meld.cards.length < BotConfig.bookSize) {
           for (final card in bot.currentHand) {
             if (!card.isWild && _canAddCardToMeld(card, meld)) {
-              return BotDecision(
-                action: 'addToMeld',
-                data: {'meldIndex': i, 'card': card},
-              );
+              final addition = {'meldIndex': i, 'card': card};
+              if (!isSafeAddToMeld(bot, addition)) {
+                continue;
+              }
+              return BotDecision(action: 'addToMeld', data: addition);
             }
           }
         }
@@ -750,10 +825,10 @@ class BotEndGameManager {
           .where((meld) => !meld.any((card) => card.isWild))
           .toList();
       if (cleanMelds.isNotEmpty) {
-        return BotDecision(
-          action: 'createMeld',
-          data: _findBestBookPotentialMeld(cleanMelds),
-        );
+        final bestMeld = _findBestBookPotentialMeld(cleanMelds);
+        if (isSafeCreateMeld(bot, bestMeld)) {
+          return BotDecision(action: 'createMeld', data: bestMeld);
+        }
       }
     }
 
@@ -762,7 +837,9 @@ class BotEndGameManager {
       for (final addition in cardsToAdd) {
         final meldIndex = addition['meldIndex'] as int;
         final meld = bot.melds[meldIndex];
-        if (!meld.isClean && meld.cards.length < BotConfig.bookSize) {
+        if (!meld.isClean &&
+            meld.cards.length < BotConfig.bookSize &&
+            isSafeAddToMeld(bot, addition)) {
           return BotDecision(action: 'addToMeld', data: addition);
         }
       }
@@ -772,10 +849,10 @@ class BotEndGameManager {
           .where((meld) => meld.any((card) => card.isWild))
           .toList();
       if (dirtyMelds.isNotEmpty) {
-        return BotDecision(
-          action: 'createMeld',
-          data: _findBestBookPotentialMeld(dirtyMelds),
-        );
+        final bestMeld = _findBestBookPotentialMeld(dirtyMelds);
+        if (isSafeCreateMeld(bot, bestMeld)) {
+          return BotDecision(action: 'createMeld', data: bestMeld);
+        }
       }
     }
 
@@ -846,45 +923,6 @@ class BotEndGameManager {
       }
       if (bot.currentHand.isNotEmpty) {
         return BotDecision(action: 'discard', data: bot.currentHand.first);
-      }
-    }
-
-    // If we're close to books, try to complete the missing book type
-    if (cleanBooks > 0 || dirtyBooks > 0) {
-      final needsClean = cleanBooks == 0;
-      final needsDirty = dirtyBooks == 0;
-      final minMeldSize = needsClean && dirtyBooks > 0 ? 3 : 5;
-
-      for (int i = 0; i < bot.melds.length; i++) {
-        final meld = bot.melds[i];
-        if (meld.cards.length >= minMeldSize &&
-            meld.cards.length < BotConfig.bookSize) {
-          if ((needsClean && meld.isClean) || (needsDirty && !meld.isClean)) {
-            final addableCards = bot.currentHand
-                .where((card) => meld.canAddCard(card))
-                .where((card) => needsClean ? !card.isWild : true)
-                .toList();
-            if (addableCards.isNotEmpty) {
-              return BotDecision(
-                action: 'addToMeld',
-                data: {'meldIndex': i, 'card': addableCards.first},
-              );
-            }
-          }
-        }
-      }
-
-      if (needsClean) {
-        final cleanMelds = controller
-            .findPossibleMelds(bot)
-            .where((meld) => !meld.any((card) => card.isWild))
-            .toList();
-        if (cleanMelds.isNotEmpty) {
-          return BotDecision(
-            action: 'createMeld',
-            data: _findBestBookPotentialMeld(cleanMelds),
-          );
-        }
       }
     }
 

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -705,6 +705,15 @@ class EnhancedBotAI {
     );
     final cardsToAdd = _filterWildCardAdditions(rawCardsToAdd, bot);
     if (cardsToAdd.isNotEmpty) {
+      if (bot.hasPickedUpFoot && bot.hasDirtyBook && !bot.hasCleanBook) {
+        final cleanAdditions = _filterCleanBookPriorityAdditions(
+          bot,
+          cardsToAdd,
+        );
+        if (cleanAdditions.isNotEmpty) {
+          return BotDecision(action: 'addToMeld', data: cleanAdditions.first);
+        }
+      }
       return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
     }
 
@@ -1786,6 +1795,11 @@ class EnhancedBotAI {
     final turnCount = _gameAnalyzer.getTurnCount(bot.id);
     final personality = _personalityManager.getPersonality(bot.id);
 
+    // On foot without both book types — keep melding, never hoard toward go-out
+    if (bot.hasPickedUpFoot && !bot.canGoOutWithBooks) {
+      return false;
+    }
+
     // Calculate time-based pressure: worry more the longer we've been in hand without reaching foot
     final timePressure = _calculateTimePressure(bot, turnCount, personality);
     final personalityHoldingLimit = _getPersonalityHoldingLimit(
@@ -2530,9 +2544,14 @@ class EnhancedBotAI {
     // No clean book yet: never add wilds to naturals-only melds — use wilds only
     // on piles that are already dirty (building the dirty book lane).
     if (bot.hasPlayedDown && !bot.hasCleanBook) {
+      if (bot.hasPickedUpFoot && bot.hasDirtyBook) {
+        return _filterCleanBookPriorityAdditions(bot, result);
+      }
       result = result.where((addition) {
         final card = addition['card'] as PlayingCard;
-        if (!card.isWild) return true;
+        if (!card.isWild) {
+          return true;
+        }
         final meld = addition['meld'] as Meld;
         final alreadyDirty = meld.cards.any((c) => c.isWild);
         return alreadyDirty;
@@ -2986,17 +3005,22 @@ class EnhancedBotAI {
     final needsDirty = dirtyBooks == 0;
 
     // Find near-complete melds of the needed type
+    final minNearBookSize = needsClean && dirtyBooks > 0 && bot.hasPickedUpFoot
+        ? 3
+        : 5;
+
     for (int i = 0; i < bot.melds.length; i++) {
       final meld = bot.melds[i];
-      if (meld.cards.length >= 5) {
+      if (meld.cards.length >= minNearBookSize) {
         // Near book
         final isClean = meld.isClean;
 
         if ((needsClean && isClean) || (needsDirty && !isClean)) {
           // Try to add cards to complete this book
-          final addableCards = bot.currentHand.where(
-            (card) => meld.canAddCard(card),
-          );
+          final addableCards = bot.currentHand
+              .where((card) => meld.canAddCard(card))
+              .where((card) => needsClean ? !card.isWild : true)
+              .toList();
           if (addableCards.isNotEmpty) {
             return BotDecision(
               action: 'addToMeld',

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -3449,18 +3449,27 @@ class EnhancedBotAI {
         case 'goOut':
           return bot.canGoOut && bot.hasPickedUpFoot;
         case 'createMeld':
-          return decision.data is List<PlayingCard> &&
-              (decision.data as List<PlayingCard>).isNotEmpty;
+          if (decision.data is! List<PlayingCard>) {
+            return false;
+          }
+          final meldCards = decision.data as List<PlayingCard>;
+          return meldCards.isNotEmpty &&
+              BotEndGameManager.isSafeCreateMeld(bot, meldCards);
         case 'createMultipleMelds':
           return decision.data is List<List<PlayingCard>> &&
               (decision.data as List<List<PlayingCard>>).isNotEmpty;
         case 'addToMeld':
-          if (decision.data is! Map<String, dynamic>) return false;
+          if (decision.data is! Map<String, dynamic>) {
+            return false;
+          }
           final data = decision.data as Map<String, dynamic>;
           final meldIndex = data['meldIndex'] as int?;
-          return meldIndex != null &&
-              meldIndex >= 0 &&
-              meldIndex < bot.melds.length;
+          if (meldIndex == null ||
+              meldIndex < 0 ||
+              meldIndex >= bot.melds.length) {
+            return false;
+          }
+          return BotEndGameManager.isSafeAddToMeld(bot, data);
         case 'discard':
           return decision.data is PlayingCard &&
               bot.hasHandCard(decision.data as PlayingCard);

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -1052,7 +1052,7 @@ class BotTurnManager {
 
         case 'discard':
           final card = decision.data;
-          if (handSize <= 3) {
+          if (handSize <= 3 && bot.canGoOutWithBooks) {
             return '$personality bot discarding ${card?.toString() ?? 'card'} while positioning for end-game';
           } else {
             return '$personality bot discarding ${card?.toString() ?? 'card'} (${handSize - 1} cards remaining)';

--- a/test/ai/bot_clean_meld_and_penalty_test.dart
+++ b/test/ai/bot_clean_meld_and_penalty_test.dart
@@ -81,6 +81,17 @@ void main() {
         const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
       ];
       botPlayer.melds.add(Meld.createMeld(sixQueens)!);
+      botPlayer.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: null, rank: CardRank.joker),
+        ])!,
+      );
 
       botPlayer.hand.clear();
       botPlayer.foot.clear();
@@ -98,12 +109,15 @@ void main() {
       );
       expect(additions, isNotEmpty);
 
+      final safeAddition = additions.firstWhere(
+        (addition) => BotEndGameManager.isSafeAddToMeld(botPlayer, addition),
+      );
+
       final decision = endGameManager.handleEndGame(botPlayer, controller);
       expect(decision, isNotNull);
       expect(decision!.action, 'addToMeld');
       final chosen = decision.data as Map<String, dynamic>;
-      // Delegates to [BotMeldAnalyzer.findCardsToAddToExistingMelds] — same top pick
-      expect(chosen['card'], same(additions.first['card'] as PlayingCard));
+      expect(chosen['card'], same(safeAddition['card'] as PlayingCard));
     });
   });
 

--- a/test/ai/bot_end_game_test.dart
+++ b/test/ai/bot_end_game_test.dart
@@ -173,17 +173,9 @@ void main() {
           botPlayer,
           gameController,
         );
-        // End game manager may not create melds if not in optimal position
-        // It focuses on completing existing melds and going out, or returning null
-        if (decision != null) {
-          expect(decision.action, anyOf(['createMeld', 'discard']));
-          if (decision.action == 'createMeld') {
-            final meldCards = decision.data as List<PlayingCard>;
-            expect(meldCards.length, greaterThanOrEqualTo(3));
-            // The meld may not be all aces depending on the end game manager's logic
-            expect(meldCards.isNotEmpty, isTrue);
-          }
-        }
+        // Without existing books, a 4-card ace meld would leave one stranded card.
+        expect(decision, isNotNull);
+        expect(decision!.action, equals('noMeld'));
       });
     });
 

--- a/test/ai/bot_finish_round_strategy_test.dart
+++ b/test/ai/bot_finish_round_strategy_test.dart
@@ -110,44 +110,51 @@ void main() {
       expect(decision!.action, equals('goOut'));
     });
 
-    test('does not aggressively finish when only dirty books exist', () {
-      botPlayer.melds.clear();
-      botPlayer.melds.add(dirtyBook());
-      botPlayer.melds.add(
-        Meld(
-          rank: CardRank.queen,
-          cards: [
-            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
-            const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
-            const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
-            const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
-            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
-            const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
-            const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
-          ],
-          type: MeldType.mixed,
-        ),
-      );
-      botPlayer.hand.clear();
-      botPlayer.foot.clear();
-      botPlayer.foot.addAll([
-        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
-        const PlayingCard(suit: Suit.spades, rank: CardRank.five),
-      ]);
+    test(
+      'does not aggressively finish when only dirty books exist',
+      () {
+        botPlayer.melds.clear();
+        botPlayer.melds.add(dirtyBook());
+        botPlayer.melds.add(
+          Meld(
+            rank: CardRank.queen,
+            cards: [
+              const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+              const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+              const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+              const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+              const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+              const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+              const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+            ],
+            type: MeldType.mixed,
+          ),
+        );
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.foot.addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+        ]);
 
-      expect(botPlayer.hasDirtyBook, isTrue);
-      expect(botPlayer.hasCleanBook, isFalse);
-      expect(botPlayer.canGoOutWithBooks, isFalse);
+        expect(botPlayer.hasDirtyBook, isTrue);
+        expect(botPlayer.hasCleanBook, isFalse);
+        expect(botPlayer.canGoOutWithBooks, isFalse);
 
-      gameController.gameState.turnPhase = TurnPhase.meld;
-      gameController.gameState.hasDrawnFromDeck = true;
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
 
-      final decision = endGameManager.handleEndGame(botPlayer, gameController);
+        final decision = endGameManager.handleEndGame(
+          botPlayer,
+          gameController,
+        );
 
-      expect(decision, isNotNull);
-      expect(decision!.action, isNot('discard'));
-      expect(decision.action, isNot('goOut'));
-    });
+        expect(decision, isNotNull);
+        expect(decision!.action, isNot('discard'));
+        expect(decision.action, isNot('goOut'));
+      },
+      tags: ['clean_book_regression'],
+    );
 
     test(
       'builds clean book lane when dirty books exist but clean is missing',
@@ -182,6 +189,72 @@ void main() {
         final addition = decision.data as Map<String, dynamic>;
         expect((addition['card'] as PlayingCard).rank, equals(CardRank.seven));
       },
+      tags: ['clean_book_regression'],
+    );
+
+    test(
+      'rejects meld that leaves a single card without both book types',
+      () {
+        botPlayer.melds.clear();
+        botPlayer.melds.add(dirtyBook());
+        botPlayer.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+          ])!,
+        );
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.foot.addAll([
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+        ]);
+
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        final decision = botAI.makeDecision(botPlayer, gameController);
+
+        expect(decision.action, isNot('addToMeld'));
+      },
+      tags: ['clean_book_regression'],
+    );
+
+    test(
+      'allows meld that completes clean book even when one card remains',
+      () {
+        botPlayer.melds.clear();
+        botPlayer.melds.add(dirtyBook());
+        botPlayer.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          ])!,
+        );
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.foot.addAll([
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+        ]);
+
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        final decision = botAI.makeDecision(botPlayer, gameController);
+
+        expect(decision.action, equals('addToMeld'));
+        final addition = decision.data as Map<String, dynamic>;
+        expect((addition['card'] as PlayingCard).rank, equals(CardRank.seven));
+      },
+      tags: ['clean_book_regression'],
     );
 
     test('post-playdown transition triggers on hand pile with 8+ cards', () {

--- a/test/ai/bot_finish_round_strategy_test.dart
+++ b/test/ai/bot_finish_round_strategy_test.dart
@@ -110,6 +110,80 @@ void main() {
       expect(decision!.action, equals('goOut'));
     });
 
+    test('does not aggressively finish when only dirty books exist', () {
+      botPlayer.melds.clear();
+      botPlayer.melds.add(dirtyBook());
+      botPlayer.melds.add(
+        Meld(
+          rank: CardRank.queen,
+          cards: [
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+          ],
+          type: MeldType.mixed,
+        ),
+      );
+      botPlayer.hand.clear();
+      botPlayer.foot.clear();
+      botPlayer.foot.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+      ]);
+
+      expect(botPlayer.hasDirtyBook, isTrue);
+      expect(botPlayer.hasCleanBook, isFalse);
+      expect(botPlayer.canGoOutWithBooks, isFalse);
+
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+
+      final decision = endGameManager.handleEndGame(botPlayer, gameController);
+
+      expect(decision, isNotNull);
+      expect(decision!.action, isNot('discard'));
+      expect(decision.action, isNot('goOut'));
+    });
+
+    test(
+      'builds clean book lane when dirty books exist but clean is missing',
+      () {
+        botPlayer.melds.clear();
+        botPlayer.melds.add(dirtyBook());
+        botPlayer.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+          ])!,
+        );
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.foot.add(
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+        );
+
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        final decision = endGameManager.handleEndGame(
+          botPlayer,
+          gameController,
+        );
+
+        expect(decision, isNotNull);
+        expect(decision!.action, equals('addToMeld'));
+        final addition = decision.data as Map<String, dynamic>;
+        expect((addition['card'] as PlayingCard).rank, equals(CardRank.seven));
+      },
+    );
+
     test('post-playdown transition triggers on hand pile with 8+ cards', () {
       final transitionManager = BotFootTransitionManager();
       botPlayer.hasPickedUpFoot = false;

--- a/test/ai/bot_foot_phase_melding_test.dart
+++ b/test/ai/bot_foot_phase_melding_test.dart
@@ -296,6 +296,7 @@ void main() {
         expect(card.rank, equals(CardRank.seven));
         expect(card.isWild, isFalse);
       },
+      tags: ['clean_book_regression'],
     );
   });
 }

--- a/test/ai/bot_foot_phase_melding_test.dart
+++ b/test/ai/bot_foot_phase_melding_test.dart
@@ -237,5 +237,65 @@ void main() {
         anyOf('createMeld', 'addToMeld', 'createMultipleMelds'),
       );
     });
+
+    test(
+      'Alex session regression: builds clean sevens instead of wilds on dirty queens',
+      () {
+        botAI.assignPersonality(bot.id, BotPersonality.adaptive);
+
+        dealBotFoot([
+          const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.three),
+        ]);
+
+        bot.melds.addAll([
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+          ])!,
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.joker),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+          ])!,
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.joker),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+          ])!,
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.two),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.two),
+          ])!,
+        ]);
+
+        expect(bot.hasDirtyBook, isTrue);
+        expect(bot.hasCleanBook, isFalse);
+        expect(bot.canGoOutWithBooks, isFalse);
+
+        final decision = botAI.makeDecision(bot, gameController);
+
+        expect(decision.action, equals('addToMeld'));
+        final addition = decision.data as Map<String, dynamic>;
+        final card = addition['card'] as PlayingCard;
+        expect(card.rank, equals(CardRank.seven));
+        expect(card.isWild, isFalse);
+      },
+    );
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Firestore session `session_17837098113421342` showed Alex on foot with two dirty books but no clean book, discarding to an empty hand and looping on `error` decisions.

## Fix

- Gate aggressive go-out on `canGoOutWithBooks`
- Prioritize clean-book lanes when only dirty books exist
- Block wild additions to dirty piles during clean-book chase
- **PR review follow-up:** reject add/create-meld moves that leave one card while still missing a required book type (`leavesUnfinishableSingleCard`), enforced in `BotEndGameManager.handleEndGame` and `EnhancedBotAI._isValidDecision`
- Remove unreachable missing-book logic from `_attemptAggressiveGoOut` (covered by `_handleIncompleteBookRequirements`)

## Tests

Tagged with `clean_book_regression` for selective runs (`flutter test -t clean_book_regression`).

All **813** unit tests pass; `flutter analyze` clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ceb9ce57-d48d-4ec2-a55b-f915b2a91098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceb9ce57-d48d-4ec2-a55b-f915b2a91098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved bot end-game decisions when clean or dirty books are incomplete.
  * Bots now prioritize building required clean books and avoid unsuitable wild-card plays.
  * Refined go-out behavior under competitive pressure and near-empty hands.
  * Improved meld progression when a dirty book exists but a clean book is missing.
  * Updated bot discard reasoning to display remaining cards when appropriate.

* **Tests**
  * Added coverage for book requirements, meld progression, and end-game strategy scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->