### PR TITLE
Add solo game setup screen with configurable rules and bots

### DIFF
--- a/lib/config/bot_configurations.dart
+++ b/lib/config/bot_configurations.dart
@@ -1,0 +1,35 @@
+import '../ai/bot_personality.dart';
+
+/// Bot configuration with display name and personality mapping.
+class BotConfig {
+  final String name;
+  final BotPersonality personality;
+
+  const BotConfig(this.name, this.personality);
+}
+
+/// Shared bot configurations with predefined personality mappings.
+const List<BotConfig> kBotConfigurations = [
+  BotConfig('Clara', BotPersonality.conservative),
+  BotConfig('Carl', BotPersonality.conservative),
+  BotConfig('Bob', BotPersonality.aggressive),
+  BotConfig('Rita', BotPersonality.aggressive),
+  BotConfig('Ben', BotPersonality.bookBuilder),
+  BotConfig('Tiana', BotPersonality.bookBuilder),
+  BotConfig('Alex', BotPersonality.adaptive),
+  BotConfig('Sue', BotPersonality.adaptive),
+];
+
+/// Human-readable labels for bot personalities.
+String botPersonalityLabel(BotPersonality personality) {
+  switch (personality) {
+    case BotPersonality.conservative:
+      return 'Conservative';
+    case BotPersonality.aggressive:
+      return 'Aggressive';
+    case BotPersonality.bookBuilder:
+      return 'Book Builder';
+    case BotPersonality.adaptive:
+      return 'Adaptive';
+  }
+}

--- a/lib/config/solo_game_settings.dart
+++ b/lib/config/solo_game_settings.dart
@@ -1,0 +1,212 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../ai/bot_personality.dart';
+import '../models/player.dart';
+import 'bot_configurations.dart';
+import 'game_config.dart';
+
+/// Configurable settings for a solo (human vs bots) game.
+class SoloGameSettings {
+  static const int minBotCount = 1;
+  static const int maxBotCount = 5;
+  static const String preferencesKey = 'solo_game_settings';
+
+  final int botCount;
+  final List<BotPersonality> botPersonalities;
+  final bool enableGoingOutBonus;
+  final bool enableFinalTurnAfterGoingOut;
+
+  const SoloGameSettings({
+    required this.botCount,
+    required this.botPersonalities,
+    required this.enableGoingOutBonus,
+    required this.enableFinalTurnAfterGoingOut,
+  }) : assert(botCount >= minBotCount && botCount <= maxBotCount);
+
+  static const SoloGameSettings defaults = SoloGameSettings(
+    botCount: 2,
+    botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
+    enableGoingOutBonus: true,
+    enableFinalTurnAfterGoingOut: true,
+  );
+
+  int get goingOutBonusPoints =>
+      enableGoingOutBonus ? GameConfig.goingOutBonus : 0;
+
+  /// Returns personalities padded or trimmed to match [botCount].
+  List<BotPersonality> get normalizedPersonalities {
+    if (botPersonalities.length == botCount) {
+      return List<BotPersonality>.from(botPersonalities);
+    }
+    if (botPersonalities.length > botCount) {
+      return botPersonalities.take(botCount).toList();
+    }
+    final result = List<BotPersonality>.from(botPersonalities);
+    final fallback = BotPersonality.values;
+    var index = 0;
+    while (result.length < botCount) {
+      result.add(fallback[index % fallback.length]);
+      index++;
+    }
+    return result;
+  }
+
+  SoloGameSettings copyWith({
+    int? botCount,
+    List<BotPersonality>? botPersonalities,
+    bool? enableGoingOutBonus,
+    bool? enableFinalTurnAfterGoingOut,
+  }) {
+    final nextBotCount = botCount ?? this.botCount;
+    return SoloGameSettings(
+      botCount: nextBotCount,
+      botPersonalities: botPersonalities ?? this.botPersonalities,
+      enableGoingOutBonus: enableGoingOutBonus ?? this.enableGoingOutBonus,
+      enableFinalTurnAfterGoingOut:
+          enableFinalTurnAfterGoingOut ?? this.enableFinalTurnAfterGoingOut,
+    )._normalized();
+  }
+
+  SoloGameSettings _normalized() {
+    return SoloGameSettings(
+      botCount: botCount,
+      botPersonalities: normalizedPersonalities,
+      enableGoingOutBonus: enableGoingOutBonus,
+      enableFinalTurnAfterGoingOut: enableFinalTurnAfterGoingOut,
+    );
+  }
+
+  /// Preview bot names for the setup UI (deterministic for current personalities).
+  List<String> get previewBotNames => _assignBotNames(
+    normalizedPersonalities,
+    random: Random(normalizedPersonalities.join().hashCode),
+  );
+
+  /// Builds 1 human + N bot players from these settings.
+  List<Player> buildPlayers({Random? random}) {
+    final personalities = normalizedPersonalities;
+    final botNames = _assignBotNames(personalities, random: random);
+
+    final players = <Player>[
+      Player(id: '1', name: 'You', type: PlayerType.human),
+    ];
+
+    for (var i = 0; i < botCount; i++) {
+      players.add(
+        Player(id: '${i + 2}', name: botNames[i], type: PlayerType.bot),
+      );
+    }
+
+    return players;
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'botCount': botCount,
+      'botPersonalities': botPersonalities.map((p) => p.name).toList(),
+      'enableGoingOutBonus': enableGoingOutBonus,
+      'enableFinalTurnAfterGoingOut': enableFinalTurnAfterGoingOut,
+    };
+  }
+
+  factory SoloGameSettings.fromJson(Map<String, dynamic> json) {
+    final personalities = (json['botPersonalities'] as List<dynamic>? ?? [])
+        .map((value) => _parsePersonality(value as String))
+        .toList();
+
+    return SoloGameSettings(
+      botCount: json['botCount'] as int? ?? defaults.botCount,
+      botPersonalities: personalities.isEmpty
+          ? defaults.botPersonalities
+          : personalities,
+      enableGoingOutBonus:
+          json['enableGoingOutBonus'] as bool? ?? defaults.enableGoingOutBonus,
+      enableFinalTurnAfterGoingOut:
+          json['enableFinalTurnAfterGoingOut'] as bool? ??
+          defaults.enableFinalTurnAfterGoingOut,
+    )._normalized();
+  }
+
+  static BotPersonality _parsePersonality(String value) {
+    for (final personality in BotPersonality.values) {
+      if (personality.name == value) {
+        return personality;
+      }
+    }
+    return BotPersonality.adaptive;
+  }
+
+  static Future<SoloGameSettings> loadFromPreferences() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final jsonString = prefs.getString(preferencesKey);
+      if (jsonString == null) {
+        return defaults;
+      }
+      final jsonMap = jsonDecode(jsonString) as Map<String, dynamic>;
+      return SoloGameSettings.fromJson(jsonMap);
+    } catch (_) {
+      return defaults;
+    }
+  }
+
+  Future<void> saveToPreferences() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(preferencesKey, jsonEncode(toJson()));
+    } catch (_) {
+      // Preferences are optional — ignore failures.
+    }
+  }
+
+  static List<String> _assignBotNames(
+    List<BotPersonality> personalities, {
+    Random? random,
+  }) {
+    final rng = random ?? Random();
+    final available = List<BotConfig>.from(kBotConfigurations)..shuffle(rng);
+    final usedNames = <String>{};
+    final names = <String>[];
+
+    for (final personality in personalities) {
+      final matching = available
+          .where(
+            (config) =>
+                config.personality == personality &&
+                !usedNames.contains(config.name),
+          )
+          .toList();
+
+      if (matching.isNotEmpty) {
+        names.add(matching.first.name);
+        usedNames.add(matching.first.name);
+        continue;
+      }
+
+      final fallback = available
+          .where((config) => !usedNames.contains(config.name))
+          .toList();
+      if (fallback.isNotEmpty) {
+        names.add(fallback.first.name);
+        usedNames.add(fallback.first.name);
+      } else {
+        names.add('Bot ${names.length + 1}');
+      }
+    }
+
+    return names;
+  }
+
+  /// Randomizes bot personalities for all bot slots.
+  static List<BotPersonality> randomPersonalities(int count, {Random? random}) {
+    final rng = random ?? Random();
+    final values = BotPersonality.values;
+    return List<BotPersonality>.generate(
+      count,
+      (_) => values[rng.nextInt(values.length)],
+    );
+  }
+}

--- a/lib/config/solo_game_settings.dart
+++ b/lib/config/solo_game_settings.dart
@@ -19,14 +19,18 @@ class SoloGameSettings {
   final bool enableGoingOutBonus;
   final bool enableFinalTurnAfterGoingOut;
 
-  const SoloGameSettings({
-    required this.botCount,
+  SoloGameSettings({
+    required int botCount,
     required this.botPersonalities,
     required this.enableGoingOutBonus,
     required this.enableFinalTurnAfterGoingOut,
-  }) : assert(botCount >= minBotCount && botCount <= maxBotCount);
+  }) : botCount = _clampBotCount(botCount);
 
-  static const SoloGameSettings defaults = SoloGameSettings(
+  static int _clampBotCount(int count) {
+    return count.clamp(minBotCount, maxBotCount);
+  }
+
+  static final SoloGameSettings defaults = SoloGameSettings(
     botCount: 2,
     botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
     enableGoingOutBonus: true,
@@ -118,7 +122,7 @@ class SoloGameSettings {
         .toList();
 
     return SoloGameSettings(
-      botCount: json['botCount'] as int? ?? defaults.botCount,
+      botCount: _clampBotCount(json['botCount'] as int? ?? defaults.botCount),
       botPersonalities: personalities.isEmpty
           ? defaults.botPersonalities
           : personalities,

--- a/lib/config/solo_game_settings.dart
+++ b/lib/config/solo_game_settings.dart
@@ -37,6 +37,14 @@ class SoloGameSettings {
     enableFinalTurnAfterGoingOut: true,
   );
 
+  /// Disables final-turn phase; useful for legacy tests expecting immediate round end.
+  static final SoloGameSettings immediateRoundEnd = SoloGameSettings(
+    botCount: 2,
+    botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
+    enableGoingOutBonus: true,
+    enableFinalTurnAfterGoingOut: false,
+  );
+
   int get goingOutBonusPoints =>
       enableGoingOutBonus ? GameConfig.goingOutBonus : 0;
 

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -7,6 +7,7 @@ import '../models/meld.dart';
 import '../models/round_score_breakdown.dart';
 import '../services/game_save_service.dart';
 import '../utils/debug_logger.dart';
+import '../config/solo_game_settings.dart';
 import 'game_interface.dart';
 import 'managers/meld_manager.dart';
 import 'managers/game_serializer.dart';
@@ -42,11 +43,13 @@ class GameController implements GameInterface {
     required List<Player> players,
     int? seed,
     GameEventBus? eventBus,
+    SoloGameSettings? soloSettings,
   }) {
     final actualSeed = seed ?? Random().nextInt(1000000);
     final gameState = GameState(
       players: players,
       deck: Deck.createHandAndFootDeck(players.length, seed: actualSeed),
+      soloSettings: soloSettings,
     );
 
     return GameController._internal(
@@ -193,17 +196,24 @@ class GameController implements GameInterface {
   }
 
   /// Ends the current round when a player goes out and publishes UI events.
-  /// Safe to call multiple times — no-ops if the round already ended.
-  void endRoundForPlayer(Player player) {
+  /// Returns true if the round ended immediately; false if final-turn phase started.
+  bool endRoundForPlayer(Player player) {
     if (_gameState.phase == GamePhase.roundEnd ||
         _gameState.phase == GamePhase.gameEnd) {
-      return;
+      return true;
     }
 
     final roundBefore = _gameState.round;
-    _gameState.endRound();
-    _publishRoundOrGameEndEvents(player, roundBefore);
+    final roundEnded = _gameState.handlePlayerWentOut();
+    if (roundEnded) {
+      _publishRoundOrGameEndEvents(player, roundBefore);
+    } else {
+      publishTurnEndedEvent(player);
+    }
+    return roundEnded;
   }
+
+  SoloGameSettings get soloSettings => _gameState.soloSettings;
 
   void _publishRoundOrGameEndEvents(Player player, int roundBefore) {
     final phase = _gameState.phase;
@@ -243,6 +253,11 @@ class GameController implements GameInterface {
 
       if (_gameState.phase != phaseBefore) {
         _publishRoundOrGameEndEvents(player, roundBefore);
+      } else if (_gameState.finalTurnPhaseActive &&
+          _gameState.playerWhoWentOutIndex != null &&
+          _gameState.players[_gameState.playerWhoWentOutIndex!].id ==
+              player.id) {
+        publishTurnEndedEvent(player);
       } else {
         // Check if turn ended (player changed or phase changed)
         final newPlayer = _gameState.currentPlayer;
@@ -330,6 +345,11 @@ class GameController implements GameInterface {
       // Check if player went out (round or game ended)
       if (_gameState.phase != phaseBefore) {
         _publishRoundOrGameEndEvents(player, roundBefore);
+      } else if (_gameState.finalTurnPhaseActive &&
+          _gameState.playerWhoWentOutIndex != null &&
+          _gameState.players[_gameState.playerWhoWentOutIndex!].id ==
+              player.id) {
+        publishTurnEndedEvent(player);
       }
     }
 
@@ -393,6 +413,11 @@ class GameController implements GameInterface {
       // Check if player went out (round or game ended)
       if (_gameState.phase != phaseBefore) {
         _publishRoundOrGameEndEvents(player, roundBefore);
+      } else if (_gameState.finalTurnPhaseActive &&
+          _gameState.playerWhoWentOutIndex != null &&
+          _gameState.players[_gameState.playerWhoWentOutIndex!].id ==
+              player.id) {
+        publishTurnEndedEvent(player);
       }
     }
 

--- a/lib/game/game_controller_factory.dart
+++ b/lib/game/game_controller_factory.dart
@@ -2,6 +2,7 @@ import '../models/player.dart';
 import 'game_controller.dart';
 import 'enhanced_multiplayer_controller.dart';
 import 'network_adapter.dart';
+import '../config/solo_game_settings.dart';
 
 /// Factory for creating game controllers with proper DRY architecture
 /// This centralizes controller creation logic and uses direct controller types
@@ -10,9 +11,15 @@ class GameControllerFactory {
   static GameController createSingleplayerGame({
     required List<Player> players,
     int? seed,
-    dynamic eventBus, // Optional event bus for event-driven architecture
+    dynamic eventBus,
+    SoloGameSettings? soloSettings,
   }) {
-    return GameController(players: players, seed: seed, eventBus: eventBus);
+    return GameController(
+      players: players,
+      seed: seed,
+      eventBus: eventBus,
+      soloSettings: soloSettings,
+    );
   }
 
   /// Create a multiplayer game controller with Firebase backend

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -250,6 +250,18 @@ class GameState {
         playersAwaitingFinalTurn.add(i);
       }
     }
+    for (var i = 0; i < players.length; i++) {
+      if (i != playerWhoWentOutIndex) {
+        playersAwaitingFinalTurn.add(i);
+      }
+    }
+
+    if (playersAwaitingFinalTurn.isEmpty) {
+      _logAction('🏆 went out and ended the round!');
+      endRound();
+      return true;
+    }
+
     _logAction('Final turns — one last chance for other players');
     nextPlayer();
     return false;

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -228,6 +228,12 @@ class GameState {
   ///
   /// Returns true if the round ended immediately; false if final-turn phase started.
   bool handlePlayerWentOut() {
+    if (finalTurnPhaseActive) {
+      _logAction('🏆 went out!');
+      nextPlayer();
+      return false;
+    }
+
     playerWhoWentOutIndex = currentPlayerIndex;
 
     if (!soloSettings.enableFinalTurnAfterGoingOut) {

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -4,6 +4,7 @@ import 'deck.dart';
 import 'player.dart';
 import 'meld.dart';
 import '../config/game_config.dart';
+import '../config/solo_game_settings.dart';
 import '../game/managers/game_rules_engine.dart';
 
 enum GamePhase { setup, playing, roundEnd, gameEnd }
@@ -63,6 +64,18 @@ class GameState {
   bool _isMultiplayer = false;
   String? _viewerId;
 
+  /// Solo game rule settings (bot count is reflected in [players] length).
+  SoloGameSettings soloSettings;
+
+  /// True while other players take one final turn after someone goes out.
+  bool finalTurnPhaseActive;
+
+  /// Player index who went out this round (used for scoring).
+  int? playerWhoWentOutIndex;
+
+  /// Player indices still owed a final turn after a go-out.
+  final Set<int> playersAwaitingFinalTurn;
+
   GameState({
     required this.players,
     required this.deck,
@@ -76,10 +89,16 @@ class GameState {
     this.discardPileFrozen = false,
     this.hasDrawnFromDeck = false,
     this.hasMelded = false,
+    SoloGameSettings? soloSettings,
+    this.finalTurnPhaseActive = false,
+    this.playerWhoWentOutIndex,
+    Set<int>? playersAwaitingFinalTurn,
     bool isMultiplayer = false,
     String? viewerId,
   }) : discardPile = discardPile ?? [],
        recentActions = recentActions ?? [],
+       soloSettings = soloSettings ?? SoloGameSettings.defaults,
+       playersAwaitingFinalTurn = playersAwaitingFinalTurn ?? {},
        _isMultiplayer = isMultiplayer,
        _viewerId = viewerId;
 
@@ -186,6 +205,56 @@ class GameState {
     currentPlayer.clearNewlyDrawnCards();
   }
 
+  /// Complete the active turn, advance play, and end the round if final turns are done.
+  ///
+  /// Returns true when [endRound] was triggered (round or game ended).
+  bool completeTurn() {
+    final finishedIndex = currentPlayerIndex;
+    nextPlayer();
+
+    if (finalTurnPhaseActive) {
+      playersAwaitingFinalTurn.remove(finishedIndex);
+      if (playersAwaitingFinalTurn.isEmpty) {
+        _logAction('Final turns complete — round ending');
+        endRound();
+        return true;
+      }
+    }
+
+    return phase == GamePhase.roundEnd || phase == GamePhase.gameEnd;
+  }
+
+  /// Handle a player meeting go-out conditions.
+  ///
+  /// Returns true if the round ended immediately; false if final-turn phase started.
+  bool handlePlayerWentOut() {
+    playerWhoWentOutIndex = currentPlayerIndex;
+
+    if (!soloSettings.enableFinalTurnAfterGoingOut) {
+      _logAction('🏆 went out and ended the round!');
+      endRound();
+      return true;
+    }
+
+    _logAction('🏆 went out!');
+    finalTurnPhaseActive = true;
+    playersAwaitingFinalTurn.clear();
+    for (var i = 0; i < players.length; i++) {
+      if (i != playerWhoWentOutIndex) {
+        playersAwaitingFinalTurn.add(i);
+      }
+    }
+    _logAction('Final turns — one last chance for other players');
+    nextPlayer();
+    return false;
+  }
+
+  void _resetFinalTurnState() {
+    finalTurnPhaseActive = false;
+    playerWhoWentOutIndex = null;
+    playersAwaitingFinalTurn.clear();
+  }
+
   void startRound() {
     phase = GamePhase.playing;
     currentPlayerIndex = 0;
@@ -193,6 +262,8 @@ class GameState {
     discardPileFrozen = false;
     hasDrawnFromDeck = false;
     hasMelded = false;
+
+    _resetFinalTurnState();
 
     // Reset stalemate tracking for new round
     _resetStalemateTracking();
@@ -433,9 +504,6 @@ class GameState {
 
       // Check if player has gone out after melding
       if (currentPlayer.canGoOut) {
-        _logAction('🏆 went out and ended the round!');
-
-        // Defensive logging for going out via playMeld
         if (kDebugMode) {
           _logAction(
             'GOING OUT DEBUG (playMeld): footSize=${currentPlayer.foot.length}, '
@@ -444,19 +512,7 @@ class GameState {
           );
         }
 
-        endRound();
-
-        // Defensive check: Verify round actually ended (could be roundEnd or gameEnd if someone won)
-        if (phase != GamePhase.roundEnd && phase != GamePhase.gameEnd) {
-          _logAction(
-            'ERROR: endRound() called from playMeld but phase is still $phase!',
-          );
-          print(
-            'Warning: Unexpected phase after endRound() in playMeld, but continuing game',
-          );
-          // Don't throw exception - log warning but continue game gracefully
-        }
-
+        handlePlayerWentOut();
         return true;
       }
 
@@ -501,9 +557,6 @@ class GameState {
 
       // Check if player has gone out after melding
       if (currentPlayer.canGoOut) {
-        _logAction('🏆 went out and ended the round!');
-
-        // Defensive logging for going out via playMeldBypass
         if (kDebugMode) {
           _logAction(
             'GOING OUT DEBUG (playMeldBypass): footSize=${currentPlayer.foot.length}, '
@@ -512,19 +565,7 @@ class GameState {
           );
         }
 
-        endRound();
-
-        // Defensive check: Verify round actually ended (could be roundEnd or gameEnd if someone won)
-        if (phase != GamePhase.roundEnd && phase != GamePhase.gameEnd) {
-          _logAction(
-            'ERROR: endRound() called from playMeldBypass but phase is still $phase!',
-          );
-          print(
-            'Warning: Unexpected phase after endRound() in playMeldBypass, but continuing game',
-          );
-          // Don't throw exception - log warning but continue game gracefully
-        }
-
+        handlePlayerWentOut();
         return true;
       }
 
@@ -587,25 +628,12 @@ class GameState {
 
     // Check if player has gone out after adding to meld
     if (currentPlayer.canGoOut) {
-      _logAction('🏆 went out and ended the round!');
-
-      // Defensive logging: Record the going out decision
       if (kDebugMode) {
         _logAction('GOING OUT DEBUG: Pre-op: $preOpState');
         _logAction('GOING OUT DEBUG: Post-op: $postOpState');
       }
 
-      endRound();
-
-      // Defensive check: Verify round actually ended (could be roundEnd or gameEnd if someone won)
-      if (phase != GamePhase.roundEnd && phase != GamePhase.gameEnd) {
-        _logAction(
-          'ERROR: endRound() called but phase is still $phase - this should not happen!',
-        );
-        print(
-          'Warning: Unexpected phase after endRound(), but continuing game',
-        );
-      }
+      handlePlayerWentOut();
     } else {
       // Debug: Log why player can't go out when they have empty hands
       if (currentPlayer.currentHand.isEmpty && kDebugMode) {
@@ -657,8 +685,7 @@ class GameState {
       }
 
       if (currentPlayer.canGoOut) {
-        _logAction('🏆 went out and ended the round!');
-        endRound();
+        handlePlayerWentOut();
         return true;
       }
 
@@ -683,7 +710,7 @@ class GameState {
         }
       }
 
-      nextPlayer();
+      completeTurn();
       return true;
     }
     return false;
@@ -765,7 +792,11 @@ class GameState {
     // Calculate penalty points for cards in hand
     for (final player in players) {
       // Record detailed score breakdown for stalemate (no one went out)
-      player.recordRoundScoreBreakdown(round: round, wentOut: false);
+      player.recordRoundScoreBreakdown(
+        round: round,
+        wentOut: false,
+        goingOutBonusPoints: soloSettings.goingOutBonusPoints,
+      );
 
       // Calculate total score including penalties for unplayed cards
       final meldValue = player.calculateMeldValue();
@@ -836,15 +867,18 @@ class GameState {
 
     // Find the player who went out (if any)
     final playersWhoCanGoOut = players.where((p) => p.canGoOut).toList();
-    final playerWhoWentOut = playersWhoCanGoOut.isEmpty
-        ? null
-        : playersWhoCanGoOut.first;
+    final Player? playerWhoWentOut = playerWhoWentOutIndex != null
+        ? players[playerWhoWentOutIndex!]
+        : (playersWhoCanGoOut.isEmpty ? null : playersWhoCanGoOut.first);
+
+    final goingOutBonus = soloSettings.goingOutBonusPoints;
 
     for (final player in players) {
       // Record detailed score breakdown before updating total score
       player.recordRoundScoreBreakdown(
         round: round,
         wentOut: player == playerWhoWentOut,
+        goingOutBonusPoints: goingOutBonus,
       );
 
       // CRITICAL FIX: Include ALL unplayed cards (hand + foot) as negative when round ends
@@ -854,11 +888,13 @@ class GameState {
 
       // Add going out bonus
       if (player == playerWhoWentOut) {
-        roundScore += GameConfig.goingOutBonus;
+        roundScore += goingOutBonus;
       }
 
       player.updateScore(roundScore);
     }
+
+    _resetFinalTurnState();
 
     final highestScore = players
         .map((p) => p.score)

--- a/lib/models/player.dart
+++ b/lib/models/player.dart
@@ -401,7 +401,11 @@ class Player {
   }
 
   /// Records the detailed score breakdown for a completed round
-  void recordRoundScoreBreakdown({required int round, required bool wentOut}) {
+  void recordRoundScoreBreakdown({
+    required int round,
+    required bool wentOut,
+    int? goingOutBonusPoints,
+  }) {
     // Prevent duplicate round entries
     if (roundScoreHistory.any((breakdown) => breakdown.round == round)) {
       return;
@@ -410,7 +414,9 @@ class Player {
     final cardPoints =
         calculateMeldValue() - (cleanBookPoints + dirtyBookPoints);
     final penaltyPoints = calculateAllUnplayedCardsValue();
-    final goingOutBonus = wentOut ? GameConfig.goingOutBonus : 0;
+    final goingOutBonus = wentOut
+        ? (goingOutBonusPoints ?? GameConfig.goingOutBonus)
+        : 0;
     final totalRoundScore =
         cardPoints +
         cleanBookPoints +

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -11,6 +10,9 @@ import '../game/game_controller.dart';
 import '../game/game_controller_factory.dart';
 import '../ai/enhanced_bot_ai.dart';
 import '../ai/bot_personality.dart';
+import '../config/bot_configurations.dart';
+import '../config/solo_game_settings.dart';
+import '../services/firebase_service.dart';
 import '../widgets/melds_section.dart';
 import '../widgets/game_hand_display.dart';
 import '../widgets/game_board_layout.dart';
@@ -23,6 +25,7 @@ import '../services/game_analytics_logger.dart';
 import '../services/analytics_batcher.dart';
 import '../services/analytics_fields.dart';
 import 'main_menu_screen.dart';
+import 'solo_game_setup_screen.dart';
 import '../utils/debug_logger.dart';
 import 'managers/bot_turn_manager.dart';
 import 'managers/dialog_manager.dart';
@@ -32,31 +35,19 @@ import 'managers/event_based_game_state_manager.dart';
 import '../providers/game_providers.dart';
 import '../providers/computed_providers.dart';
 
-/// Bot configuration for randomized personality assignment
-class BotConfig {
-  final String name;
-  final BotPersonality personality;
-
-  const BotConfig(this.name, this.personality);
-}
-
-/// Shared bot configurations with predefined personality mappings
-const List<BotConfig> kBotConfigurations = [
-  BotConfig('Clara', BotPersonality.conservative),
-  BotConfig('Carl', BotPersonality.conservative),
-  BotConfig('Bob', BotPersonality.aggressive),
-  BotConfig('Rita', BotPersonality.aggressive),
-  BotConfig('Ben', BotPersonality.bookBuilder),
-  BotConfig('Tiana', BotPersonality.bookBuilder),
-  BotConfig('Alex', BotPersonality.adaptive),
-  BotConfig('Sue', BotPersonality.adaptive),
-];
+/// Shared bot configurations live in [kBotConfigurations].
 
 class GameScreen extends ConsumerStatefulWidget {
   final int? testSeed; // For deterministic testing
   final GameController? gameController; // For continuing saved games
+  final SoloGameSettings? settings; // For new solo games from setup screen
 
-  const GameScreen({super.key, this.testSeed, this.gameController});
+  const GameScreen({
+    super.key,
+    this.testSeed,
+    this.gameController,
+    this.settings,
+  });
 
   @override
   ConsumerState<GameScreen> createState() => _GameScreenState();
@@ -326,7 +317,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
               TextButton(
                 onPressed: () {
                   Navigator.pop(context);
-                  _startFreshGame();
+                  _navigateToSoloSetup();
                 },
                 child: const Text('New Game'),
               ),
@@ -347,27 +338,16 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     _startFreshGame();
   }
 
-  /// Generate random bot configurations with varied personalities and names
-  List<BotConfig> _generateRandomBotConfigurations() {
-    final Random random = Random();
-
-    // Use shared bot configurations
-    final botOptions = List<BotConfig>.from(kBotConfigurations);
-
-    // Shuffle and take first two to ensure no duplicates
-    botOptions.shuffle(random);
-    return botOptions.take(2).toList();
+  void _navigateToSoloSetup() {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (context) => const SoloGameSetupScreen()),
+    );
   }
 
   void _startFreshGame() {
-    // Randomize bot personalities and names each game for variety
-    final botConfigs = _generateRandomBotConfigurations();
-
-    final players = [
-      Player(id: '1', name: 'You', type: PlayerType.human),
-      Player(id: '2', name: botConfigs[0].name, type: PlayerType.bot),
-      Player(id: '3', name: botConfigs[1].name, type: PlayerType.bot),
-    ];
+    final settings = widget.settings ?? SoloGameSettings.defaults;
+    final players = settings.buildPlayers();
+    final personalities = settings.normalizedPersonalities;
 
     // Debug logging for player setup
     DebugLogger.debug('Setting up fresh game with players:');
@@ -385,15 +365,20 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       players: players,
       seed: widget.testSeed,
       eventBus: eventBus,
+      soloSettings: settings,
     );
 
     // Store in Riverpod provider for reactive access
     controllerNotifier.setController(newController, eventBus);
 
-    // Use Riverpod provider for bot AI
+    // Assign bot personalities from setup settings
     final botAI = ref.read(botAIProvider);
-    botAI.assignPersonality('2', botConfigs[0].personality);
-    botAI.assignPersonality('3', botConfigs[1].personality);
+    final botPlayers = players.where((p) => p.type == PlayerType.bot).toList();
+    for (var i = 0; i < botPlayers.length; i++) {
+      botAI.assignPersonality(botPlayers[i].id, personalities[i]);
+    }
+
+    _logSoloGameStarted(settings);
 
     newController.initializeGame();
 
@@ -884,6 +869,25 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     }
   }
 
+  Future<void> _logSoloGameStarted(SoloGameSettings settings) async {
+    try {
+      await FirebaseService.logGameEvent(
+        'solo_game_started',
+        parameters: {
+          'game_type': 'solo',
+          'botCount': settings.botCount,
+          'botPersonalities': settings.normalizedPersonalities
+              .map((p) => p.name)
+              .join(','),
+          'goingOutBonus': settings.enableGoingOutBonus,
+          'finalTurn': settings.enableFinalTurnAfterGoingOut,
+        },
+      );
+    } catch (_) {
+      // Silently ignore Firebase errors in singleplayer mode
+    }
+  }
+
   Future<void> _startNewGame() async {
     // Clear any saved game when explicitly starting new
     await GameController.clearSavedGame();
@@ -894,8 +898,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       _viewingPlayerMelds = null;
     });
 
-    // Start a fresh game directly (not checking for saves)
-    _startFreshGame();
+    _navigateToSoloSetup();
   }
 
   void _onDrawFromDeck() {

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -300,6 +302,12 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       return;
     }
 
+    // Configured solo start from setup screen takes priority over saved game.
+    if (widget.settings != null) {
+      _startFreshGame();
+      return;
+    }
+
     // Check if there's a saved game
     final hasSaved = await GameController.hasSavedGame();
 
@@ -346,7 +354,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
   void _startFreshGame() {
     final settings = widget.settings ?? SoloGameSettings.defaults;
-    final players = settings.buildPlayers();
+    final nameSeed =
+        widget.testSeed ?? settings.normalizedPersonalities.join().hashCode;
+    final players = settings.buildPlayers(random: Random(nameSeed));
     final personalities = settings.normalizedPersonalities;
 
     // Debug logging for player setup

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../theme/balatro_theme.dart';
 import 'game_screen.dart';
 import 'multiplayer_lobby_screen.dart';
+import 'solo_game_setup_screen.dart';
 import 'multiplayer_game_screen.dart';
 import '../services/firebase_service.dart';
 import '../services/game_save_service.dart';
@@ -578,20 +579,9 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
   void _startSoloGame() async {
     setState(() => _isLoading = true);
 
-    // Log solo game start - completely optional, never crash singleplayer
-    try {
-      await FirebaseService.logGameEvent(
-        'solo_game_started',
-        parameters: {'game_type': 'solo'},
-      );
-    } catch (e) {
-      // Silently ignore Firebase errors in singleplayer mode
-      // Game must work completely offline
-    }
-
     if (mounted) {
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (context) => const GameScreen()),
+      Navigator.of(context).push(
+        MaterialPageRoute(builder: (context) => const SoloGameSetupScreen()),
       );
     }
 

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -7,29 +7,10 @@ import '../../game/game_controller.dart';
 import '../../ai/enhanced_bot_ai.dart';
 import '../../ai/bot_decision.dart';
 import '../../ai/bot_personality.dart';
+import '../../config/bot_configurations.dart';
 import '../../utils/debug_logger.dart';
 import '../../config/game_config.dart';
 import '../../services/analytics_batcher.dart';
-
-/// Bot configuration for personality assignment
-class BotConfig {
-  final String name;
-  final BotPersonality personality;
-
-  const BotConfig(this.name, this.personality);
-}
-
-/// Shared bot configurations with predefined personality mappings
-const List<BotConfig> kBotConfigurations = [
-  BotConfig('Clara', BotPersonality.conservative),
-  BotConfig('Carl', BotPersonality.conservative),
-  BotConfig('Bob', BotPersonality.aggressive),
-  BotConfig('Rita', BotPersonality.aggressive),
-  BotConfig('Ben', BotPersonality.bookBuilder),
-  BotConfig('Tiana', BotPersonality.bookBuilder),
-  BotConfig('Alex', BotPersonality.adaptive),
-  BotConfig('Sue', BotPersonality.adaptive),
-];
 
 /// Manages all bot-related functionality for the game screen.
 ///

--- a/lib/screens/solo_game_setup_screen.dart
+++ b/lib/screens/solo_game_setup_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../ai/bot_personality.dart';
 import '../config/bot_configurations.dart';
+import '../config/game_config.dart';
 import '../config/solo_game_settings.dart';
 import '../theme/balatro_theme.dart';
 import 'game_screen.dart';
@@ -103,7 +104,8 @@ class _SoloGameSetupScreenState extends State<SoloGameSetupScreen> {
                             _buildBotPersonalitiesSection(),
                             const SizedBox(height: 24),
                             _buildRuleToggle(
-                              title: '+100 pts to first player out',
+                              title:
+                                  '+${GameConfig.goingOutBonus} pts to first player out',
                               subtitle:
                                   'Bonus for the player who goes out first each round',
                               value: _settings.enableGoingOutBonus,

--- a/lib/screens/solo_game_setup_screen.dart
+++ b/lib/screens/solo_game_setup_screen.dart
@@ -1,0 +1,379 @@
+import 'package:flutter/material.dart';
+
+import '../ai/bot_personality.dart';
+import '../config/bot_configurations.dart';
+import '../config/solo_game_settings.dart';
+import '../theme/balatro_theme.dart';
+import 'game_screen.dart';
+
+/// Pre-game configuration screen for solo play.
+class SoloGameSetupScreen extends StatefulWidget {
+  const SoloGameSetupScreen({super.key});
+
+  @override
+  State<SoloGameSetupScreen> createState() => _SoloGameSetupScreenState();
+}
+
+class _SoloGameSetupScreenState extends State<SoloGameSetupScreen> {
+  late SoloGameSettings _settings;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    final settings = await SoloGameSettings.loadFromPreferences();
+    if (mounted) {
+      setState(() {
+        _settings = settings;
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _setBotCount(int count) {
+    setState(() {
+      _settings = _settings.copyWith(botCount: count);
+    });
+  }
+
+  void _setBotPersonality(int index, BotPersonality personality) {
+    final personalities = List<BotPersonality>.from(
+      _settings.normalizedPersonalities,
+    );
+    personalities[index] = personality;
+    setState(() {
+      _settings = _settings.copyWith(botPersonalities: personalities);
+    });
+  }
+
+  void _randomizePersonalities() {
+    setState(() {
+      _settings = _settings.copyWith(
+        botPersonalities: SoloGameSettings.randomPersonalities(
+          _settings.botCount,
+        ),
+      );
+    });
+  }
+
+  Future<void> _startGame() async {
+    await _settings.saveToPreferences();
+    if (!mounted) {
+      return;
+    }
+
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (context) => GameScreen(settings: _settings)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Color(0xFF1a0d2e), Color(0xFF16213e), Color(0xFF0f3460)],
+          ),
+        ),
+        child: SafeArea(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(
+                    color: BalatroTheme.neonPink,
+                  ),
+                )
+              : Column(
+                  children: [
+                    _buildHeader(),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        padding: const EdgeInsets.all(20),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            _buildBotCountSelector(),
+                            const SizedBox(height: 24),
+                            _buildBotPersonalitiesSection(),
+                            const SizedBox(height: 24),
+                            _buildRuleToggle(
+                              title: '+100 pts to first player out',
+                              subtitle:
+                                  'Bonus for the player who goes out first each round',
+                              value: _settings.enableGoingOutBonus,
+                              onChanged: (value) {
+                                setState(() {
+                                  _settings = _settings.copyWith(
+                                    enableGoingOutBonus: value,
+                                  );
+                                });
+                              },
+                            ),
+                            const SizedBox(height: 16),
+                            _buildRuleToggle(
+                              title: 'One more turn after going out',
+                              subtitle:
+                                  'Other players each get one final turn after someone goes out',
+                              value: _settings.enableFinalTurnAfterGoingOut,
+                              onChanged: (value) {
+                                setState(() {
+                                  _settings = _settings.copyWith(
+                                    enableFinalTurnAfterGoingOut: value,
+                                  );
+                                });
+                              },
+                            ),
+                            const SizedBox(height: 32),
+                            _buildStartButton(),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          IconButton(
+            onPressed: () => Navigator.of(context).pop(),
+            icon: const Icon(Icons.arrow_back, color: Colors.white),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            'SOLO GAME SETUP',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: BalatroTheme.neonBlue,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBotCountSelector() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Number of Bots',
+          style: TextStyle(
+            color: BalatroTheme.neonPink,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'You + ${_settings.botCount} bot${_settings.botCount == 1 ? '' : 's'} = ${_settings.botCount + 1} players',
+          style: TextStyle(
+            color: BalatroTheme.primaryText.withValues(alpha: 0.7),
+            fontSize: 14,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: List.generate(SoloGameSettings.maxBotCount, (index) {
+            final count = index + 1;
+            final isSelected = _settings.botCount == count;
+            return Expanded(
+              child: GestureDetector(
+                onTap: () => _setBotCount(count),
+                child: Container(
+                  margin: const EdgeInsets.symmetric(horizontal: 4),
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  decoration: BoxDecoration(
+                    color: isSelected
+                        ? BalatroTheme.neonPink.withValues(alpha: 0.3)
+                        : BalatroTheme.cardBackground,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: isSelected
+                          ? BalatroTheme.neonPink
+                          : BalatroTheme.neonPink.withValues(alpha: 0.3),
+                      width: isSelected ? 2 : 1,
+                    ),
+                  ),
+                  child: Text(
+                    '$count',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: isSelected ? BalatroTheme.neonPink : Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBotPersonalitiesSection() {
+    final personalities = _settings.normalizedPersonalities;
+    final previewNames = _settings.previewBotNames;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Bot Personalities',
+                style: TextStyle(
+                  color: BalatroTheme.neonPink,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            TextButton.icon(
+              onPressed: _randomizePersonalities,
+              icon: const Icon(Icons.shuffle, color: BalatroTheme.neonBlue),
+              label: const Text(
+                'Randomize',
+                style: TextStyle(color: BalatroTheme.neonBlue),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ...List.generate(personalities.length, (index) {
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: _buildBotPersonalityRow(
+              botNumber: index + 1,
+              botName: previewNames[index],
+              personality: personalities[index],
+              onChanged: (value) {
+                if (value != null) {
+                  _setBotPersonality(index, value);
+                }
+              },
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  Widget _buildBotPersonalityRow({
+    required int botNumber,
+    required String botName,
+    required BotPersonality personality,
+    required ValueChanged<BotPersonality?> onChanged,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: BalatroTheme.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: BalatroTheme.neonPink.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Bot $botNumber: $botName',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          DropdownButton<BotPersonality>(
+            value: personality,
+            dropdownColor: BalatroTheme.darkPurple,
+            underline: const SizedBox.shrink(),
+            style: const TextStyle(color: Colors.white),
+            items: BotPersonality.values
+                .map(
+                  (value) => DropdownMenuItem(
+                    value: value,
+                    child: Text(botPersonalityLabel(value)),
+                  ),
+                )
+                .toList(),
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRuleToggle({
+    required String title,
+    required String subtitle,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: BalatroTheme.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: BalatroTheme.neonPink.withValues(alpha: 0.3)),
+      ),
+      child: SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        title: Text(
+          title,
+          style: const TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        subtitle: Text(
+          subtitle,
+          style: TextStyle(
+            color: BalatroTheme.primaryText.withValues(alpha: 0.7),
+            fontSize: 13,
+          ),
+        ),
+        value: value,
+        activeColor: BalatroTheme.neonPink,
+        onChanged: onChanged,
+      ),
+    );
+  }
+
+  Widget _buildStartButton() {
+    return ElevatedButton(
+      onPressed: _startGame,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: BalatroTheme.neonPink,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+      child: const Text(
+        'START GAME',
+        style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+}

--- a/lib/services/game_save_service.dart
+++ b/lib/services/game_save_service.dart
@@ -6,6 +6,7 @@ import '../models/player.dart';
 import '../models/card.dart';
 import '../models/meld.dart';
 import '../game/game_controller.dart';
+import '../config/solo_game_settings.dart';
 
 class GameSaveService {
   static const String _saveKey = 'hand_foot_game_save';
@@ -95,6 +96,10 @@ class GameSaveService {
       'discardPileFrozen': gameState.discardPileFrozen,
       'hasDrawnFromDeck': gameState.hasDrawnFromDeck,
       'hasMelded': gameState.hasMelded,
+      'soloSettings': gameState.soloSettings.toJson(),
+      'finalTurnPhaseActive': gameState.finalTurnPhaseActive,
+      'playerWhoWentOutIndex': gameState.playerWhoWentOutIndex,
+      'playersAwaitingFinalTurn': gameState.playersAwaitingFinalTurn.toList(),
     };
   }
 
@@ -143,9 +148,18 @@ class GameSaveService {
           .toList();
 
       final gameSeed = savedData['gameSeed'] as int?;
+      final soloSettings = savedData['soloSettings'] != null
+          ? SoloGameSettings.fromJson(
+              savedData['soloSettings'] as Map<String, dynamic>,
+            )
+          : SoloGameSettings.defaults;
 
       // Create game controller with restored players and seed
-      final gameController = GameController(players: players, seed: gameSeed);
+      final gameController = GameController(
+        players: players,
+        seed: gameSeed,
+        soloSettings: soloSettings,
+      );
 
       // Restore game state
       _restoreGameState(gameController.gameState, savedData);
@@ -200,6 +214,23 @@ class GameSaveService {
     gameState.discardPileFrozen = savedData['discardPileFrozen'] as bool;
     gameState.hasDrawnFromDeck = savedData['hasDrawnFromDeck'] as bool;
     gameState.hasMelded = savedData['hasMelded'] as bool;
+
+    if (savedData['soloSettings'] != null) {
+      gameState.soloSettings = SoloGameSettings.fromJson(
+        savedData['soloSettings'] as Map<String, dynamic>,
+      );
+    }
+    gameState.finalTurnPhaseActive =
+        savedData['finalTurnPhaseActive'] as bool? ?? false;
+    gameState.playerWhoWentOutIndex =
+        savedData['playerWhoWentOutIndex'] as int?;
+    gameState.playersAwaitingFinalTurn.clear();
+    final awaiting = savedData['playersAwaitingFinalTurn'] as List<dynamic>?;
+    if (awaiting != null) {
+      gameState.playersAwaitingFinalTurn.addAll(
+        awaiting.map((value) => value as int),
+      );
+    }
 
     // Find winner if exists
     final winnerId = savedData['winner'] as String?;

--- a/test/ai/bot_turn_manager_execution_test.dart
+++ b/test/ai/bot_turn_manager_execution_test.dart
@@ -10,7 +10,7 @@ import 'package:hand_foot_game_flutter/models/meld.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 import 'package:hand_foot_game_flutter/screens/managers/bot_turn_manager.dart';
 
-const _immediateRoundEndSettings = SoloGameSettings(
+final _immediateRoundEndSettings = SoloGameSettings(
   botCount: 1,
   botPersonalities: [BotPersonality.adaptive],
   enableGoingOutBonus: true,

--- a/test/ai/bot_turn_manager_execution_test.dart
+++ b/test/ai/bot_turn_manager_execution_test.dart
@@ -1,12 +1,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/ai/bot_decision.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
 import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
 import 'package:hand_foot_game_flutter/game/game_controller.dart';
 import 'package:hand_foot_game_flutter/models/card.dart';
 import 'package:hand_foot_game_flutter/models/game_state.dart';
 import 'package:hand_foot_game_flutter/models/meld.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 import 'package:hand_foot_game_flutter/screens/managers/bot_turn_manager.dart';
+
+const _immediateRoundEndSettings = SoloGameSettings(
+  botCount: 1,
+  botPersonalities: [BotPersonality.adaptive],
+  enableGoingOutBonus: true,
+  enableFinalTurnAfterGoingOut: false,
+);
 
 void main() {
   group('BotTurnManager execution', () {
@@ -19,7 +28,11 @@ void main() {
         Player(id: 'human', name: 'You', type: PlayerType.human),
         Player(id: 'bot1', name: 'Clara', type: PlayerType.bot),
       ];
-      gameController = GameController(players: players, seed: 454749);
+      gameController = GameController(
+        players: players,
+        seed: 454749,
+        soloSettings: _immediateRoundEndSettings,
+      );
       gameController.initializeGame();
       botPlayer = players[1];
       botPlayer.hasPlayedDown = true;

--- a/test/config/solo_game_settings_test.dart
+++ b/test/config/solo_game_settings_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'dart:math';
 import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
 import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
@@ -64,9 +65,30 @@ void main() {
       expect(restored.enableFinalTurnAfterGoingOut, isFalse);
     });
 
+    test('fromJson clamps out-of-range botCount', () {
+      final restored = SoloGameSettings.fromJson({'botCount': 99});
+      expect(restored.botCount, SoloGameSettings.maxBotCount);
+    });
+
+    test('copyWith clamps out-of-range botCount', () {
+      final settings = SoloGameSettings.defaults.copyWith(botCount: 0);
+      expect(settings.botCount, SoloGameSettings.minBotCount);
+    });
+
     test('previewBotNames returns one name per bot', () {
       final settings = SoloGameSettings.defaults.copyWith(botCount: 3);
       expect(settings.previewBotNames, hasLength(3));
+    });
+
+    test('buildPlayers uses preview-name seed for deterministic names', () {
+      final settings = SoloGameSettings.defaults;
+      final nameSeed = settings.normalizedPersonalities.join().hashCode;
+      final players = settings.buildPlayers(random: Random(nameSeed));
+      final botNames = players
+          .where((p) => p.type == PlayerType.bot)
+          .map((p) => p.name)
+          .toList();
+      expect(botNames, settings.previewBotNames);
     });
   });
 }

--- a/test/config/solo_game_settings_test.dart
+++ b/test/config/solo_game_settings_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('SoloGameSettings', () {
+    test('defaults match expected solo configuration', () {
+      expect(SoloGameSettings.defaults.botCount, 2);
+      expect(SoloGameSettings.defaults.enableGoingOutBonus, isTrue);
+      expect(SoloGameSettings.defaults.enableFinalTurnAfterGoingOut, isTrue);
+      expect(SoloGameSettings.defaults.normalizedPersonalities, hasLength(2));
+    });
+
+    test('copyWith pads personalities when bot count increases', () {
+      final settings = SoloGameSettings.defaults.copyWith(botCount: 4);
+      expect(settings.normalizedPersonalities, hasLength(4));
+    });
+
+    test('copyWith trims personalities when bot count decreases', () {
+      final settings = SoloGameSettings.defaults.copyWith(botCount: 1);
+      expect(settings.normalizedPersonalities, hasLength(1));
+    });
+
+    test('goingOutBonusPoints respects toggle', () {
+      expect(SoloGameSettings.defaults.goingOutBonusPoints, 100);
+      expect(
+        SoloGameSettings.defaults
+            .copyWith(enableGoingOutBonus: false)
+            .goingOutBonusPoints,
+        0,
+      );
+    });
+
+    test('buildPlayers creates one human and configured bots', () {
+      final settings = SoloGameSettings.defaults.copyWith(botCount: 3);
+      final players = settings.buildPlayers();
+
+      expect(players, hasLength(4));
+      expect(players.first.type, PlayerType.human);
+      expect(players.where((p) => p.type == PlayerType.bot), hasLength(3));
+      expect(players.map((p) => p.name).toSet(), hasLength(4));
+    });
+
+    test('toJson and fromJson round-trip', () {
+      final original = SoloGameSettings(
+        botCount: 3,
+        botPersonalities: [
+          BotPersonality.aggressive,
+          BotPersonality.bookBuilder,
+          BotPersonality.conservative,
+        ],
+        enableGoingOutBonus: false,
+        enableFinalTurnAfterGoingOut: false,
+      );
+
+      final restored = SoloGameSettings.fromJson(original.toJson());
+      expect(restored.botCount, 3);
+      expect(
+        restored.normalizedPersonalities,
+        original.normalizedPersonalities,
+      );
+      expect(restored.enableGoingOutBonus, isFalse);
+      expect(restored.enableFinalTurnAfterGoingOut, isFalse);
+    });
+
+    test('previewBotNames returns one name per bot', () {
+      final settings = SoloGameSettings.defaults.copyWith(botCount: 3);
+      expect(settings.previewBotNames, hasLength(3));
+    });
+  });
+}

--- a/test/game/bot_go_out_round_transition_regression_test.dart
+++ b/test/game/bot_go_out_round_transition_regression_test.dart
@@ -9,14 +9,14 @@ import 'package:hand_foot_game_flutter/models/game_state.dart';
 import 'package:hand_foot_game_flutter/models/meld.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 
-const _immediateRoundEndSettings = SoloGameSettings(
+final _immediateRoundEndSettings = SoloGameSettings(
   botCount: 1,
   botPersonalities: [BotPersonality.adaptive],
   enableGoingOutBonus: true,
   enableFinalTurnAfterGoingOut: false,
 );
 
-const _threePlayerImmediateRoundEndSettings = SoloGameSettings(
+final _threePlayerImmediateRoundEndSettings = SoloGameSettings(
   botCount: 2,
   botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
   enableGoingOutBonus: true,

--- a/test/game/bot_go_out_round_transition_regression_test.dart
+++ b/test/game/bot_go_out_round_transition_regression_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
 import 'package:hand_foot_game_flutter/game/events/game_event.dart';
 import 'package:hand_foot_game_flutter/game/events/game_event_bus.dart';
 import 'package:hand_foot_game_flutter/game/game_controller.dart';
@@ -6,6 +8,20 @@ import 'package:hand_foot_game_flutter/models/card.dart';
 import 'package:hand_foot_game_flutter/models/game_state.dart';
 import 'package:hand_foot_game_flutter/models/meld.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
+
+const _immediateRoundEndSettings = SoloGameSettings(
+  botCount: 1,
+  botPersonalities: [BotPersonality.adaptive],
+  enableGoingOutBonus: true,
+  enableFinalTurnAfterGoingOut: false,
+);
+
+const _threePlayerImmediateRoundEndSettings = SoloGameSettings(
+  botCount: 2,
+  botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
+  enableGoingOutBonus: true,
+  enableFinalTurnAfterGoingOut: false,
+);
 
 void main() {
   group('GameController round transition regression', () {
@@ -26,6 +42,7 @@ void main() {
         final controller = GameController(
           players: [human, rita],
           eventBus: eventBus,
+          soloSettings: _immediateRoundEndSettings,
         );
         controller.initializeGame();
 
@@ -61,6 +78,7 @@ void main() {
         final controller = GameController(
           players: [human, rita],
           eventBus: eventBus,
+          soloSettings: _immediateRoundEndSettings,
         );
         controller.initializeGame();
 
@@ -84,7 +102,10 @@ void main() {
       final human = Player(id: '1', name: 'You', type: PlayerType.human);
       final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
       final alex = Player(id: '3', name: 'Alex', type: PlayerType.bot);
-      final controller = GameController(players: [human, rita, alex]);
+      final controller = GameController(
+        players: [human, rita, alex],
+        soloSettings: _threePlayerImmediateRoundEndSettings,
+      );
       controller.initializeGame();
 
       _setupPlayerToGoOut(rita);
@@ -143,6 +164,7 @@ void main() {
       final controller = GameController(
         players: [human, rita],
         eventBus: eventBus,
+        soloSettings: _immediateRoundEndSettings,
       );
       controller.initializeGame();
       _setupPlayerToGoOut(rita);

--- a/test/models/final_turn_phase_test.dart
+++ b/test/models/final_turn_phase_test.dart
@@ -7,14 +7,14 @@ import 'package:hand_foot_game_flutter/models/game_state.dart';
 import 'package:hand_foot_game_flutter/models/meld.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 
-const _noFinalTurnSettings = SoloGameSettings(
+final _noFinalTurnSettings = SoloGameSettings(
   botCount: 2,
   botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
   enableGoingOutBonus: true,
   enableFinalTurnAfterGoingOut: false,
 );
 
-const _withFinalTurnSettings = SoloGameSettings(
+final _withFinalTurnSettings = SoloGameSettings(
   botCount: 2,
   botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
   enableGoingOutBonus: true,

--- a/test/models/final_turn_phase_test.dart
+++ b/test/models/final_turn_phase_test.dart
@@ -95,6 +95,35 @@ void main() {
       expect(gameState.phase, GamePhase.roundEnd);
       expect(gameState.finalTurnPhaseActive, isFalse);
     });
+
+    test('second go-out during final turn does not reset went-out player', () {
+      final players = [
+        Player(id: '1', name: 'You', type: PlayerType.human),
+        Player(id: '2', name: 'Rita', type: PlayerType.bot),
+        Player(id: '3', name: 'Bob', type: PlayerType.bot),
+      ];
+      final gameState = GameState(
+        players: players,
+        deck: Deck.createHandAndFootDeck(players.length),
+        soloSettings: _withFinalTurnSettings,
+      );
+
+      gameState.phase = GamePhase.playing;
+      _setupPlayerToGoOut(players[0]);
+      gameState.currentPlayerIndex = 0;
+      gameState.handlePlayerWentOut();
+      expect(gameState.playerWhoWentOutIndex, 0);
+      expect(gameState.playersAwaitingFinalTurn, {1, 2});
+
+      gameState.phase = GamePhase.playing;
+      _setupPlayerToGoOut(players[1]);
+      gameState.currentPlayerIndex = 1;
+      gameState.handlePlayerWentOut();
+
+      expect(gameState.playerWhoWentOutIndex, 0);
+      expect(gameState.playersAwaitingFinalTurn, {1, 2});
+      expect(gameState.currentPlayerIndex, 2);
+    });
   });
 }
 

--- a/test/models/final_turn_phase_test.dart
+++ b/test/models/final_turn_phase_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/deck.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+const _noFinalTurnSettings = SoloGameSettings(
+  botCount: 2,
+  botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
+  enableGoingOutBonus: true,
+  enableFinalTurnAfterGoingOut: false,
+);
+
+const _withFinalTurnSettings = SoloGameSettings(
+  botCount: 2,
+  botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
+  enableGoingOutBonus: true,
+  enableFinalTurnAfterGoingOut: true,
+);
+
+void main() {
+  group('Final turn phase', () {
+    test('disabled setting ends round immediately on go-out', () {
+      final players = [
+        Player(id: '1', name: 'You', type: PlayerType.human),
+        Player(id: '2', name: 'Rita', type: PlayerType.bot),
+        Player(id: '3', name: 'Bob', type: PlayerType.bot),
+      ];
+      final gameState = GameState(
+        players: players,
+        deck: Deck.createHandAndFootDeck(players.length),
+        soloSettings: _noFinalTurnSettings,
+      );
+
+      gameState.phase = GamePhase.playing;
+      _setupPlayerToGoOut(players[0]);
+      gameState.currentPlayerIndex = 0;
+
+      final ended = gameState.handlePlayerWentOut();
+
+      expect(ended, isTrue);
+      expect(gameState.phase, GamePhase.roundEnd);
+      expect(gameState.finalTurnPhaseActive, isFalse);
+    });
+
+    test('enabled setting starts final turn phase for other players', () {
+      final players = [
+        Player(id: '1', name: 'You', type: PlayerType.human),
+        Player(id: '2', name: 'Rita', type: PlayerType.bot),
+        Player(id: '3', name: 'Bob', type: PlayerType.bot),
+      ];
+      final gameState = GameState(
+        players: players,
+        deck: Deck.createHandAndFootDeck(players.length),
+        soloSettings: _withFinalTurnSettings,
+      );
+
+      gameState.phase = GamePhase.playing;
+      _setupPlayerToGoOut(players[0]);
+      gameState.currentPlayerIndex = 0;
+
+      final ended = gameState.handlePlayerWentOut();
+
+      expect(ended, isFalse);
+      expect(gameState.phase, GamePhase.playing);
+      expect(gameState.finalTurnPhaseActive, isTrue);
+      expect(gameState.playersAwaitingFinalTurn, {1, 2});
+      expect(gameState.currentPlayerIndex, 1);
+    });
+
+    test('final turns complete after each other player takes one turn', () {
+      final players = [
+        Player(id: '1', name: 'You', type: PlayerType.human),
+        Player(id: '2', name: 'Rita', type: PlayerType.bot),
+        Player(id: '3', name: 'Bob', type: PlayerType.bot),
+      ];
+      final gameState = GameState(
+        players: players,
+        deck: Deck.createHandAndFootDeck(players.length),
+        soloSettings: _withFinalTurnSettings,
+      );
+
+      gameState.phase = GamePhase.playing;
+      _setupPlayerToGoOut(players[0]);
+      gameState.currentPlayerIndex = 0;
+      gameState.handlePlayerWentOut();
+
+      expect(gameState.currentPlayerIndex, 1);
+      expect(gameState.completeTurn(), isFalse);
+      expect(gameState.currentPlayerIndex, 2);
+      expect(gameState.completeTurn(), isTrue);
+      expect(gameState.phase, GamePhase.roundEnd);
+      expect(gameState.finalTurnPhaseActive, isFalse);
+    });
+  });
+}
+
+void _setupPlayerToGoOut(Player player) {
+  player.hand.clear();
+  player.foot.clear();
+  player.melds.clear();
+
+  final cleanBook = Meld.createMeld([
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+  ])!;
+
+  final dirtyBook = Meld.createMeld([
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+    const PlayingCard(rank: CardRank.joker),
+  ])!;
+
+  player.melds.add(cleanBook);
+  player.melds.add(dirtyBook);
+  player.hasPlayedDown = true;
+  player.hasPickedUpFoot = true;
+}

--- a/test/models/game_state_test.dart
+++ b/test/models/game_state_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
 import 'package:hand_foot_game_flutter/models/card.dart';
 import 'package:hand_foot_game_flutter/models/deck.dart';
 import 'package:hand_foot_game_flutter/models/meld.dart';
@@ -16,7 +17,11 @@ void main() {
         Player(id: '2', name: 'Player 2', type: PlayerType.bot),
       ];
       final deck = Deck.createHandAndFootDeck(players.length);
-      gameState = GameState(players: players, deck: deck);
+      gameState = GameState(
+        players: players,
+        deck: deck,
+        soloSettings: SoloGameSettings.immediateRoundEnd,
+      );
     });
 
     test('should initialize with correct default values', () {

--- a/test/models/going_out_bonus_settings_test.dart
+++ b/test/models/going_out_bonus_settings_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/deck.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Going out bonus settings', () {
+    test('applies +100 bonus when enabled', () {
+      final players = [
+        Player(id: '1', name: 'You', type: PlayerType.human),
+        Player(id: '2', name: 'Rita', type: PlayerType.bot),
+      ];
+      final settings = SoloGameSettings(
+        botCount: 1,
+        botPersonalities: [BotPersonality.adaptive],
+        enableGoingOutBonus: true,
+        enableFinalTurnAfterGoingOut: false,
+      );
+      final gameState = GameState(
+        players: players,
+        deck: Deck.createHandAndFootDeck(players.length),
+        soloSettings: settings,
+      );
+
+      _setupPlayerToGoOut(players[1]);
+      gameState.currentPlayerIndex = 1;
+      gameState.handlePlayerWentOut();
+
+      expect(players[1].score, greaterThan(players[0].score));
+      expect(players[1].roundScoreHistory.single.goingOutBonus, 100);
+    });
+
+    test('skips bonus when disabled', () {
+      final players = [
+        Player(id: '1', name: 'You', type: PlayerType.human),
+        Player(id: '2', name: 'Rita', type: PlayerType.bot),
+      ];
+      final settings = SoloGameSettings(
+        botCount: 1,
+        botPersonalities: [BotPersonality.adaptive],
+        enableGoingOutBonus: false,
+        enableFinalTurnAfterGoingOut: false,
+      );
+      final gameState = GameState(
+        players: players,
+        deck: Deck.createHandAndFootDeck(players.length),
+        soloSettings: settings,
+      );
+
+      _setupPlayerToGoOut(players[1]);
+      gameState.currentPlayerIndex = 1;
+      gameState.handlePlayerWentOut();
+
+      expect(players[1].roundScoreHistory.single.goingOutBonus, 0);
+    });
+  });
+}
+
+void _setupPlayerToGoOut(Player player) {
+  player.hand.clear();
+  player.foot.clear();
+  player.melds.clear();
+
+  final cleanBook = Meld.createMeld([
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+  ])!;
+
+  final dirtyBook = Meld.createMeld([
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+    const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+    const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+    const PlayingCard(rank: CardRank.joker),
+  ])!;
+
+  player.melds.add(cleanBook);
+  player.melds.add(dirtyBook);
+  player.hasPlayedDown = true;
+  player.hasPickedUpFoot = true;
+}

--- a/test/screens/bot_personality_assignment_fix_test.dart
+++ b/test/screens/bot_personality_assignment_fix_test.dart
@@ -3,7 +3,6 @@ import 'package:hand_foot_game_flutter/models/player.dart';
 import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
 import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
 import 'package:hand_foot_game_flutter/config/bot_configurations.dart';
-import 'package:hand_foot_game_flutter/screens/managers/bot_turn_manager.dart';
 
 /// Simple test for the bot personality assignment functionality
 void main() {

--- a/test/screens/bot_personality_assignment_fix_test.dart
+++ b/test/screens/bot_personality_assignment_fix_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
 import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/config/bot_configurations.dart';
 import 'package:hand_foot_game_flutter/screens/managers/bot_turn_manager.dart';
 
 /// Simple test for the bot personality assignment functionality

--- a/test/ui/round_transition_test.dart
+++ b/test/ui/round_transition_test.dart
@@ -3,6 +3,7 @@ import 'package:hand_foot_game_flutter/models/card.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 import 'package:hand_foot_game_flutter/models/game_state.dart';
 import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
 import 'package:hand_foot_game_flutter/game/game_controller.dart';
 
 void main() {
@@ -16,7 +17,10 @@ void main() {
         Player(id: '2', name: 'Bot1', type: PlayerType.bot),
         Player(id: '3', name: 'Bot2', type: PlayerType.bot),
       ];
-      gameController = GameController(players: players);
+      gameController = GameController(
+        players: players,
+        soloSettings: SoloGameSettings.immediateRoundEnd,
+      );
       gameController.initializeGame();
       humanPlayer = players[0];
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a pre-game setup screen for solo play so users can configure opponents and house rules before starting a game.

## Changes

- **New `SoloGameSetupScreen`** — opened from PLAY SOLO with:
  - Bot count selector (1–5 bots)
  - Per-bot personality dropdowns with Randomize
  - Toggle: +100 pts to first player out
  - Toggle: one more turn for other players after someone goes out
- **`SoloGameSettings` model** — builds players, persists last-used settings via SharedPreferences, serializes into game saves
- **Final-turn phase** — when enabled, round continues until each other player takes one final turn before scoring
- **Going-out bonus toggle** — respects `enableGoingOutBonus` in round scoring and score breakdown
- **Shared `kBotConfigurations`** extracted to `lib/config/bot_configurations.dart`

## Testing

- `./format_and_test.sh` passes (format, analyze, full test suite)
- New tests: `solo_game_settings_test`, `final_turn_phase_test`, `going_out_bonus_settings_test`
- Updated regression tests for immediate round-end behavior when final-turn is disabled

## Notes

- CONTINUE restores saved settings from disk
- New Game (from save dialog or in-game menu) routes back to setup screen
- Defaults match current/family rules: 2 bots, +100 bonus on, final turns on

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5315890d-f9cd-4dd4-8995-3ebec5d658de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5315890d-f9cd-4dd4-8995-3ebec5d658de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a solo-game setup flow to choose bot count, bot personalities, and rule toggles.
  * Persisted solo-game preferences and carried them through new games and saved-game restores.
  * Added optional going-out bonus and “final turn after going out” endgame handling.
* **Bug Fixes**
  * Improved round/turn transitions around going out, including correct final-turn sequencing.
  * Fixed scoring so going-out bonus and “went out” attribution reflect solo settings.
* **Tests**
  * Added/updated unit and regression tests for solo settings, final-turn phase, and scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->