### PR TITLE
Add All Clean button to meld modal

### DIFF
--- a/lib/widgets/advanced_meld_selector.dart
+++ b/lib/widgets/advanced_meld_selector.dart
@@ -234,51 +234,25 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                'Proposed Melds (${proposedMeldIndices.length})',
-                style: TextStyle(
-                  fontSize: GameResponsiveLayout.getFontSize(context, 18),
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
+              Expanded(
+                child: Text(
+                  'Proposed Melds (${proposedMeldIndices.length})',
+                  style: TextStyle(
+                    fontSize: GameResponsiveLayout.getFontSize(context, 18),
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
                 ),
               ),
-              GameResponsiveLayout.isSmallMobile(context)
-                  ? ElevatedButton(
-                      onPressed: _canCreateNewMeld() ? _createNewMeld : null,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF10B981),
-                        foregroundColor: Colors.white,
-                        elevation: 4,
-                        shadowColor: const Color(
-                          0xFF10B981,
-                        ).withValues(alpha: 0.4),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 8,
-                        ),
-                        minimumSize: const Size(60, 32),
-                      ),
-                      child: const Text('New', style: TextStyle(fontSize: 12)),
-                    )
-                  : ElevatedButton.icon(
-                      onPressed: _canCreateNewMeld() ? _createNewMeld : null,
-                      icon: const Icon(Icons.add, size: 18),
-                      label: const Text('New Meld'),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF10B981),
-                        foregroundColor: Colors.white,
-                        elevation: 4,
-                        shadowColor: const Color(
-                          0xFF10B981,
-                        ).withValues(alpha: 0.4),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                    ),
+              const SizedBox(width: 8),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildAllCleanMeldsButton(),
+                  const SizedBox(width: 8),
+                  _buildNewMeldButton(),
+                ],
+              ),
             ],
           ),
           const SizedBox(height: 8),
@@ -294,7 +268,7 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
                     ),
                     child: const Center(
                       child: Text(
-                        'No melds created yet\nSelect cards and click "New Meld"',
+                        'No melds created yet\nSelect cards, tap "All Clean", or click "New Meld"',
                         textAlign: TextAlign.center,
                         style: TextStyle(color: Colors.white60, fontSize: 16),
                       ),
@@ -686,8 +660,184 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
     );
   }
 
+  Widget _buildAllCleanMeldsButton() {
+    final isSmallMobile = GameResponsiveLayout.isSmallMobile(context);
+    final buttonStyle = ElevatedButton.styleFrom(
+      backgroundColor: const Color(0xFF3B82F6),
+      foregroundColor: Colors.white,
+      disabledBackgroundColor: const Color(0xFF374151),
+      disabledForegroundColor: Colors.white54,
+      elevation: 4,
+      shadowColor: const Color(0xFF3B82F6).withValues(alpha: 0.4),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(isSmallMobile ? 8 : 12),
+      ),
+      padding: EdgeInsets.symmetric(
+        horizontal: isSmallMobile ? 10 : 14,
+        vertical: isSmallMobile ? 8 : 10,
+      ),
+      minimumSize: Size(isSmallMobile ? 56 : 0, isSmallMobile ? 32 : 36),
+    );
+
+    if (isSmallMobile) {
+      return ElevatedButton(
+        onPressed: _hasCleanMeldOptions() ? _createAllCleanMelds : null,
+        style: buttonStyle,
+        child: const Text('Clean', style: TextStyle(fontSize: 12)),
+      );
+    }
+
+    return ElevatedButton.icon(
+      onPressed: _hasCleanMeldOptions() ? _createAllCleanMelds : null,
+      icon: const Icon(Icons.auto_awesome, size: 18),
+      label: const Text('All Clean'),
+      style: buttonStyle,
+    );
+  }
+
+  Widget _buildNewMeldButton() {
+    final isSmallMobile = GameResponsiveLayout.isSmallMobile(context);
+    final buttonStyle = ElevatedButton.styleFrom(
+      backgroundColor: const Color(0xFF10B981),
+      foregroundColor: Colors.white,
+      disabledBackgroundColor: const Color(0xFF374151),
+      disabledForegroundColor: Colors.white54,
+      elevation: 4,
+      shadowColor: const Color(0xFF10B981).withValues(alpha: 0.4),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(isSmallMobile ? 8 : 12),
+      ),
+      padding: EdgeInsets.symmetric(
+        horizontal: isSmallMobile ? 12 : 14,
+        vertical: isSmallMobile ? 8 : 10,
+      ),
+      minimumSize: Size(isSmallMobile ? 60 : 0, isSmallMobile ? 32 : 36),
+    );
+
+    if (isSmallMobile) {
+      return ElevatedButton(
+        onPressed: _canCreateNewMeld() ? _createNewMeld : null,
+        style: buttonStyle,
+        child: const Text('New', style: TextStyle(fontSize: 12)),
+      );
+    }
+
+    return ElevatedButton.icon(
+      onPressed: _canCreateNewMeld() ? _createNewMeld : null,
+      icon: const Icon(Icons.add, size: 18),
+      label: const Text('New Meld'),
+      style: buttonStyle,
+    );
+  }
+
   bool _canCreateNewMeld() {
     return selectedAvailableIndices.length >= GameConfig.minTotalCardsForMeld;
+  }
+
+  bool _hasCleanMeldOptions() {
+    return _findNewCleanMeldGroups().isNotEmpty ||
+        _hasExtendableCleanProposedMelds();
+  }
+
+  bool _hasExtendableCleanProposedMelds() {
+    for (final handIndex in availableCardIndices) {
+      final card = widget.player.currentHand[handIndex];
+      if (card.isWild || card.isThree) {
+        continue;
+      }
+
+      for (final meldIndices in proposedMeldIndices) {
+        if (_isCleanNaturalMeldIndices(meldIndices) &&
+            _meldNaturalRank(meldIndices) == card.rank) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  List<List<int>> _findNewCleanMeldGroups() {
+    final groups = <List<int>>[];
+    final cardsByRank = <CardRank, List<int>>{};
+
+    for (final handIndex in availableCardIndices) {
+      final card = widget.player.currentHand[handIndex];
+      if (card.isWild || card.isThree) {
+        continue;
+      }
+      cardsByRank.putIfAbsent(card.rank, () => []).add(handIndex);
+    }
+
+    for (final indices in cardsByRank.values) {
+      if (indices.length >= GameConfig.minTotalCardsForMeld) {
+        groups.add(List<int>.from(indices));
+      }
+    }
+
+    return groups;
+  }
+
+  CardRank? _meldNaturalRank(List<int> meldIndices) {
+    for (final handIndex in meldIndices) {
+      final card = widget.player.currentHand[handIndex];
+      if (!card.isWild && !card.isThree) {
+        return card.rank;
+      }
+    }
+    return null;
+  }
+
+  bool _isCleanNaturalMeldIndices(List<int> meldIndices) {
+    for (final handIndex in meldIndices) {
+      final card = widget.player.currentHand[handIndex];
+      if (card.isWild || card.isThree) {
+        return false;
+      }
+    }
+    return meldIndices.isNotEmpty;
+  }
+
+  void _createAllCleanMelds() {
+    setState(() {
+      _extendExistingCleanProposedMelds();
+      _createNewCleanMeldGroups();
+      selectedAvailableIndices.clear();
+      _sortAvailableCardIndices();
+    });
+  }
+
+  void _extendExistingCleanProposedMelds() {
+    final indicesToRemove = <int>{};
+
+    for (final handIndex in List<int>.from(availableCardIndices)) {
+      final card = widget.player.currentHand[handIndex];
+      if (card.isWild || card.isThree) {
+        continue;
+      }
+
+      for (int i = 0; i < proposedMeldIndices.length; i++) {
+        final meldIndices = proposedMeldIndices[i];
+        if (_isCleanNaturalMeldIndices(meldIndices) &&
+            _meldNaturalRank(meldIndices) == card.rank) {
+          meldIndices.add(handIndex);
+          indicesToRemove.add(handIndex);
+          break;
+        }
+      }
+    }
+
+    for (final handIndex in indicesToRemove) {
+      availableCardIndices.remove(handIndex);
+    }
+  }
+
+  void _createNewCleanMeldGroups() {
+    for (final meldIndices in _findNewCleanMeldGroups()) {
+      proposedMeldIndices.add(meldIndices);
+      for (final handIndex in meldIndices) {
+        availableCardIndices.remove(handIndex);
+      }
+    }
   }
 
   void _createNewMeld() {

--- a/lib/widgets/advanced_meld_selector.dart
+++ b/lib/widgets/advanced_meld_selector.dart
@@ -681,6 +681,7 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
 
     if (isSmallMobile) {
       return ElevatedButton(
+        key: const Key('all_clean_melds_button'),
         onPressed: _hasCleanMeldOptions() ? _createAllCleanMelds : null,
         style: buttonStyle,
         child: const Text('Clean', style: TextStyle(fontSize: 12)),
@@ -688,6 +689,7 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
     }
 
     return ElevatedButton.icon(
+      key: const Key('all_clean_melds_button'),
       onPressed: _hasCleanMeldOptions() ? _createAllCleanMelds : null,
       icon: const Icon(Icons.auto_awesome, size: 18),
       label: const Text('All Clean'),
@@ -788,13 +790,24 @@ class _AdvancedMeldSelectorState extends State<AdvancedMeldSelector> {
   }
 
   bool _isCleanNaturalMeldIndices(List<int> meldIndices) {
+    if (meldIndices.isEmpty) {
+      return false;
+    }
+
+    CardRank? expectedRank;
     for (final handIndex in meldIndices) {
       final card = widget.player.currentHand[handIndex];
       if (card.isWild || card.isThree) {
         return false;
       }
+
+      expectedRank ??= card.rank;
+      if (card.rank != expectedRank) {
+        return false;
+      }
     }
-    return meldIndices.isNotEmpty;
+
+    return true;
   }
 
   void _createAllCleanMelds() {

--- a/test/widgets/advanced_meld_selector_test.dart
+++ b/test/widgets/advanced_meld_selector_test.dart
@@ -623,4 +623,184 @@ void main() {
       expect(isDirtyMeld, isTrue);
     });
   });
+
+  group('Advanced Meld Selector - Auto Create Clean Melds', () {
+    late Player testPlayer;
+
+    setUp(() {
+      testPlayer = Player(
+        id: 'clean_auto_test',
+        name: 'Clean Auto Test Player',
+        type: PlayerType.human,
+      );
+    });
+
+    List<List<int>> findNewCleanMeldGroups(
+      List<int> availableCardIndices,
+      List<PlayingCard> hand,
+    ) {
+      final groups = <List<int>>[];
+      final cardsByRank = <CardRank, List<int>>{};
+
+      for (final handIndex in availableCardIndices) {
+        final card = hand[handIndex];
+        if (card.isWild || card.isThree) {
+          continue;
+        }
+        cardsByRank.putIfAbsent(card.rank, () => []).add(handIndex);
+      }
+
+      for (final indices in cardsByRank.values) {
+        if (indices.length >= 3) {
+          groups.add(List<int>.from(indices));
+        }
+      }
+
+      return groups;
+    }
+
+    void createAllCleanMelds({
+      required List<List<int>> proposedMeldIndices,
+      required List<int> availableCardIndices,
+      required List<PlayingCard> hand,
+    }) {
+      final indicesToRemove = <int>{};
+
+      for (final handIndex in List<int>.from(availableCardIndices)) {
+        final card = hand[handIndex];
+        if (card.isWild || card.isThree) {
+          continue;
+        }
+
+        for (final meldIndices in proposedMeldIndices) {
+          final hasWild = meldIndices.any((index) => hand[index].isWild);
+          if (hasWild) {
+            continue;
+          }
+
+          final rank = meldIndices
+              .map((index) => hand[index])
+              .firstWhere((c) => !c.isWild)
+              .rank;
+          if (rank == card.rank) {
+            meldIndices.add(handIndex);
+            indicesToRemove.add(handIndex);
+            break;
+          }
+        }
+      }
+
+      for (final handIndex in indicesToRemove) {
+        availableCardIndices.remove(handIndex);
+      }
+
+      for (final meldIndices in findNewCleanMeldGroups(
+        availableCardIndices,
+        hand,
+      )) {
+        proposedMeldIndices.add(meldIndices);
+        for (final handIndex in meldIndices) {
+          availableCardIndices.remove(handIndex);
+        }
+      }
+    }
+
+    test('should create melds for all clean rank groups in hand', () {
+      testPlayer.currentHand.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.four),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.four),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+      ]);
+
+      final proposedMeldIndices = <List<int>>[];
+      final availableCardIndices = List.generate(
+        testPlayer.currentHand.length,
+        (index) => index,
+      );
+
+      createAllCleanMelds(
+        proposedMeldIndices: proposedMeldIndices,
+        availableCardIndices: availableCardIndices,
+        hand: testPlayer.currentHand,
+      );
+
+      expect(proposedMeldIndices.length, equals(3));
+      expect(availableCardIndices, equals([10, 11]));
+
+      final fourMeld = proposedMeldIndices.firstWhere(
+        (meld) => testPlayer.currentHand[meld.first].rank == CardRank.four,
+      );
+      final sevenMeld = proposedMeldIndices.firstWhere(
+        (meld) => testPlayer.currentHand[meld.first].rank == CardRank.seven,
+      );
+      final kingMeld = proposedMeldIndices.firstWhere(
+        (meld) => testPlayer.currentHand[meld.first].rank == CardRank.king,
+      );
+
+      expect(fourMeld, equals([0, 1, 2]));
+      expect(sevenMeld, equals([3, 4, 5]));
+      expect(kingMeld, equals([6, 7, 8, 9]));
+    });
+
+    test('should skip wild cards and 3s when auto-creating clean melds', () {
+      testPlayer.currentHand.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        const PlayingCard(rank: CardRank.joker),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.three),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.three),
+      ]);
+
+      final proposedMeldIndices = <List<int>>[];
+      final availableCardIndices = List.generate(
+        testPlayer.currentHand.length,
+        (index) => index,
+      );
+
+      createAllCleanMelds(
+        proposedMeldIndices: proposedMeldIndices,
+        availableCardIndices: availableCardIndices,
+        hand: testPlayer.currentHand,
+      );
+
+      expect(proposedMeldIndices.length, equals(1));
+      expect(proposedMeldIndices.first, equals([0, 1, 2]));
+      expect(availableCardIndices, equals([3, 4, 5]));
+    });
+
+    test('should extend existing clean proposed meld with matching cards', () {
+      testPlayer.currentHand.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+      ]);
+
+      final proposedMeldIndices = <List<int>>[
+        [0, 1, 2],
+      ];
+      final availableCardIndices = [3, 4];
+
+      createAllCleanMelds(
+        proposedMeldIndices: proposedMeldIndices,
+        availableCardIndices: availableCardIndices,
+        hand: testPlayer.currentHand,
+      );
+
+      expect(proposedMeldIndices.length, equals(1));
+      expect(proposedMeldIndices.first, equals([0, 1, 2, 3]));
+      expect(availableCardIndices, equals([4]));
+    });
+  });
 }

--- a/test/widgets/advanced_meld_selector_test.dart
+++ b/test/widgets/advanced_meld_selector_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/models/card.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/widgets/advanced_meld_selector.dart';
 
 void main() {
   group('Advanced Meld Selector Multi-Meld State Management', () {
@@ -627,6 +629,85 @@ void main() {
   group('Advanced Meld Selector - Auto Create Clean Melds', () {
     late Player testPlayer;
 
+    Future<void> pumpMeldSelector(WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AdvancedMeldSelector(
+              player: testPlayer,
+              playDownRequirement: 60,
+              onCancel: () {},
+              onConfirm: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    void seedMeldSelectorState(
+      WidgetTester tester, {
+      required List<List<int>> proposedMeldIndices,
+      required List<int> availableCardIndices,
+    }) {
+      final finder = find.byType(AdvancedMeldSelector);
+      final state = tester.state<State<StatefulWidget>>(finder);
+      final dynamic selectorState = state;
+      selectorState.proposedMeldIndices
+        ..clear()
+        ..addAll(proposedMeldIndices.map(List<int>.from));
+      selectorState.availableCardIndices
+        ..clear()
+        ..addAll(availableCardIndices);
+      selectorState.selectedAvailableIndices.clear();
+      (tester.element(finder) as StatefulElement).markNeedsBuild();
+    }
+
+    Future<void> tapAllClean(WidgetTester tester) async {
+      await tester.tap(find.byKey(const Key('all_clean_melds_button')));
+      await tester.pumpAndSettle();
+    }
+
+    Finder proposedMeldsListView() => find.descendant(
+      of: find.byType(AdvancedMeldSelector),
+      matching: find.byType(ListView),
+    );
+
+    Future<void> expectRenderedPreview(
+      WidgetTester tester,
+      String previewKey,
+    ) async {
+      final previewFinder = find.byKey(ValueKey(previewKey));
+      for (
+        var attempt = 0;
+        attempt < 8 && previewFinder.evaluate().isEmpty;
+        attempt++
+      ) {
+        await tester.drag(proposedMeldsListView(), const Offset(0, -150));
+        await tester.pumpAndSettle();
+      }
+      expect(previewFinder, findsOneWidget);
+    }
+
+    List<List<int>> proposedMeldIndicesFromWidget(WidgetTester tester) {
+      final dynamic selectorState = tester.state(
+        find.byType(AdvancedMeldSelector),
+      );
+      return (selectorState.proposedMeldIndices as List)
+          .map((meld) => List<int>.from(meld as List))
+          .toList();
+    }
+
+    List<int> availableCardIndicesFromWidget(WidgetTester tester) {
+      final dynamic selectorState = tester.state(
+        find.byType(AdvancedMeldSelector),
+      );
+      return List<int>.from(selectorState.availableCardIndices as List);
+    }
+
     setUp(() {
       testPlayer = Player(
         id: 'clean_auto_test',
@@ -635,77 +716,9 @@ void main() {
       );
     });
 
-    List<List<int>> findNewCleanMeldGroups(
-      List<int> availableCardIndices,
-      List<PlayingCard> hand,
-    ) {
-      final groups = <List<int>>[];
-      final cardsByRank = <CardRank, List<int>>{};
-
-      for (final handIndex in availableCardIndices) {
-        final card = hand[handIndex];
-        if (card.isWild || card.isThree) {
-          continue;
-        }
-        cardsByRank.putIfAbsent(card.rank, () => []).add(handIndex);
-      }
-
-      for (final indices in cardsByRank.values) {
-        if (indices.length >= 3) {
-          groups.add(List<int>.from(indices));
-        }
-      }
-
-      return groups;
-    }
-
-    void createAllCleanMelds({
-      required List<List<int>> proposedMeldIndices,
-      required List<int> availableCardIndices,
-      required List<PlayingCard> hand,
-    }) {
-      final indicesToRemove = <int>{};
-
-      for (final handIndex in List<int>.from(availableCardIndices)) {
-        final card = hand[handIndex];
-        if (card.isWild || card.isThree) {
-          continue;
-        }
-
-        for (final meldIndices in proposedMeldIndices) {
-          final hasWild = meldIndices.any((index) => hand[index].isWild);
-          if (hasWild) {
-            continue;
-          }
-
-          final rank = meldIndices
-              .map((index) => hand[index])
-              .firstWhere((c) => !c.isWild)
-              .rank;
-          if (rank == card.rank) {
-            meldIndices.add(handIndex);
-            indicesToRemove.add(handIndex);
-            break;
-          }
-        }
-      }
-
-      for (final handIndex in indicesToRemove) {
-        availableCardIndices.remove(handIndex);
-      }
-
-      for (final meldIndices in findNewCleanMeldGroups(
-        availableCardIndices,
-        hand,
-      )) {
-        proposedMeldIndices.add(meldIndices);
-        for (final handIndex in meldIndices) {
-          availableCardIndices.remove(handIndex);
-        }
-      }
-    }
-
-    test('should create melds for all clean rank groups in hand', () {
+    testWidgets('creates proposed melds for all clean rank groups', (
+      tester,
+    ) async {
       testPlayer.currentHand.addAll([
         const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
         const PlayingCard(suit: Suit.spades, rank: CardRank.four),
@@ -721,37 +734,32 @@ void main() {
         const PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
       ]);
 
-      final proposedMeldIndices = <List<int>>[];
-      final availableCardIndices = List.generate(
-        testPlayer.currentHand.length,
-        (index) => index,
-      );
+      await pumpMeldSelector(tester);
+      await tapAllClean(tester);
 
-      createAllCleanMelds(
-        proposedMeldIndices: proposedMeldIndices,
-        availableCardIndices: availableCardIndices,
-        hand: testPlayer.currentHand,
+      expect(find.text('Proposed Melds (3)'), findsOneWidget);
+      expect(find.text('Available Cards (2)'), findsOneWidget);
+      await expectRenderedPreview(tester, 'preview-0-0');
+      await expectRenderedPreview(tester, 'preview-1-0');
+      await expectRenderedPreview(tester, 'preview-2-0');
+      expect(find.byKey(const ValueKey('mobile_card_10')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_11')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_0')), findsNothing);
+      expect(find.byKey(const ValueKey('mobile_card_6')), findsNothing);
+      expect(
+        proposedMeldIndicesFromWidget(tester),
+        equals([
+          [0, 1, 2],
+          [3, 4, 5],
+          [6, 7, 8, 9],
+        ]),
       );
-
-      expect(proposedMeldIndices.length, equals(3));
-      expect(availableCardIndices, equals([10, 11]));
-
-      final fourMeld = proposedMeldIndices.firstWhere(
-        (meld) => testPlayer.currentHand[meld.first].rank == CardRank.four,
-      );
-      final sevenMeld = proposedMeldIndices.firstWhere(
-        (meld) => testPlayer.currentHand[meld.first].rank == CardRank.seven,
-      );
-      final kingMeld = proposedMeldIndices.firstWhere(
-        (meld) => testPlayer.currentHand[meld.first].rank == CardRank.king,
-      );
-
-      expect(fourMeld, equals([0, 1, 2]));
-      expect(sevenMeld, equals([3, 4, 5]));
-      expect(kingMeld, equals([6, 7, 8, 9]));
+      expect(availableCardIndicesFromWidget(tester), unorderedEquals([10, 11]));
     });
 
-    test('should skip wild cards and 3s when auto-creating clean melds', () {
+    testWidgets('skips wild cards and 3s when auto-creating clean melds', (
+      tester,
+    ) async {
       testPlayer.currentHand.addAll([
         const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
         const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
@@ -761,24 +769,20 @@ void main() {
         const PlayingCard(suit: Suit.hearts, rank: CardRank.three),
       ]);
 
-      final proposedMeldIndices = <List<int>>[];
-      final availableCardIndices = List.generate(
-        testPlayer.currentHand.length,
-        (index) => index,
-      );
+      await pumpMeldSelector(tester);
+      await tapAllClean(tester);
 
-      createAllCleanMelds(
-        proposedMeldIndices: proposedMeldIndices,
-        availableCardIndices: availableCardIndices,
-        hand: testPlayer.currentHand,
-      );
-
-      expect(proposedMeldIndices.length, equals(1));
-      expect(proposedMeldIndices.first, equals([0, 1, 2]));
-      expect(availableCardIndices, equals([3, 4, 5]));
+      expect(find.text('Proposed Melds (1)'), findsOneWidget);
+      expect(find.text('Available Cards (3)'), findsOneWidget);
+      expect(find.byKey(const ValueKey('preview-0-0')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_3')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_4')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_5')), findsOneWidget);
     });
 
-    test('should extend existing clean proposed meld with matching cards', () {
+    testWidgets('extends existing clean proposed meld with matching cards', (
+      tester,
+    ) async {
       testPlayer.currentHand.addAll([
         const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
         const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
@@ -787,20 +791,67 @@ void main() {
         const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
       ]);
 
-      final proposedMeldIndices = <List<int>>[
-        [0, 1, 2],
-      ];
-      final availableCardIndices = [3, 4];
-
-      createAllCleanMelds(
-        proposedMeldIndices: proposedMeldIndices,
-        availableCardIndices: availableCardIndices,
-        hand: testPlayer.currentHand,
+      await pumpMeldSelector(tester);
+      seedMeldSelectorState(
+        tester,
+        proposedMeldIndices: [
+          [0, 1, 2],
+        ],
+        availableCardIndices: [3, 4],
       );
+      await tester.pumpAndSettle();
 
-      expect(proposedMeldIndices.length, equals(1));
-      expect(proposedMeldIndices.first, equals([0, 1, 2, 3]));
-      expect(availableCardIndices, equals([4]));
+      await tapAllClean(tester);
+
+      expect(find.text('Proposed Melds (1)'), findsOneWidget);
+      expect(find.text('Available Cards (1)'), findsOneWidget);
+      expect(find.byKey(const ValueKey('preview-0-3')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_4')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_3')), findsNothing);
+    });
+
+    testWidgets('does not extend mixed-rank proposed melds', (tester) async {
+      testPlayer.currentHand.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+      ]);
+
+      await pumpMeldSelector(tester);
+      seedMeldSelectorState(
+        tester,
+        proposedMeldIndices: [
+          [0, 3],
+        ],
+        availableCardIndices: [1, 2, 4, 5, 6],
+      );
+      await tester.pumpAndSettle();
+
+      await tapAllClean(tester);
+
+      expect(find.text('Proposed Melds (2)'), findsOneWidget);
+      expect(find.text('Available Cards (2)'), findsOneWidget);
+      await expectRenderedPreview(tester, 'preview-0-0');
+      await expectRenderedPreview(tester, 'preview-0-1');
+      await expectRenderedPreview(tester, 'preview-1-0');
+      await expectRenderedPreview(tester, 'preview-1-1');
+      await expectRenderedPreview(tester, 'preview-1-2');
+      expect(find.byKey(const ValueKey('mobile_card_4')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_5')), findsOneWidget);
+      expect(find.byKey(const ValueKey('mobile_card_6')), findsNothing);
+      expect(find.byKey(const ValueKey('preview-0-2')), findsNothing);
+      expect(
+        proposedMeldIndicesFromWidget(tester),
+        equals([
+          [0, 3],
+          [1, 2, 6],
+        ]),
+      );
+      expect(availableCardIndicesFromWidget(tester), equals([4, 5]));
     });
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **All Clean** button to the advanced meld selector so players can automatically create melds for every clean option in their hand instead of building each meld manually.

## Behavior

- Scans available (unassigned) cards in the modal
- Groups natural cards of the same rank with **3+ cards** and **no wilds**
- Creates a proposed meld for each qualifying rank group
- Extends existing clean proposed melds when matching naturals are still available
- Skips 3s and wild cards (those still require manual meld creation)
- Button is disabled when no clean meld options exist

## UI

- Desktop/tablet: blue **All Clean** button with sparkle icon, next to **New Meld**
- Small mobile: compact **Clean** button label to save space
- Empty-state hint updated to mention the new action

## Testing

- Added unit tests for auto-create logic (multiple rank groups, wild/3 exclusion, extending existing melds)
- `flutter analyze` clean
- All `advanced_meld_selector_test.dart` tests pass (24)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da84866b-8fe1-4a3a-96ea-1579a3beb1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da84866b-8fe1-4a3a-96ea-1579a3beb1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **All Clean** action to auto-create eligible clean melds.
  * Clean meld generation now considers only eligible natural cards, and can extend existing proposed clean melds with matching available cards.
  * Updated the meld section to show **All Clean** and **New** side-by-side with improved mobile-friendly styling.
  * Enhanced empty-state messaging to guide next steps when no proposed melds exist.

* **Tests**
  * Added widget-level tests covering clean-meld creation, skipping wilds and threes, extending existing melds, and rejecting mixed-rank extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->