### PR TITLE
Fix multiplayer auth, sync, lifecycle, and Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -68,6 +68,7 @@ service cloud.firestore {
       && gameStateUnchanged(oldData, newData)
       && newData.players.size() == oldData.players.size() + 1
       && newData.players.size() <= newData.maxPlayers
+      && getPlayerIds(newData).hasAll(getPlayerIds(oldData))
       && request.auth.uid in getPlayerIds(newData)
       && !(request.auth.uid in getPlayerIds(oldData));
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,19 +3,21 @@ service cloud.firestore {
   match /databases/{database}/documents {
     // Games collection rules
     match /games/{gameId} {
-      // Anyone can read games to browse/join
+      // Authenticated users can read games to browse/join
       allow read: if request.auth != null;
       
-      // Only authenticated users can create games
+      // Only authenticated users can create games (host must match auth uid)
       allow create: if request.auth != null 
-        && request.auth.uid == resource.data.hostId
-        && isValidGameCreation(resource.data);
+        && request.auth.uid == request.resource.data.hostId
+        && isValidGameCreation(request.resource.data);
       
-      // Only host or players in the game can update
-      allow update: if request.auth != null 
-        && (request.auth.uid == resource.data.hostId 
+      // Host, existing players, or a new player joining a waiting lobby may update
+      allow update: if request.auth != null && (
+        ((request.auth.uid == resource.data.hostId 
             || request.auth.uid in getPlayerIds(resource.data))
-        && isValidGameUpdate(resource.data, request.resource.data);
+         && isValidGameUpdate(resource.data, request.resource.data))
+        || isPlayerJoining(resource.data, request.resource.data)
+      );
       
       // Only host can delete games
       allow delete: if request.auth != null 
@@ -56,6 +58,13 @@ service cloud.firestore {
     let playerCountValid = newData.players.size() <= newData.maxPlayers;
     
     return statusValid && hostUnchanged && playerCountValid;
+  }
+
+  function isPlayerJoining(oldData, newData) {
+    return oldData.status == 'waiting'
+      && newData.players.size() == oldData.players.size() + 1
+      && request.auth.uid in getPlayerIds(newData)
+      && !(request.auth.uid in getPlayerIds(oldData));
   }
   
   function getPlayerIds(gameData) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -62,9 +62,18 @@ service cloud.firestore {
 
   function isPlayerJoining(oldData, newData) {
     return oldData.status == 'waiting'
+      && oldData.hostId == newData.hostId
+      && oldData.maxPlayers == newData.maxPlayers
+      && oldData.status == newData.status
+      && gameStateUnchanged(oldData, newData)
       && newData.players.size() == oldData.players.size() + 1
+      && newData.players.size() <= newData.maxPlayers
       && request.auth.uid in getPlayerIds(newData)
       && !(request.auth.uid in getPlayerIds(oldData));
+  }
+
+  function gameStateUnchanged(oldData, newData) {
+    return oldData.get('gameState', null) == newData.get('gameState', null);
   }
   
   function getPlayerIds(gameData) {

--- a/lib/game/enhanced_multiplayer_controller.dart
+++ b/lib/game/enhanced_multiplayer_controller.dart
@@ -7,6 +7,7 @@ import '../models/game_state.dart';
 import '../config/game_config.dart';
 import '../models/multiplayer_errors.dart';
 import '../services/multiplayer_resume_service.dart';
+import '../services/firebase_service.dart';
 import '../utils/debug_logger.dart';
 import 'game_controller.dart';
 import 'network_adapter.dart';
@@ -116,6 +117,9 @@ class EnhancedMultiplayerController implements MultiplayerGameInterface {
       );
       if (!success) return null;
 
+      final gameData = await FirebaseService.getGame(gameId);
+      final isHost = gameData?['hostId'] == userId;
+
       // Create temporary player for local game controller
       final tempPlayer = Player(
         id: userId,
@@ -130,7 +134,7 @@ class EnhancedMultiplayerController implements MultiplayerGameInterface {
         currentUserId: userId,
         gameController: gameController,
         networkAdapter: networkAdapter,
-        isHost: false,
+        isHost: isHost,
       );
 
       await controller._startListening();
@@ -153,6 +157,15 @@ class EnhancedMultiplayerController implements MultiplayerGameInterface {
   Future<bool> startMultiplayerGame() async {
     if (!_isHost) return false;
     return await _networkAdapter.startGame(gameId);
+  }
+
+  /// Leave the multiplayer game and clean up Firestore lobby/player records.
+  @override
+  Future<bool> leaveGame() async {
+    if (_isDisposed) {
+      return false;
+    }
+    return await _networkAdapter.leaveGame(gameId);
   }
 
   Future<void> _startListening() async {
@@ -413,6 +426,9 @@ class EnhancedMultiplayerController implements MultiplayerGameInterface {
       localGameState.recentActions,
       newGameState.recentActions,
     );
+
+    // Keep deck in sync after draws (authoritative server state)
+    localGameState.deck.replaceCards(newGameState.deck.cards);
   }
 
   void _replaceCollectionAtomically<T>(List<T> targetList, List<T> newData) {

--- a/lib/game/enhanced_multiplayer_controller.dart
+++ b/lib/game/enhanced_multiplayer_controller.dart
@@ -143,7 +143,7 @@ class EnhancedMultiplayerController implements MultiplayerGameInterface {
       await MultiplayerResumeService.saveActiveGame(
         gameId: gameId,
         playerName: playerName,
-        isHost: false,
+        isHost: isHost,
       );
 
       return controller;
@@ -165,7 +165,17 @@ class EnhancedMultiplayerController implements MultiplayerGameInterface {
     if (_isDisposed) {
       return false;
     }
-    return await _networkAdapter.leaveGame(gameId);
+
+    var leaveSuccess = false;
+    try {
+      await _queueNetworkOperation(() async {
+        leaveSuccess = await _networkAdapter.leaveGame(gameId);
+      });
+      return leaveSuccess;
+    } catch (e) {
+      DebugLogger.error('Failed to leave game: $e');
+      return false;
+    }
   }
 
   Future<void> _startListening() async {

--- a/lib/game/game_interface.dart
+++ b/lib/game/game_interface.dart
@@ -66,5 +66,6 @@ abstract class MultiplayerGameInterface extends GameInterface {
 
   // Multiplayer game management
   Future<bool> startMultiplayerGame();
+  Future<bool> leaveGame();
   Player? getCurrentUserPlayer();
 }

--- a/lib/game/network_adapter.dart
+++ b/lib/game/network_adapter.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import '../models/game_state.dart';
 import '../services/firebase_service.dart';
 
@@ -93,15 +94,18 @@ class FirebaseNetworkAdapter implements NetworkAdapter {
     required String hostPlayerName,
     required int maxPlayers,
   }) {
-    return FirebaseService.createGame(
+    return FirebaseService.createGameWithResult(
       hostPlayerName: hostPlayerName,
       maxPlayers: maxPlayers,
-    );
+    ).then((result) => result.gameId);
   }
 
   @override
   Future<bool> joinGame({required String gameId, required String playerName}) {
-    return FirebaseService.joinGame(gameId: gameId, playerName: playerName);
+    return FirebaseService.joinGameWithResult(
+      gameId: gameId,
+      playerName: playerName,
+    ).then((result) => result.isSuccess);
   }
 
   @override
@@ -121,7 +125,7 @@ class FirebaseNetworkAdapter implements NetworkAdapter {
 
   @override
   Future<String?> getCurrentUserId() {
-    return FirebaseService.getDeviceUserId();
+    return FirebaseService.getMultiplayerUserId();
   }
 
   @override
@@ -501,5 +505,11 @@ class MockNetworkAdapter implements NetworkAdapter {
   void simulateReconnection() {
     _isConnected = true;
     _connectionController.add(true);
+  }
+
+  /// Push a game state update to listeners (for unit tests).
+  @visibleForTesting
+  void simulateGameStateUpdate(GameState? state) {
+    _gameStateController.add(state);
   }
 }

--- a/lib/models/multiplayer_result.dart
+++ b/lib/models/multiplayer_result.dart
@@ -1,0 +1,62 @@
+/// Reason codes for multiplayer create/join failures surfaced to the UI.
+enum MultiplayerFailureReason {
+  notConfigured,
+  notAuthenticated,
+  invalidInput,
+  gameNotFound,
+  gameFull,
+  gameNotAccepting,
+  rateLimited,
+  permissionDenied,
+  unknown,
+}
+
+/// User-facing message for a [MultiplayerFailureReason].
+String multiplayerFailureMessage(MultiplayerFailureReason reason) {
+  switch (reason) {
+    case MultiplayerFailureReason.notConfigured:
+      return 'Multiplayer requires Firebase configuration.';
+    case MultiplayerFailureReason.notAuthenticated:
+      return 'Could not sign in for multiplayer. Please try again.';
+    case MultiplayerFailureReason.invalidInput:
+      return 'Invalid player name or game settings.';
+    case MultiplayerFailureReason.gameNotFound:
+      return 'Game not found. Check the game ID and try again.';
+    case MultiplayerFailureReason.gameFull:
+      return 'This game is full.';
+    case MultiplayerFailureReason.gameNotAccepting:
+      return 'This game is no longer accepting players.';
+    case MultiplayerFailureReason.rateLimited:
+      return 'Too many games created. Please wait and try again.';
+    case MultiplayerFailureReason.permissionDenied:
+      return 'Permission denied. Check Firebase authentication settings.';
+    case MultiplayerFailureReason.unknown:
+      return 'Something went wrong. Please try again.';
+  }
+}
+
+/// Result of attempting to create a multiplayer game.
+class CreateGameResult {
+  final String? gameId;
+  final MultiplayerFailureReason? failureReason;
+
+  const CreateGameResult({this.gameId, this.failureReason});
+
+  bool get isSuccess => gameId != null && failureReason == null;
+
+  String? get errorMessage =>
+      failureReason != null ? multiplayerFailureMessage(failureReason!) : null;
+}
+
+/// Result of attempting to join (or rejoin) a multiplayer game.
+class JoinGameResult {
+  final bool success;
+  final MultiplayerFailureReason? failureReason;
+
+  const JoinGameResult({required this.success, this.failureReason});
+
+  bool get isSuccess => success && failureReason == null;
+
+  String? get errorMessage =>
+      failureReason != null ? multiplayerFailureMessage(failureReason!) : null;
+}

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -19,6 +19,7 @@ class MainMenuScreen extends StatefulWidget {
 class _MainMenuScreenState extends State<MainMenuScreen> {
   bool _isLoading = false;
   bool _hasSavedSinglePlayerGame = false;
+  bool _multiplayerAvailable = false;
   Map<String, dynamic>? _rejoinableGame;
 
   @override
@@ -26,6 +27,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
     super.initState();
     _checkForSavedSinglePlayerGame();
     _checkForRejoinableMultiplayerGame();
+    _multiplayerAvailable = FirebaseService.isMultiplayerAvailable;
   }
 
   /// Check for rejoinable multiplayer games
@@ -146,7 +148,8 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                           ),
                           const SizedBox(height: 20),
                         ],
-                        if (_rejoinableGame != null) ...[
+                        if (_rejoinableGame != null &&
+                            _multiplayerAvailable) ...[
                           _buildMenuButton(
                             icon: Icons.wifi,
                             label: 'REJOIN GAME',
@@ -167,15 +170,23 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                         _buildMenuButton(
                           icon: Icons.group_add,
                           label: 'CREATE GAME',
-                          description: 'Host a multiplayer game',
-                          onPressed: _createMultiplayerGame,
+                          description: _multiplayerAvailable
+                              ? 'Host a multiplayer game'
+                              : 'Multiplayer requires Firebase configuration',
+                          onPressed: _multiplayerAvailable
+                              ? _createMultiplayerGame
+                              : _showMultiplayerUnavailable,
                         ),
                         const SizedBox(height: 20),
                         _buildMenuButton(
                           icon: Icons.group,
                           label: 'JOIN GAME',
-                          description: 'Join an existing game',
-                          onPressed: _joinMultiplayerGame,
+                          description: _multiplayerAvailable
+                              ? 'Join an existing game'
+                              : 'Multiplayer requires Firebase configuration',
+                          onPressed: _multiplayerAvailable
+                              ? _joinMultiplayerGame
+                              : _showMultiplayerUnavailable,
                         ),
                         const SizedBox(height: 40),
                         _buildInfoButton(),
@@ -724,6 +735,12 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           ),
         ],
       ),
+    );
+  }
+
+  void _showMultiplayerUnavailable() {
+    _showErrorDialog(
+      'Multiplayer requires Firebase configuration. Solo play works offline.',
     );
   }
 

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -427,7 +427,7 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
                 gameId: _gameController.gameId,
                 playerId: _gameController.userId,
               ),
-              onLeaveGame: _leaveAndExit,
+              onLeaveGame: _cleanupAndExit,
             ),
             body: CardAnimationHost(
               eventBus: gameEventBus,

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -427,7 +427,7 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
                 gameId: _gameController.gameId,
                 playerId: _gameController.userId,
               ),
-              onLeaveGame: () => Navigator.pop(context),
+              onLeaveGame: _leaveAndExit,
             ),
             body: CardAnimationHost(
               eventBus: gameEventBus,
@@ -766,15 +766,27 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
   }
 
   /// Clean up multiplayer game and return to main menu
-  void _cleanupAndExit() {
-    // Clear active game info (user is intentionally leaving)
-    MultiplayerResumeService.clearActiveGame().catchError((e) {
-      debugPrint('Warning: Failed to clear active game on exit: $e');
-    });
-
+  Future<void> _leaveAndExit() async {
+    await _gameController.leaveGame();
+    await MultiplayerResumeService.clearActiveGame();
+    if (!mounted) {
+      return;
+    }
     Navigator.of(context).pushAndRemoveUntil(
       MaterialPageRoute(builder: (context) => const MainMenuScreen()),
       (route) => false,
     );
+  }
+
+  void _cleanupAndExit() {
+    _leaveAndExit().catchError((e) {
+      debugPrint('Warning: Failed to leave multiplayer game: $e');
+      if (mounted) {
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (context) => const MainMenuScreen()),
+          (route) => false,
+        );
+      }
+    });
   }
 }

--- a/lib/screens/multiplayer_lobby_screen.dart
+++ b/lib/screens/multiplayer_lobby_screen.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 import '../theme/balatro_theme.dart';
 import '../services/firebase_service.dart';
 import '../services/firebase_constants.dart';
-import '../services/device_service.dart';
 import '../game/enhanced_multiplayer_controller.dart';
 import '../game/game_controller_factory.dart';
 import '../models/game_state.dart';
@@ -59,8 +58,7 @@ class _MultiplayerLobbyScreenState extends State<MultiplayerLobbyScreen> {
   }
 
   void _generateUserId() async {
-    // Use device-based ID for better persistence and security
-    _currentUserId = await DeviceService.getDeviceId();
+    _currentUserId = await FirebaseService.getMultiplayerUserId();
   }
 
   @override
@@ -495,7 +493,9 @@ class _MultiplayerLobbyScreenState extends State<MultiplayerLobbyScreen> {
       _isHost = true;
       _startListeningToLobby();
     } else {
-      throw Exception('Failed to create game');
+      throw Exception(
+        FirebaseService.lastOperationError ?? 'Failed to create game',
+      );
     }
   }
 
@@ -512,10 +512,12 @@ class _MultiplayerLobbyScreenState extends State<MultiplayerLobbyScreen> {
     if (controller != null) {
       _gameController = controller;
       _currentGameId = _gameController!.gameId;
-      _isHost = false;
+      _isHost = controller.isHost;
       _startListeningToLobby();
     } else {
-      throw Exception('Failed to join game');
+      throw Exception(
+        FirebaseService.lastOperationError ?? 'Failed to join game',
+      );
     }
   }
 

--- a/lib/screens/multiplayer_lobby_screen.dart
+++ b/lib/screens/multiplayer_lobby_screen.dart
@@ -473,9 +473,11 @@ class _MultiplayerLobbyScreenState extends State<MultiplayerLobbyScreen> {
         await _joinGame();
       }
     } catch (e) {
-      _showErrorDialog(
-        'Failed to ${widget.mode == LobbyMode.create ? 'create' : 'join'} game. Please try again.',
-      );
+      final message = e.toString();
+      final displayMessage = message.startsWith('Exception: ')
+          ? message.substring('Exception: '.length)
+          : message;
+      _showErrorDialog(displayMessage);
     }
 
     setState(() => _isLoading = false);

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -377,7 +377,7 @@ class FirebaseService {
   /// Delete a game (host only)
   static Future<bool> deleteGame(String gameId) async {
     try {
-      final userId = await getDeviceUserId();
+      final userId = await getMultiplayerUserId();
       if (userId == null) return false;
 
       final gameDoc = await _firestore
@@ -409,7 +409,7 @@ class FirebaseService {
   /// Remove player from game lobby
   static Future<bool> leaveGame(String gameId) async {
     try {
-      final userId = await getDeviceUserId();
+      final userId = await getMultiplayerUserId();
       if (userId == null) return false;
 
       final gameDoc = await _firestore
@@ -774,7 +774,7 @@ class FirebaseService {
   /// Start a game (host only)
   static Future<bool> startGame(String gameId) async {
     try {
-      final userId = await getDeviceUserId();
+      final userId = await getMultiplayerUserId();
       if (userId == null) return false;
 
       final gameDoc = await _firestore

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:logging/logging.dart';
@@ -9,6 +10,7 @@ import '../models/player.dart';
 import '../models/deck.dart';
 import '../models/card.dart';
 import '../models/meld.dart';
+import '../models/multiplayer_result.dart';
 import 'firebase_constants.dart';
 import 'device_service.dart';
 
@@ -32,6 +34,22 @@ class FirebaseService {
       FirebaseConstants.maxGamesPerUserPerHour;
   static const int maxGamesPerUserPerDay =
       FirebaseConstants.maxGamesPerUserPerDay;
+
+  static bool _firebaseCoreInitialized = false;
+  static bool _isAuthenticated = false;
+  static String? lastOperationError;
+
+  /// True when Firebase options point at a real project (not the public stub).
+  static bool get isConfigured {
+    try {
+      return !DefaultFirebaseOptions.currentPlatform.projectId.contains('stub');
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// True when Firebase is configured and the user has an anonymous auth session.
+  static bool get isMultiplayerAvailable => isConfigured && _isAuthenticated;
 
   /// Initialize Firebase with proper configuration
   static Future<void> initialize() async {
@@ -60,7 +78,12 @@ class FirebaseService {
       );
 
       await Firebase.initializeApp(options: options);
+      _firebaseCoreInitialized = true;
       _logger.info('🚀 Firebase core initialized successfully');
+
+      if (isConfigured) {
+        await ensureAuthenticated();
+      }
 
       // Explicitly initialize analytics for web
       if (kIsWeb) {
@@ -78,6 +101,35 @@ class FirebaseService {
       // Don't throw - allow app to continue without Firebase
       // This handles cases where Firebase isn't properly configured
       rethrow; // Let main.dart handle the error gracefully
+    }
+  }
+
+  /// Ensure the user is signed in anonymously for Firestore security rules.
+  static Future<bool> ensureAuthenticated() async {
+    if (!_firebaseCoreInitialized || !isConfigured) {
+      _isAuthenticated = false;
+      return false;
+    }
+
+    try {
+      final auth = FirebaseAuth.instance;
+      if (auth.currentUser != null) {
+        _isAuthenticated = true;
+        return true;
+      }
+
+      await auth.signInAnonymously();
+      _isAuthenticated = auth.currentUser != null;
+      if (_isAuthenticated) {
+        _logger.info(
+          'Signed in anonymously for multiplayer: ${auth.currentUser!.uid.substring(0, 8)}...',
+        );
+      }
+      return _isAuthenticated;
+    } catch (e) {
+      _logger.warning('Anonymous authentication failed: $e');
+      _isAuthenticated = false;
+      return false;
     }
   }
 
@@ -427,17 +479,20 @@ class FirebaseService {
     }
   }
 
-  /// Get device-based user identification for multiplayer games
-  /// This replaces anonymous authentication with a more secure device-based approach
-  static Future<String?> getDeviceUserId() async {
-    try {
-      final deviceId = await DeviceService.getDeviceId();
-      _logger.info('Using device ID: ${deviceId.substring(0, 8)}...');
-      return deviceId;
-    } catch (e) {
-      _logger.severe('Failed to get device user ID: $e');
+  /// Get Firebase Auth UID for multiplayer player identity (matches Firestore rules).
+  static Future<String?> getMultiplayerUserId() async {
+    if (!isConfigured) {
       return null;
     }
+    if (!await ensureAuthenticated()) {
+      return null;
+    }
+    return FirebaseAuth.instance.currentUser?.uid;
+  }
+
+  /// Backwards-compatible alias — returns Firebase Auth UID, not device ID.
+  static Future<String?> getDeviceUserId() {
+    return getMultiplayerUserId();
   }
 
   /// Get device name for display purposes
@@ -455,22 +510,59 @@ class FirebaseService {
     required String hostPlayerName,
     required int maxPlayers,
   }) async {
+    final result = await createGameWithResult(
+      hostPlayerName: hostPlayerName,
+      maxPlayers: maxPlayers,
+    );
+    return result.gameId;
+  }
+
+  /// Create a game and return a typed result for UI error handling.
+  static Future<CreateGameResult> createGameWithResult({
+    required String hostPlayerName,
+    required int maxPlayers,
+  }) async {
+    lastOperationError = null;
     try {
-      final userId = await getDeviceUserId();
+      if (!isConfigured) {
+        lastOperationError = multiplayerFailureMessage(
+          MultiplayerFailureReason.notConfigured,
+        );
+        return const CreateGameResult(
+          failureReason: MultiplayerFailureReason.notConfigured,
+        );
+      }
+
+      final userId = await getMultiplayerUserId();
       if (userId == null) {
-        _logger.warning('Cannot create game: failed to get device ID');
-        return null;
+        _logger.warning('Cannot create game: failed to authenticate');
+        lastOperationError = multiplayerFailureMessage(
+          MultiplayerFailureReason.notAuthenticated,
+        );
+        return const CreateGameResult(
+          failureReason: MultiplayerFailureReason.notAuthenticated,
+        );
       }
 
       // Validate inputs
       if (!_isValidPlayerName(hostPlayerName)) {
         _logger.warning('Invalid player name: $hostPlayerName');
-        return null;
+        lastOperationError = multiplayerFailureMessage(
+          MultiplayerFailureReason.invalidInput,
+        );
+        return const CreateGameResult(
+          failureReason: MultiplayerFailureReason.invalidInput,
+        );
       }
 
       if (!_isValidPlayerCount(maxPlayers)) {
         _logger.warning('Invalid max players: $maxPlayers');
-        return null;
+        lastOperationError = multiplayerFailureMessage(
+          MultiplayerFailureReason.invalidInput,
+        );
+        return const CreateGameResult(
+          failureReason: MultiplayerFailureReason.invalidInput,
+        );
       }
 
       // Check rate limiting
@@ -480,14 +572,24 @@ class FirebaseService {
           'game_creation_rate_limited',
           parameters: {'user_id': userId},
         );
-        return null;
+        lastOperationError = multiplayerFailureMessage(
+          MultiplayerFailureReason.rateLimited,
+        );
+        return const CreateGameResult(
+          failureReason: MultiplayerFailureReason.rateLimited,
+        );
       }
 
       // Generate short, user-friendly game ID
       final gameId = await _generateShortGameId();
       if (gameId == null) {
         _logger.warning('Failed to generate unique game ID');
-        return null;
+        lastOperationError = multiplayerFailureMessage(
+          MultiplayerFailureReason.unknown,
+        );
+        return const CreateGameResult(
+          failureReason: MultiplayerFailureReason.unknown,
+        );
       }
 
       // Create initial game state with host player
@@ -511,15 +613,21 @@ class FirebaseService {
 
       _logger.info('Created game: $gameId');
       await logGameCreated(maxPlayers: maxPlayers);
-      return gameId;
+      return CreateGameResult(gameId: gameId);
     } catch (e) {
       _logger.severe('Failed to create game: $e');
       await logGameEvent(
         'game_creation_failed',
         parameters: {'error': e.toString()},
       );
-      return null;
+      final reason = _failureReasonFromException(e);
+      _setLastOperationError(reason);
+      return CreateGameResult(failureReason: reason);
     }
+  }
+
+  static void _setLastOperationError(MultiplayerFailureReason reason) {
+    lastOperationError = multiplayerFailureMessage(reason);
   }
 
   /// Join an existing game with validation
@@ -527,11 +635,38 @@ class FirebaseService {
     required String gameId,
     required String playerName,
   }) async {
+    final result = await joinGameWithResult(
+      gameId: gameId,
+      playerName: playerName,
+    );
+    return result.isSuccess;
+  }
+
+  /// Join or rejoin a game and return a typed result for UI error handling.
+  static Future<JoinGameResult> joinGameWithResult({
+    required String gameId,
+    required String playerName,
+  }) async {
+    lastOperationError = null;
     try {
-      final userId = await getDeviceUserId();
+      if (!isConfigured) {
+        lastOperationError = multiplayerFailureMessage(
+          MultiplayerFailureReason.notConfigured,
+        );
+        return const JoinGameResult(
+          success: false,
+          failureReason: MultiplayerFailureReason.notConfigured,
+        );
+      }
+
+      final userId = await getMultiplayerUserId();
       if (userId == null) {
-        _logger.warning('Cannot join game: failed to get device ID');
-        return false;
+        _logger.warning('Cannot join game: failed to authenticate');
+        _setLastOperationError(MultiplayerFailureReason.notAuthenticated);
+        return const JoinGameResult(
+          success: false,
+          failureReason: MultiplayerFailureReason.notAuthenticated,
+        );
       }
 
       // Normalize game ID (convert short codes to uppercase)
@@ -542,12 +677,20 @@ class FirebaseService {
       // Validate inputs
       if (!_isValidGameId(normalizedGameId)) {
         _logger.warning('Invalid game ID: $gameId');
-        return false;
+        _setLastOperationError(MultiplayerFailureReason.invalidInput);
+        return const JoinGameResult(
+          success: false,
+          failureReason: MultiplayerFailureReason.invalidInput,
+        );
       }
 
       if (!_isValidPlayerName(playerName)) {
         _logger.warning('Invalid player name: $playerName');
-        return false;
+        _setLastOperationError(MultiplayerFailureReason.invalidInput);
+        return const JoinGameResult(
+          success: false,
+          failureReason: MultiplayerFailureReason.invalidInput,
+        );
       }
 
       final gameDoc = await _firestore
@@ -556,7 +699,11 @@ class FirebaseService {
           .get();
       if (!gameDoc.exists) {
         _logger.warning('Game not found: $gameId');
-        return false;
+        _setLastOperationError(MultiplayerFailureReason.gameNotFound);
+        return const JoinGameResult(
+          success: false,
+          failureReason: MultiplayerFailureReason.gameNotFound,
+        );
       }
 
       final gameData = gameDoc.data()!;
@@ -564,15 +711,40 @@ class FirebaseService {
         gameData['players'] ?? [],
       );
       final maxPlayers = gameData['maxPlayers'] as int;
+      final status = gameData['status'] as String?;
+
+      // Rejoin: player already in the game (waiting or playing)
+      final existingPlayerIndex = players.indexWhere(
+        (player) => player['id'] == userId,
+      );
+      if (existingPlayerIndex >= 0) {
+        if (players[existingPlayerIndex]['name'] != playerName) {
+          players[existingPlayerIndex]['name'] = playerName;
+          await _firestore
+              .collection(gamesCollection)
+              .doc(normalizedGameId)
+              .update({'players': players});
+        }
+        _logger.info('Rejoined game: $normalizedGameId as $playerName');
+        return const JoinGameResult(success: true);
+      }
 
       if (players.length >= maxPlayers) {
         _logger.warning('Game is full: $gameId');
-        return false;
+        _setLastOperationError(MultiplayerFailureReason.gameFull);
+        return const JoinGameResult(
+          success: false,
+          failureReason: MultiplayerFailureReason.gameFull,
+        );
       }
 
-      if (gameData['status'] != FirebaseConstants.gameStatusWaiting) {
-        _logger.warning('Game is not accepting players: $gameId');
-        return false;
+      if (status != FirebaseConstants.gameStatusWaiting) {
+        _logger.warning('Game is not accepting new players: $gameId');
+        _setLastOperationError(MultiplayerFailureReason.gameNotAccepting);
+        return const JoinGameResult(
+          success: false,
+          failureReason: MultiplayerFailureReason.gameNotAccepting,
+        );
       }
 
       // Add new player
@@ -590,10 +762,12 @@ class FirebaseService {
 
       _logger.info('Joined game: $normalizedGameId as $playerName');
       await logGameJoined();
-      return true;
+      return const JoinGameResult(success: true);
     } catch (e) {
       _logger.severe('Failed to join game: $e');
-      return false;
+      final reason = _failureReasonFromException(e);
+      _setLastOperationError(reason);
+      return JoinGameResult(success: false, failureReason: reason);
     }
   }
 
@@ -659,9 +833,9 @@ class FirebaseService {
         'lastUpdated': FieldValue.serverTimestamp(),
       };
 
-      // If game has ended, mark for cleanup
+      // If game has ended, mark for cleanup (must match Firestore rules: playing -> finished)
       if (gameState.phase == GamePhase.gameEnd) {
-        updateData['status'] = FirebaseConstants.gameStatusCompleted;
+        updateData['status'] = FirebaseConstants.gameStatusFinished;
         updateData['completedAt'] = FieldValue.serverTimestamp();
 
         // Schedule automatic cleanup after 1 hour
@@ -705,7 +879,7 @@ class FirebaseService {
 
       final completedGames = await _firestore
           .collection(gamesCollection)
-          .where('status', isEqualTo: FirebaseConstants.gameStatusCompleted)
+          .where('status', isEqualTo: FirebaseConstants.gameStatusFinished)
           .where('completedAt', isLessThan: cutoffTime)
           .limit(50) // Process in batches
           .get();
@@ -1127,5 +1301,26 @@ class FirebaseService {
         .catchError((error) {
           _logger.warning('Failed to cleanup old limit entries: $error');
         });
+  }
+
+  static MultiplayerFailureReason _failureReasonFromException(Object e) {
+    final message = e.toString().toLowerCase();
+    if (message.contains('permission-denied') ||
+        message.contains('permission denied')) {
+      return MultiplayerFailureReason.permissionDenied;
+    }
+    return MultiplayerFailureReason.unknown;
+  }
+
+  /// Exposed for unit tests verifying Firestore serialization round-trips.
+  @visibleForTesting
+  static Map<String, dynamic> gameStateToMapForTesting(GameState gameState) {
+    return _gameStateToMap(gameState);
+  }
+
+  /// Exposed for unit tests verifying Firestore deserialization round-trips.
+  @visibleForTesting
+  static GameState gameStateFromMapForTesting(Map<String, dynamic> data) {
+    return _gameStateFromMap(data);
   }
 }

--- a/test/game/enhanced_multiplayer_controller_test.dart
+++ b/test/game/enhanced_multiplayer_controller_test.dart
@@ -205,6 +205,24 @@ void main() {
       });
     });
 
+    group('Leave Game', () {
+      test('should call network adapter leaveGame', () async {
+        mockAdapter._mockUserId = 'test-user';
+        mockAdapter._mockGameId = 'TEST123';
+
+        controller = await EnhancedMultiplayerController.createGame(
+          hostPlayerName: 'TestHost',
+          maxPlayers: 4,
+          networkAdapter: mockAdapter,
+        );
+
+        final result = await controller!.leaveGame();
+
+        expect(result, isTrue);
+        expect(mockAdapter.leaveGameCalled, isTrue);
+      });
+    });
+
     group('Disposal', () {
       test('should clean up resources properly', () async {
         mockAdapter._mockUserId = 'test-user';
@@ -232,6 +250,7 @@ class TestMockNetworkAdapter extends MockNetworkAdapter {
   String? _mockUserId;
   String? _mockGameId;
   bool _mockJoinSuccess = false;
+  bool leaveGameCalled = false;
   int syncCalls = 0;
   bool isDisposed = false;
 
@@ -261,6 +280,12 @@ class TestMockNetworkAdapter extends MockNetworkAdapter {
     await Future.delayed(
       const Duration(milliseconds: 10),
     ); // Simulate network delay
+    return true;
+  }
+
+  @override
+  Future<bool> leaveGame(String gameId) async {
+    leaveGameCalled = true;
     return true;
   }
 

--- a/test/game/multiplayer_game_state_sync_test.dart
+++ b/test/game/multiplayer_game_state_sync_test.dart
@@ -325,5 +325,51 @@ void main() {
         expect(controller!.getCurrentUserPlayer()!.name, 'PlayerB');
       },
     );
+
+    test('FIX: deck syncs on incremental game state updates', () async {
+      mockAdapter.mockUserId = 'player1';
+      mockAdapter.mockGameId = 'DECK-SYNC';
+
+      controller = await EnhancedMultiplayerController.createGame(
+        hostPlayerName: 'Player1',
+        maxPlayers: 2,
+        networkAdapter: mockAdapter,
+      );
+
+      final initialDeck = Deck.createHandAndFootDeck(2, seed: 12345);
+      final initialState = GameState(
+        players: [
+          Player(id: 'player1', name: 'Player1', type: PlayerType.human),
+          Player(id: 'player2', name: 'Player2', type: PlayerType.human),
+        ],
+        deck: initialDeck,
+        phase: GamePhase.playing,
+        turnPhase: TurnPhase.draw,
+      );
+
+      await controller!.initializeFromServerState(initialState);
+      final initialDeckSize = controller!.gameState.deck.size;
+      expect(initialDeckSize, greaterThan(0));
+
+      final updatedDeck = Deck.createHandAndFootDeck(2, seed: 12345);
+      updatedDeck.drawCard();
+      updatedDeck.drawCard();
+
+      final updatedState = GameState(
+        players: initialState.players,
+        deck: updatedDeck,
+        phase: GamePhase.playing,
+        turnPhase: TurnPhase.meld,
+        currentPlayerIndex: 1,
+      );
+      updatedState.hasDrawnFromDeck = true;
+
+      mockAdapter.simulateGameStateUpdate(updatedState);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(controller!.gameState.deck.size, initialDeckSize - 2);
+      expect(controller!.gameState.turnPhase, TurnPhase.meld);
+      expect(controller!.gameState.currentPlayerIndex, 1);
+    });
   });
 }

--- a/test/integration/multiplayer_integration_test.dart
+++ b/test/integration/multiplayer_integration_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/services/firebase_service.dart';
 import 'package:hand_foot_game_flutter/services/device_service.dart';
 import 'package:hand_foot_game_flutter/game/game_controller_factory.dart';
+import 'package:hand_foot_game_flutter/game/enhanced_multiplayer_controller.dart';
 import 'package:hand_foot_game_flutter/services/firebase_constants.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 import 'package:hand_foot_game_flutter/models/game_state.dart';
@@ -10,20 +11,25 @@ import 'package:hand_foot_game_flutter/models/deck.dart';
 void main() {
   group('Mock multiplayer success path', () {
     test('create and join with mock adapter succeeds end-to-end', () async {
-      final hostController =
-          await GameControllerFactory.createTestMultiplayerGame(
-            hostPlayerName: 'Host',
-            maxPlayers: 2,
-          );
+      EnhancedMultiplayerController? hostController;
+      EnhancedMultiplayerController? guestController;
+      addTearDown(() {
+        hostController?.dispose();
+        guestController?.dispose();
+      });
+
+      hostController = await GameControllerFactory.createTestMultiplayerGame(
+        hostPlayerName: 'Host',
+        maxPlayers: 2,
+      );
 
       expect(hostController, isNotNull);
       expect(hostController!.isHost, isTrue);
 
-      final guestController =
-          await GameControllerFactory.joinTestMultiplayerGame(
-            gameId: hostController.gameId,
-            playerName: 'Guest',
-          );
+      guestController = await GameControllerFactory.joinTestMultiplayerGame(
+        gameId: hostController.gameId,
+        playerName: 'Guest',
+      );
 
       expect(guestController, isNotNull);
       expect(guestController!.isHost, isFalse);
@@ -56,9 +62,6 @@ void main() {
 
       final hostLeft = await hostController.leaveGame();
       expect(hostLeft, isTrue);
-
-      hostController.dispose();
-      guestController.dispose();
     });
   });
 

--- a/test/integration/multiplayer_integration_test.dart
+++ b/test/integration/multiplayer_integration_test.dart
@@ -3,8 +3,55 @@ import 'package:hand_foot_game_flutter/services/firebase_service.dart';
 import 'package:hand_foot_game_flutter/services/device_service.dart';
 import 'package:hand_foot_game_flutter/game/game_controller_factory.dart';
 import 'package:hand_foot_game_flutter/services/firebase_constants.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/deck.dart';
 
 void main() {
+  group('Mock multiplayer success path', () {
+    test('create and join with mock adapter succeeds end-to-end', () async {
+      final hostController = await GameControllerFactory.createTestMultiplayerGame(
+        hostPlayerName: 'Host',
+        maxPlayers: 2,
+      );
+
+      expect(hostController, isNotNull);
+      expect(hostController!.isHost, isTrue);
+
+      final guestController = await GameControllerFactory.joinTestMultiplayerGame(
+        gameId: hostController.gameId,
+        playerName: 'Guest',
+      );
+
+      expect(guestController, isNotNull);
+      expect(guestController!.isHost, isFalse);
+
+      final started = await hostController.startMultiplayerGame();
+      expect(started, isTrue);
+
+      final serverState = GameState(
+        players: [
+          Player(id: hostController.userId, name: 'Host', type: PlayerType.human),
+          Player(id: guestController.userId, name: 'Guest', type: PlayerType.human),
+        ],
+        deck: Deck(),
+        phase: GamePhase.playing,
+      );
+
+      await hostController.initializeFromServerState(serverState);
+      await guestController.initializeFromServerState(serverState);
+
+      expect(hostController.gameState.players.length, 2);
+      expect(guestController.gameState.players.length, 2);
+
+      final hostLeft = await hostController.leaveGame();
+      expect(hostLeft, isTrue);
+
+      hostController.dispose();
+      guestController.dispose();
+    });
+  });
+
   group('Multiplayer Integration Tests', () {
     test('complete game creation flow', () async {
       expect(() async {

--- a/test/integration/multiplayer_integration_test.dart
+++ b/test/integration/multiplayer_integration_test.dart
@@ -10,18 +10,20 @@ import 'package:hand_foot_game_flutter/models/deck.dart';
 void main() {
   group('Mock multiplayer success path', () {
     test('create and join with mock adapter succeeds end-to-end', () async {
-      final hostController = await GameControllerFactory.createTestMultiplayerGame(
-        hostPlayerName: 'Host',
-        maxPlayers: 2,
-      );
+      final hostController =
+          await GameControllerFactory.createTestMultiplayerGame(
+            hostPlayerName: 'Host',
+            maxPlayers: 2,
+          );
 
       expect(hostController, isNotNull);
       expect(hostController!.isHost, isTrue);
 
-      final guestController = await GameControllerFactory.joinTestMultiplayerGame(
-        gameId: hostController.gameId,
-        playerName: 'Guest',
-      );
+      final guestController =
+          await GameControllerFactory.joinTestMultiplayerGame(
+            gameId: hostController.gameId,
+            playerName: 'Guest',
+          );
 
       expect(guestController, isNotNull);
       expect(guestController!.isHost, isFalse);
@@ -31,8 +33,16 @@ void main() {
 
       final serverState = GameState(
         players: [
-          Player(id: hostController.userId, name: 'Host', type: PlayerType.human),
-          Player(id: guestController.userId, name: 'Guest', type: PlayerType.human),
+          Player(
+            id: hostController.userId,
+            name: 'Host',
+            type: PlayerType.human,
+          ),
+          Player(
+            id: guestController.userId,
+            name: 'Guest',
+            type: PlayerType.human,
+          ),
         ],
         deck: Deck(),
         phase: GamePhase.playing,

--- a/test/services/firebase_serialization_test.dart
+++ b/test/services/firebase_serialization_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/deck.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/services/firebase_service.dart';
+
+void main() {
+  group('Firebase game state serialization', () {
+    test('round-trips a full game state through Firestore maps', () {
+      final playerA = Player(
+        id: 'player-a',
+        name: 'Alice',
+        type: PlayerType.human,
+      );
+      final playerB = Player(
+        id: 'player-b',
+        name: 'Bob',
+        type: PlayerType.human,
+      );
+
+      playerA.hand.addAll([
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+      ]);
+      playerA.foot.addAll([
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+      ]);
+      playerA.melds.add(
+        Meld(
+          rank: CardRank.seven,
+          cards: [
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          ],
+        ),
+      );
+      playerA.score = 120;
+      playerA.hasPlayedDown = true;
+      playerA.hasPickedUpFoot = false;
+
+      playerB.hand.addAll([
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+      ]);
+
+      final deck = Deck.createHandAndFootDeck(2, seed: 424242);
+      deck.drawCard();
+
+      final original = GameState(
+        players: [playerA, playerB],
+        deck: deck,
+        discardPile: [
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.five),
+        ],
+        currentPlayerIndex: 1,
+        phase: GamePhase.playing,
+        turnPhase: TurnPhase.meld,
+        round: 2,
+        discardPileFrozen: true,
+        hasDrawnFromDeck: true,
+        hasMelded: false,
+      );
+      original.recentActions.add(
+        GameAction(message: 'Alice drew from deck', playerName: 'Alice'),
+      );
+
+      final serialized = FirebaseService.gameStateToMapForTesting(original);
+      final restored = FirebaseService.gameStateFromMapForTesting(serialized);
+
+      expect(restored.players.length, 2);
+      expect(restored.players[0].id, 'player-a');
+      expect(restored.players[0].hand.length, 2);
+      expect(restored.players[0].foot.length, 1);
+      expect(restored.players[0].melds.length, 1);
+      expect(restored.players[0].score, 120);
+      expect(restored.players[0].hasPlayedDown, isTrue);
+      expect(restored.players[1].hand.length, 1);
+
+      expect(restored.deck.size, original.deck.size);
+      expect(restored.discardPile.length, 1);
+      expect(restored.currentPlayerIndex, 1);
+      expect(restored.phase, GamePhase.playing);
+      expect(restored.turnPhase, TurnPhase.meld);
+      expect(restored.round, 2);
+      expect(restored.discardPileFrozen, isTrue);
+      expect(restored.hasDrawnFromDeck, isTrue);
+      expect(restored.hasMelded, isFalse);
+      expect(restored.recentActions.length, 1);
+      expect(restored.recentActions.first.playerName, 'Alice');
+    });
+  });
+}

--- a/test/services/firebase_service_test.dart
+++ b/test/services/firebase_service_test.dart
@@ -259,12 +259,40 @@ void main() {
     });
   });
 
+  group('Multiplayer typed results', () {
+    test(
+      'createGameWithResult returns typed failure for invalid input',
+      () async {
+        final result = await FirebaseService.createGameWithResult(
+          hostPlayerName: '',
+          maxPlayers: 4,
+        );
+
+        expect(result.isSuccess, isFalse);
+        expect(result.failureReason, isNotNull);
+        expect(FirebaseService.lastOperationError, isNotEmpty);
+      },
+    );
+
+    test(
+      'joinGameWithResult returns typed failure for invalid game ID',
+      () async {
+        final result = await FirebaseService.joinGameWithResult(
+          gameId: 'bad',
+          playerName: 'TestPlayer',
+        );
+
+        expect(result.isSuccess, isFalse);
+        expect(result.failureReason, isNotNull);
+        expect(FirebaseService.lastOperationError, isNotEmpty);
+      },
+    );
+  });
+
   group('Data Serialization', () {
-    // TODO: Add tests for serialization methods once we have mock Firebase setup
-    // These tests would verify the _gameStateToMap and _gameStateFromMap methods
-    test('placeholder for serialization tests', () {
-      // This would require setting up mock Firestore and game state objects
-      expect(true, true); // Placeholder
+    test('serialization helpers are exposed for testing', () {
+      expect(FirebaseService.gameStateToMapForTesting, isNotNull);
+      expect(FirebaseService.gameStateFromMapForTesting, isNotNull);
     });
   });
 }

--- a/test/services/firebase_service_test.dart
+++ b/test/services/firebase_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/services/firebase_service.dart';
 import 'package:hand_foot_game_flutter/services/firebase_constants.dart';
+import 'package:hand_foot_game_flutter/models/multiplayer_result.dart';
 
 void main() {
   group('FirebaseService Analytics', () {
@@ -261,7 +262,7 @@ void main() {
 
   group('Multiplayer typed results', () {
     test(
-      'createGameWithResult returns typed failure for invalid input',
+      'createGameWithResult returns notConfigured in stub Firebase environment',
       () async {
         final result = await FirebaseService.createGameWithResult(
           hostPlayerName: '',
@@ -269,13 +270,13 @@ void main() {
         );
 
         expect(result.isSuccess, isFalse);
-        expect(result.failureReason, isNotNull);
+        expect(result.failureReason, MultiplayerFailureReason.notConfigured);
         expect(FirebaseService.lastOperationError, isNotEmpty);
       },
     );
 
     test(
-      'joinGameWithResult returns typed failure for invalid game ID',
+      'joinGameWithResult returns notConfigured in stub Firebase environment',
       () async {
         final result = await FirebaseService.joinGameWithResult(
           gameId: 'bad',
@@ -283,7 +284,7 @@ void main() {
         );
 
         expect(result.isSuccess, isFalse);
-        expect(result.failureReason, isNotNull);
+        expect(result.failureReason, MultiplayerFailureReason.notConfigured);
         expect(FirebaseService.lastOperationError, isNotEmpty);
       },
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes critical blockers preventing real Firebase multiplayer from working end-to-end.

- **Auth alignment:** Signs in anonymously on Firebase init and uses `auth.uid` as the multiplayer player ID (matches Firestore security rules).
- **Firestore rules:** Fixes create (`request.resource.data`), join (`isPlayerJoining`), and status transitions (`playing` → `finished`).
- **State sync:** Syncs deck on incremental `_updateLocalGameState` updates so non-active clients stay consistent after draws.
- **Lifecycle:** Calls `leaveGame()` when exiting multiplayer; deduplicates `joinGame` for rejoin.
- **UX:** Gates CREATE/JOIN/REJOIN when stub Firebase config is active; surfaces typed create/join errors in the lobby via `lastOperationError`.

## Testing

- `./format_and_test.sh` — all ~750 tests pass
- New tests: serialization round-trip, deck sync, leaveGame, typed result failures, mock adapter integration success path
- Web smoke test: app serves at `http://localhost:8080` (200 OK)

## Deploy notes (required for live multiplayer)

1. Enable **Anonymous Auth** in Firebase Console
2. Deploy updated rules: `firebase deploy --only firestore`
3. Inject real Firebase web config via `.env` + `scripts/setup_local_firebase.sh` (or Vercel env vars for production)

Live two-client testing was not possible in this environment (no Firebase credentials / MCP auth).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5211-2c21-75d6-a651-dd4304f194a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5211-2c21-75d6-a651-dd4304f194a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved multiplayer create/join with typed, reason-based error messages.
  * Added “Leave Game” lifecycle support with safe exit back to the main menu.
  * Multiplayer buttons now handle “unavailable” state with an explanatory dialog.
* **Bug Fixes**
  * Fixed deck synchronization during incremental multiplayer state updates.
  * Improved host detection and joining behavior for waiting-lobby players.
  * Hardened Firestore game lifecycle rules for create/join/update authorization.
* **Tests**
  * Expanded unit/integration coverage for leaving, lobby joining, typed failures, deck sync regression, and game-state serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->