### PR TITLE
Fix scoreboard to display actual player names

### DIFF
--- a/lib/widgets/scoreboard_modal.dart
+++ b/lib/widgets/scoreboard_modal.dart
@@ -74,7 +74,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
 
     // Build accessibility label
     final accessibilityLabel =
-        'Player ${playerIndex + 1}, '
+        '${player.name}, '
         'Total score: ${breakdown['gameTotal']}, '
         'Round ${widget.gameState.round} score: ${breakdown['currentRoundTotal']}, '
         '${canGoOut ? 'Can go out, ' : ''}'
@@ -124,7 +124,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
                           children: [
                             Flexible(
                               child: Text(
-                                'Player ${playerIndex + 1}',
+                                player.name,
                                 style: Theme.of(context)
                                     .textTheme
                                     .headlineMedium
@@ -467,7 +467,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
                       ),
                       const SizedBox(width: 8),
                       Text(
-                        'Leader: Player ${sortedPlayers[0] + 1} (${widget.gameState.players[sortedPlayers[0]].score} points)',
+                        'Leader: ${widget.gameState.players[sortedPlayers[0]].name} (${widget.gameState.players[sortedPlayers[0]].score} points)',
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.bold,

--- a/lib/widgets/scoreboard_modal.dart
+++ b/lib/widgets/scoreboard_modal.dart
@@ -63,7 +63,27 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
     return Colors.grey;
   }
 
-  Widget _buildPlayerScoreCard(int playerIndex) {
+  Set<String> _duplicatePlayerNames() {
+    final nameCounts = <String, int>{};
+    for (final player in widget.gameState.players) {
+      nameCounts[player.name] = (nameCounts[player.name] ?? 0) + 1;
+    }
+
+    return nameCounts.entries
+        .where((entry) => entry.value > 1)
+        .map((entry) => entry.key)
+        .toSet();
+  }
+
+  String _displayNameForPlayer(int playerIndex, Set<String> duplicateNames) {
+    final player = widget.gameState.players[playerIndex];
+    if (duplicateNames.contains(player.name)) {
+      return '${player.name} (${playerIndex + 1})';
+    }
+    return player.name;
+  }
+
+  Widget _buildPlayerScoreCard(int playerIndex, Set<String> duplicateNames) {
     final breakdown = _calculateScoreBreakdown(playerIndex);
     final isCurrentPlayer = playerIndex == widget.gameState.currentPlayerIndex;
     final player = widget.gameState.players[playerIndex];
@@ -71,10 +91,11 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
     final canGoOut =
         widget.gameState.phase == GamePhase.playing && player.canGoOut;
     final isExpanded = expandedPlayerIndex == playerIndex;
+    final displayName = _displayNameForPlayer(playerIndex, duplicateNames);
 
     // Build accessibility label
     final accessibilityLabel =
-        '${player.name}, '
+        '$displayName, '
         'Total score: ${breakdown['gameTotal']}, '
         'Round ${widget.gameState.round} score: ${breakdown['currentRoundTotal']}, '
         '${canGoOut ? 'Can go out, ' : ''}'
@@ -124,7 +145,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
                           children: [
                             Flexible(
                               child: Text(
-                                player.name,
+                                displayName,
                                 style: Theme.of(context)
                                     .textTheme
                                     .headlineMedium
@@ -383,6 +404,9 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
             widget.gameState.players[a].score,
           ),
         );
+    final duplicateNames = _duplicatePlayerNames();
+    final leaderIndex = sortedPlayers[0];
+    final leaderName = _displayNameForPlayer(leaderIndex, duplicateNames);
 
     return Semantics(
       label: 'Scoreboard for Round ${widget.gameState.round}',
@@ -467,7 +491,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
                       ),
                       const SizedBox(width: 8),
                       Text(
-                        'Leader: ${widget.gameState.players[sortedPlayers[0]].name} (${widget.gameState.players[sortedPlayers[0]].score} points)',
+                        'Leader: $leaderName (${widget.gameState.players[leaderIndex].score} points)',
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.bold,
@@ -486,7 +510,10 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
                   itemBuilder: (context, index) {
                     return Padding(
                       padding: const EdgeInsets.only(bottom: 12),
-                      child: _buildPlayerScoreCard(sortedPlayers[index]),
+                      child: _buildPlayerScoreCard(
+                        sortedPlayers[index],
+                        duplicateNames,
+                      ),
                     );
                   },
                 ),

--- a/test/widgets/scoreboard_modal_test.dart
+++ b/test/widgets/scoreboard_modal_test.dart
@@ -342,6 +342,21 @@ void main() {
         );
         expect(find.text('Bot 2'), findsOneWidget);
         expect(find.textContaining('Player '), findsNothing);
+
+        expect(
+          find.bySemanticsLabel('You, Total score: 1370, Round 2 score: 0, '),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel('Bot 1, Total score: 1325, Round 2 score: 0, '),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel(
+            'Bot 2, Total score: 370, Round 2 score: 0, Current player',
+          ),
+          findsOneWidget,
+        );
       });
 
       testWidgets('disambiguates duplicate player names with index suffix', (
@@ -355,7 +370,7 @@ void main() {
             hand: [],
             foot: [],
             melds: [],
-            score: 1500,
+            score: 1200,
           ),
           Player(
             id: '2',
@@ -364,7 +379,7 @@ void main() {
             hand: [],
             foot: [],
             melds: [],
-            score: 1200,
+            score: 1500,
           ),
           Player(
             id: '3',
@@ -398,7 +413,7 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.text('Leader: Guest (1) (1500 points)'), findsOneWidget);
+        expect(find.text('Leader: Guest (2) (1500 points)'), findsOneWidget);
         expect(find.text('Guest (1)'), findsOneWidget);
         expect(find.text('Guest (2)'), findsOneWidget);
 
@@ -409,6 +424,23 @@ void main() {
         );
         expect(find.text('You'), findsOneWidget);
         expect(find.text('Guest'), findsNothing);
+
+        expect(
+          find.bySemanticsLabel(
+            'Guest (1), Total score: 1200, Round 2 score: 0, Current player',
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel(
+            'Guest (2), Total score: 1500, Round 2 score: 0, ',
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel('You, Total score: 900, Round 2 score: 0, '),
+          findsOneWidget,
+        );
       });
 
       testWidgets('displays score breakdown components', (

--- a/test/widgets/scoreboard_modal_test.dart
+++ b/test/widgets/scoreboard_modal_test.dart
@@ -277,6 +277,73 @@ void main() {
         expect(find.text('Leader: Player 3 (2000 points)'), findsOneWidget);
       });
 
+      testWidgets('displays actual player names instead of index labels', (
+        WidgetTester tester,
+      ) async {
+        final namedPlayers = [
+          Player(
+            id: '1',
+            name: 'You',
+            type: PlayerType.human,
+            hand: [],
+            foot: [],
+            melds: [],
+            score: 1370,
+          ),
+          Player(
+            id: '2',
+            name: 'Bot 1',
+            type: PlayerType.bot,
+            hand: [],
+            foot: [],
+            melds: [],
+            score: 1325,
+          ),
+          Player(
+            id: '3',
+            name: 'Bot 2',
+            type: PlayerType.bot,
+            hand: [],
+            foot: [],
+            melds: [],
+            score: 370,
+          ),
+        ];
+
+        final namedGameState = GameState(
+          players: namedPlayers,
+          deck: Deck.createHandAndFootDeck(3),
+          currentPlayerIndex: 2,
+          phase: GamePhase.playing,
+          round: 2,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: MediaQuery(
+                data: const MediaQueryData(size: Size(800, 1200)),
+                child: ScoreboardModal(gameState: namedGameState),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Leader: You (1370 points)'), findsOneWidget);
+        expect(find.text('You'), findsOneWidget);
+        expect(find.text('Bot 1'), findsOneWidget);
+
+        await tester.scrollUntilVisible(
+          find.text('Bot 2'),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        expect(find.text('Bot 2'), findsOneWidget);
+        expect(find.textContaining('Player '), findsNothing);
+      });
+
       testWidgets('displays score breakdown components', (
         WidgetTester tester,
       ) async {

--- a/test/widgets/scoreboard_modal_test.dart
+++ b/test/widgets/scoreboard_modal_test.dart
@@ -344,6 +344,73 @@ void main() {
         expect(find.textContaining('Player '), findsNothing);
       });
 
+      testWidgets('disambiguates duplicate player names with index suffix', (
+        WidgetTester tester,
+      ) async {
+        final duplicateNamePlayers = [
+          Player(
+            id: '1',
+            name: 'Guest',
+            type: PlayerType.human,
+            hand: [],
+            foot: [],
+            melds: [],
+            score: 1500,
+          ),
+          Player(
+            id: '2',
+            name: 'Guest',
+            type: PlayerType.human,
+            hand: [],
+            foot: [],
+            melds: [],
+            score: 1200,
+          ),
+          Player(
+            id: '3',
+            name: 'You',
+            type: PlayerType.human,
+            hand: [],
+            foot: [],
+            melds: [],
+            score: 900,
+          ),
+        ];
+
+        final duplicateNameGameState = GameState(
+          players: duplicateNamePlayers,
+          deck: Deck.createHandAndFootDeck(3),
+          currentPlayerIndex: 0,
+          phase: GamePhase.playing,
+          round: 2,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: MediaQuery(
+                data: const MediaQueryData(size: Size(800, 1200)),
+                child: ScoreboardModal(gameState: duplicateNameGameState),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Leader: Guest (1) (1500 points)'), findsOneWidget);
+        expect(find.text('Guest (1)'), findsOneWidget);
+        expect(find.text('Guest (2)'), findsOneWidget);
+
+        await tester.scrollUntilVisible(
+          find.text('You'),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        expect(find.text('You'), findsOneWidget);
+        expect(find.text('Guest'), findsNothing);
+      });
+
       testWidgets('displays score breakdown components', (
         WidgetTester tester,
       ) async {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The scoreboard modal was showing generic labels like "Player 1", "Player 2", and "Player 3" instead of each player's configured name (e.g. "You", "Bot 1", "Bot 2").

## Changes

- Use `player.name` for player card headers, the leader summary, and accessibility labels in `ScoreboardModal`
- Add a widget test that verifies real player names are displayed and index-based labels are not

## Test plan

- [x] `flutter test test/widgets/scoreboard_modal_test.dart` — all 11 tests pass
- [x] `flutter analyze` — no issues on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1033b126-41fb-42db-80de-2d2ef4a58b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1033b126-41fb-42db-80de-2d2ef4a58b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scoreboard player cards now display each player’s actual name (instead of generic “Player N” labels), with matching leader/visible header text and accessibility labels.
  * If multiple players share the same name, the scoreboard disambiguates them by appending an index suffix (e.g., “Guest (1)”, “Guest (2)”).

* **Tests**
  * Added widget tests for named players, including correct leader label rendering, absence of “Player ” labels, and scroll-to-visibility verification.
  * Added widget tests covering duplicate-name disambiguation and accessibility label correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->