### PR TITLE
Add perfect 22-card grab mini-game (+100 bonus)

### DIFF
--- a/lib/config/game_config.dart
+++ b/lib/config/game_config.dart
@@ -67,6 +67,12 @@ class GameConfig {
   /// Bonus points awarded to player who goes out first
   static const int goingOutBonus = 100;
 
+  /// Bonus points for grabbing exactly hand + foot cards at round start
+  static const int perfectGrabBonus = 100;
+
+  /// Target card count for the perfect-grab mini-game (hand + foot)
+  static const int perfectGrabTarget = handSize + footSize; // 22 cards
+
   /// Total points needed to win the game
   static const int winningScore = 8500;
 

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import '../config/game_config.dart';
 import '../models/card.dart';
 import '../models/deck.dart';
 import '../models/player.dart';
@@ -72,15 +73,40 @@ class GameController implements GameInterface {
   // ============= Core Game Flow =============
 
   @override
-  void initializeGame() {
+  void initializeGame({bool dealCards = true}) {
     _gameState.deck.shuffle();
     _gameState.startRound();
+    if (dealCards) {
+      _completeRoundStart(earnedPerfectGrabBonus: false);
+    }
+  }
+
+  /// Shuffles and resets play state for the next round without dealing cards.
+  /// Call [completeRoundStart] after the perfect-grab mini-game finishes.
+  void prepareNewRoundDeal() {
+    if (_gameState.phase == GamePhase.roundEnd) {
+      _gameState.resetForNewRound(dealCardsAfterReset: false);
+    }
+  }
+
+  /// Deals cards and optionally awards the perfect-grab bonus to the human player.
+  void completeRoundStart({required bool earnedPerfectGrabBonus}) {
+    _completeRoundStart(earnedPerfectGrabBonus: earnedPerfectGrabBonus);
+  }
+
+  void _completeRoundStart({required bool earnedPerfectGrabBonus}) {
     _gameState.dealCards();
 
-    // Publish round started event
-    _eventBus.publish(RoundStartedEvent(roundNumber: _gameState.round));
+    if (earnedPerfectGrabBonus) {
+      final humanPlayer = _gameState.players.firstWhere(
+        (player) => player.type == PlayerType.human,
+        orElse: () => _gameState.players.first,
+      );
+      humanPlayer.updateScore(GameConfig.perfectGrabBonus);
+      _gameState.logPerfectGrabBonus(humanPlayer.name);
+    }
 
-    // Auto-save after new game initialization
+    _eventBus.publish(RoundStartedEvent(roundNumber: _gameState.round));
     saveGame().catchError((e) => DebugLogger.error('Auto-save failed: $e'));
   }
 
@@ -280,15 +306,13 @@ class GameController implements GameInterface {
   }
 
   @override
-  void nextRound() {
+  void nextRound({bool dealCards = true}) {
     if (_gameState.phase == GamePhase.roundEnd) {
-      _gameState.resetForNewRound();
-
-      // Publish round started event
-      _eventBus.publish(RoundStartedEvent(roundNumber: _gameState.round));
-
-      // Auto-save after round transition
-      saveGame().catchError((e) => DebugLogger.error('Auto-save failed: $e'));
+      _gameState.resetForNewRound(dealCardsAfterReset: dealCards);
+      if (dealCards) {
+        _eventBus.publish(RoundStartedEvent(roundNumber: _gameState.round));
+        saveGame().catchError((e) => DebugLogger.error('Auto-save failed: $e'));
+      }
     }
   }
 

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -98,12 +98,18 @@ class GameController implements GameInterface {
     _gameState.dealCards();
 
     if (earnedPerfectGrabBonus) {
-      final humanPlayer = _gameState.players.firstWhere(
-        (player) => player.type == PlayerType.human,
-        orElse: () => _gameState.players.first,
-      );
-      humanPlayer.updateScore(GameConfig.perfectGrabBonus);
-      _gameState.logPerfectGrabBonus(humanPlayer.name);
+      final humanPlayers = _gameState.players
+          .where((player) => player.type == PlayerType.human)
+          .toList();
+      if (humanPlayers.isEmpty) {
+        DebugLogger.warning(
+          'Perfect grab bonus skipped: no human player in game',
+        );
+      } else {
+        final humanPlayer = humanPlayers.first;
+        humanPlayer.updateScore(GameConfig.perfectGrabBonus);
+        _gameState.logPerfectGrabBonus(humanPlayer.name);
+      }
     }
 
     _eventBus.publish(RoundStartedEvent(roundNumber: _gameState.round));

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -146,6 +146,13 @@ class GameState {
     _logAction(message, showCardDetails: showCardDetails);
   }
 
+  void logPerfectGrabBonus(String playerName) {
+    _logAction(
+      '🎯 $playerName perfect 22-card grab! +${GameConfig.perfectGrabBonus} bonus points',
+      showCardDetails: false,
+    );
+  }
+
   String _sanitizeMessage(String message) {
     // Remove specific card details from bot actions that shouldn't be visible
     if (message.startsWith('drew:')) {
@@ -885,7 +892,7 @@ class GameState {
     endRound();
   }
 
-  void resetForNewRound() {
+  void resetForNewRound({bool dealCardsAfterReset = true}) {
     if (phase != GamePhase.roundEnd) return;
 
     deck.addCards(discardPile);
@@ -903,7 +910,9 @@ class GameState {
 
     deck.shuffle();
     startRound();
-    dealCards();
+    if (dealCardsAfterReset) {
+      dealCards();
+    }
   }
 
   List<Player> getPlayersInOrder() {

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/game_action_buttons.dart';
 import '../widgets/game_app_bar.dart';
 import '../widgets/game_session_info_menu.dart';
 import '../widgets/card_animation_host.dart';
+import '../widgets/perfect_grab_mini_game.dart';
 import '../theme/balatro_theme.dart';
 import '../services/game_analytics_logger.dart';
 import '../services/analytics_batcher.dart';
@@ -395,29 +396,66 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     botAI.assignPersonality('2', botConfigs[0].personality);
     botAI.assignPersonality('3', botConfigs[1].personality);
 
-    newController.initializeGame();
+    newController.initializeGame(dealCards: false);
 
     // Initialize managers after game setup
     _initializeManagers();
 
-    // Sort the human player's initial hand
-    final humanPlayer = players.firstWhere((p) => p.type == PlayerType.human);
-    humanPlayer.sortHandByRank();
+    _runPerfectGrabAndStartRound(newController, roundNumber: 1);
+  }
 
-    // Start analytics session tracking
-    _startAnalyticsSession();
-
-    _isInitialized = true;
-
-    // If the first player is human, save the initial game state
-    final gameState = ref.read(currentGameStateProvider);
-    if (gameState?.currentPlayer.type == PlayerType.human) {
-      _persistenceManager.saveGameState().catchError((error) {
-        DebugLogger.error('Error saving initial game state: $error');
-      });
+  Future<void> _runPerfectGrabAndStartRound(
+    GameController controller, {
+    required int roundNumber,
+  }) async {
+    if (_disposed || !mounted) {
+      return;
     }
 
-    processCurrentPlayerTurn();
+    final earnedBonus = await PerfectGrabMiniGame.show(
+      context,
+      roundNumber: roundNumber,
+    );
+    if (_disposed || !mounted) {
+      return;
+    }
+
+    controller.completeRoundStart(earnedPerfectGrabBonus: earnedBonus);
+
+    // Sort the human player's initial hand
+    final humanPlayer = controller.gameState.players.firstWhere(
+      (player) => player.type == PlayerType.human,
+    );
+    humanPlayer.sortHandByRank();
+
+    if (!_isInitialized) {
+      // Start analytics session tracking
+      _startAnalyticsSession();
+      _isInitialized = true;
+
+      // If the first player is human, save the initial game state
+      final gameState = ref.read(currentGameStateProvider);
+      if (gameState?.currentPlayer.type == PlayerType.human) {
+        _persistenceManager.saveGameState().catchError((error) {
+          DebugLogger.error('Error saving initial game state: $error');
+        });
+      }
+    } else {
+      if (mounted) {
+        _selectedCardIndices.clear();
+        _viewingPlayerMelds = null;
+
+        _persistenceManager.saveGameState().catchError((error) {
+          DebugLogger.error(
+            'Error saving game state after round transition: $error',
+          );
+        });
+      }
+    }
+
+    if (mounted) {
+      processCurrentPlayerTurn();
+    }
   }
 
   /// Queue bot turn to process one at a time
@@ -636,21 +674,15 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         return;
       }
 
-      controller.nextRound();
+      final nextRoundNumber = controller.gameState.round;
+      controller.prepareNewRoundDeal();
+      DebugLogger.debug('Prepared deal for round $nextRoundNumber');
+
+      await _runPerfectGrabAndStartRound(
+        controller,
+        roundNumber: nextRoundNumber,
+      );
       DebugLogger.debug('Advanced to round ${controller.gameState.round}');
-
-      if (mounted) {
-        _selectedCardIndices.clear();
-        _viewingPlayerMelds = null;
-
-        _persistenceManager.saveGameState().catchError((error) {
-          DebugLogger.error(
-            'Error saving game state after round transition: $error',
-          );
-        });
-
-        processCurrentPlayerTurn();
-      }
     } catch (e) {
       DebugLogger.error('Error during round transition: $e');
       if (mounted) {

--- a/lib/widgets/perfect_grab_mini_game.dart
+++ b/lib/widgets/perfect_grab_mini_game.dart
@@ -1,0 +1,407 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../config/game_config.dart';
+import '../theme/balatro_theme.dart';
+import 'card_back_widget.dart';
+
+enum _PerfectGrabPhase { intro, countdown, playing, result }
+
+/// Timing-based mini-game: grab exactly 22 cards after the shuffle.
+///
+/// Cards deal automatically at accelerating speed. Tap GRAB when you believe
+/// you have exactly [GameConfig.perfectGrabTarget] cards for a +100 point bonus.
+class PerfectGrabMiniGame extends StatefulWidget {
+  final int roundNumber;
+  final void Function(bool earnedBonus) onComplete;
+
+  const PerfectGrabMiniGame({
+    super.key,
+    required this.roundNumber,
+    required this.onComplete,
+  });
+
+  static Future<bool> show(BuildContext context, {required int roundNumber}) {
+    return showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        return Dialog(
+          backgroundColor: Colors.transparent,
+          insetPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 24,
+          ),
+          child: PerfectGrabMiniGame(
+            roundNumber: roundNumber,
+            onComplete: (earnedBonus) {
+              Navigator.of(dialogContext).pop(earnedBonus);
+            },
+          ),
+        );
+      },
+    ).then((result) => result ?? false);
+  }
+
+  @override
+  State<PerfectGrabMiniGame> createState() => _PerfectGrabMiniGameState();
+}
+
+class _PerfectGrabMiniGameState extends State<PerfectGrabMiniGame>
+    with SingleTickerProviderStateMixin {
+  static const int _target = GameConfig.perfectGrabTarget;
+  static const int _maxCards = 34;
+  static const Duration _baseDealInterval = Duration(milliseconds: 340);
+  static const Duration _minDealInterval = Duration(milliseconds: 72);
+  static const int _intervalStepMs = 11;
+  static const int _jitterMs = 45;
+
+  final Random _random = Random();
+
+  _PerfectGrabPhase _phase = _PerfectGrabPhase.intro;
+  int _cardCount = 0;
+  int _countdown = 3;
+  bool? _earnedBonus;
+  Timer? _timer;
+  late final AnimationController _pulseController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+      lowerBound: 0.92,
+      upperBound: 1.08,
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  void _startCountdown() {
+    setState(() {
+      _phase = _PerfectGrabPhase.countdown;
+      _countdown = 3;
+    });
+    _scheduleCountdownTick();
+  }
+
+  void _scheduleCountdownTick() {
+    _timer?.cancel();
+    _timer = Timer(const Duration(seconds: 1), () {
+      if (!mounted) {
+        return;
+      }
+      if (_countdown > 1) {
+        setState(() {
+          _countdown--;
+        });
+        _scheduleCountdownTick();
+      } else {
+        _beginDealing();
+      }
+    });
+  }
+
+  void _beginDealing() {
+    setState(() {
+      _phase = _PerfectGrabPhase.playing;
+      _cardCount = 0;
+    });
+    _scheduleNextCard();
+  }
+
+  Duration _dealIntervalForCard(int nextCardIndex) {
+    final baseMs = max(
+      _minDealInterval.inMilliseconds,
+      _baseDealInterval.inMilliseconds -
+          ((nextCardIndex - 1) * _intervalStepMs),
+    );
+    final jitter = _random.nextInt(_jitterMs * 2 + 1) - _jitterMs;
+    return Duration(milliseconds: max(60, baseMs + jitter));
+  }
+
+  void _scheduleNextCard() {
+    if (_phase != _PerfectGrabPhase.playing) {
+      return;
+    }
+    if (_cardCount >= _maxCards) {
+      _finishGrab(forced: true);
+      return;
+    }
+
+    _timer?.cancel();
+    _timer = Timer(_dealIntervalForCard(_cardCount + 1), () {
+      if (!mounted || _phase != _PerfectGrabPhase.playing) {
+        return;
+      }
+      setState(() {
+        _cardCount++;
+      });
+      HapticFeedback.selectionClick();
+      _scheduleNextCard();
+    });
+  }
+
+  void _finishGrab({bool forced = false}) {
+    _timer?.cancel();
+    final success = !forced && _cardCount == _target;
+    setState(() {
+      _phase = _PerfectGrabPhase.result;
+      _earnedBonus = success;
+    });
+    if (success) {
+      HapticFeedback.heavyImpact();
+    } else {
+      HapticFeedback.lightImpact();
+    }
+    _timer = Timer(const Duration(milliseconds: 2200), () {
+      if (mounted) {
+        widget.onComplete(success);
+      }
+    });
+  }
+
+  void _skipMiniGame() {
+    _timer?.cancel();
+    widget.onComplete(false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 520, maxHeight: 640),
+      decoration: BalatroTheme.glowDecoration(
+        backgroundColor: BalatroTheme.darkPurple,
+        glowColor: BalatroTheme.neonGreen,
+        borderRadius: 20,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildHeader(),
+            const SizedBox(height: 16),
+            Expanded(child: _buildBody()),
+            const SizedBox(height: 12),
+            if (_phase != _PerfectGrabPhase.result) _buildSkipButton(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Column(
+      children: [
+        Text(
+          'Perfect Grab',
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            color: BalatroTheme.neonYellow,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Round ${widget.roundNumber} — grab exactly $_target cards',
+          textAlign: TextAlign.center,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(color: BalatroTheme.secondaryText),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBody() {
+    switch (_phase) {
+      case _PerfectGrabPhase.intro:
+        return _buildIntro();
+      case _PerfectGrabPhase.countdown:
+        return _buildCountdown();
+      case _PerfectGrabPhase.playing:
+        return _buildPlaying();
+      case _PerfectGrabPhase.result:
+        return _buildResult();
+    }
+  }
+
+  Widget _buildIntro() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Icon(Icons.back_hand, color: BalatroTheme.neonGreen, size: 56),
+        const SizedBox(height: 16),
+        Text(
+          'After shuffling, reach across the table and grab your hand & foot '
+          'in one swoop.\n\n'
+          'Cards will deal automatically — tap GRAB at exactly $_target cards '
+          'to earn +${GameConfig.perfectGrabBonus} bonus points!',
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: BalatroTheme.primaryText,
+            height: 1.4,
+          ),
+        ),
+        const SizedBox(height: 24),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: _startCountdown,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: BalatroTheme.neonGreen,
+              foregroundColor: BalatroTheme.deepPurple,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+            ),
+            child: const Text('GET READY'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCountdown() {
+    return Center(
+      child: Text(
+        '$_countdown',
+        style: Theme.of(context).textTheme.displayLarge?.copyWith(
+          color: BalatroTheme.neonPink,
+          fontWeight: FontWeight.bold,
+          fontSize: 96,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPlaying() {
+    final isNearTarget = (_cardCount - _target).abs() <= 2 && _cardCount > 0;
+    final counterColor = _cardCount == _target
+        ? BalatroTheme.neonGreen
+        : isNearTarget
+        ? BalatroTheme.neonYellow
+        : BalatroTheme.primaryText;
+
+    return Column(
+      children: [
+        Text(
+          '$_cardCount',
+          style: Theme.of(context).textTheme.displayMedium?.copyWith(
+            color: counterColor,
+            fontWeight: FontWeight.bold,
+            fontSize: 72,
+          ),
+        ),
+        Text(
+          'cards grabbed',
+          style: Theme.of(
+            context,
+          ).textTheme.titleMedium?.copyWith(color: BalatroTheme.secondaryText),
+        ),
+        const SizedBox(height: 12),
+        Expanded(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final stackHeight = min(constraints.maxHeight, 220.0);
+              final cardWidth = min(constraints.maxWidth * 0.34, 96.0);
+              final cardHeight = cardWidth / GameConfig.cardAspectRatio;
+              final visibleCards = min(_cardCount, 8);
+
+              return Center(
+                child: SizedBox(
+                  width: cardWidth + 24,
+                  height: stackHeight,
+                  child: Stack(
+                    alignment: Alignment.bottomCenter,
+                    children: [
+                      for (int i = 0; i < visibleCards; i++)
+                        Positioned(
+                          bottom: i * 6.0,
+                          child: CardBackWidget(
+                            width: cardWidth,
+                            height: cardHeight,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 8),
+        ScaleTransition(
+          scale: _pulseController,
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {
+                _finishGrab();
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: BalatroTheme.neonPink,
+                padding: const EdgeInsets.symmetric(vertical: 18),
+              ),
+              child: const Text(
+                'GRAB!',
+                style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildResult() {
+    final success = _earnedBonus ?? false;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(
+          success ? Icons.celebration : Icons.close,
+          color: success ? BalatroTheme.neonGreen : BalatroTheme.neonOrange,
+          size: 64,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          success ? 'Perfect Grab!' : 'So Close...',
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            color: success ? BalatroTheme.neonGreen : BalatroTheme.neonOrange,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          success
+              ? '+${GameConfig.perfectGrabBonus} bonus points added!'
+              : 'You grabbed $_cardCount cards. Need exactly $_target.',
+          textAlign: TextAlign.center,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyLarge?.copyWith(color: BalatroTheme.primaryText),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSkipButton() {
+    return TextButton(
+      onPressed: _skipMiniGame,
+      child: Text(
+        'Skip (no bonus)',
+        style: Theme.of(
+          context,
+        ).textTheme.bodySmall?.copyWith(color: BalatroTheme.secondaryText),
+      ),
+    );
+  }
+}

--- a/lib/widgets/perfect_grab_mini_game.dart
+++ b/lib/widgets/perfect_grab_mini_game.dart
@@ -18,10 +18,15 @@ class PerfectGrabMiniGame extends StatefulWidget {
   final int roundNumber;
   final void Function(bool earnedBonus) onComplete;
 
+  /// Fixed deal interval for deterministic widget tests.
+  @visibleForTesting
+  final Duration? fixedDealInterval;
+
   const PerfectGrabMiniGame({
     super.key,
     required this.roundNumber,
     required this.onComplete,
+    this.fixedDealInterval,
   });
 
   static Future<bool> show(BuildContext context, {required int roundNumber}) {
@@ -120,6 +125,10 @@ class _PerfectGrabMiniGameState extends State<PerfectGrabMiniGame>
   }
 
   Duration _dealIntervalForCard(int nextCardIndex) {
+    if (widget.fixedDealInterval != null) {
+      return widget.fixedDealInterval!;
+    }
+
     final baseMs = max(
       _minDealInterval.inMilliseconds,
       _baseDealInterval.inMilliseconds -
@@ -193,7 +202,7 @@ class _PerfectGrabMiniGameState extends State<PerfectGrabMiniGame>
             const SizedBox(height: 16),
             Expanded(child: _buildBody()),
             const SizedBox(height: 12),
-            if (_phase != _PerfectGrabPhase.result) _buildSkipButton(),
+            ...(_phase != _PerfectGrabPhase.result ? [_buildSkipButton()] : []),
           ],
         ),
       ),
@@ -321,16 +330,16 @@ class _PerfectGrabMiniGameState extends State<PerfectGrabMiniGame>
                   height: stackHeight,
                   child: Stack(
                     alignment: Alignment.bottomCenter,
-                    children: [
-                      for (int i = 0; i < visibleCards; i++)
-                        Positioned(
-                          bottom: i * 6.0,
-                          child: CardBackWidget(
-                            width: cardWidth,
-                            height: cardHeight,
-                          ),
+                    children: List.generate(
+                      visibleCards,
+                      (i) => Positioned(
+                        bottom: i * 6.0,
+                        child: CardBackWidget(
+                          width: cardWidth,
+                          height: cardHeight,
                         ),
-                    ],
+                      ),
+                    ),
                   ),
                 ),
               );

--- a/test/game/perfect_grab_bonus_test.dart
+++ b/test/game/perfect_grab_bonus_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/config/game_config.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Perfect grab bonus', () {
+    late List<Player> players;
+    late GameController controller;
+
+    setUp(() {
+      players = [
+        Player(id: '1', name: 'Human', type: PlayerType.human),
+        Player(id: '2', name: 'Bot 1', type: PlayerType.bot),
+        Player(id: '3', name: 'Bot 2', type: PlayerType.bot),
+      ];
+      controller = GameController(players: players, seed: 4242);
+    });
+
+    test('completeRoundStart awards bonus to human player', () {
+      controller.initializeGame(dealCards: false);
+
+      final human = players.firstWhere((p) => p.type == PlayerType.human);
+      expect(human.score, 0);
+
+      controller.completeRoundStart(earnedPerfectGrabBonus: true);
+
+      expect(human.score, GameConfig.perfectGrabBonus);
+      for (final player in players) {
+        expect(player.hand.length, 11);
+        expect(player.foot.length, 11);
+      }
+      expect(controller.gameState.discardPile.length, 1);
+      expect(controller.gameState.phase, GamePhase.playing);
+    });
+
+    test('completeRoundStart without bonus deals normally', () {
+      controller.initializeGame(dealCards: false);
+      final human = players.firstWhere((p) => p.type == PlayerType.human);
+
+      controller.completeRoundStart(earnedPerfectGrabBonus: false);
+
+      expect(human.score, 0);
+      expect(controller.gameState.phase, GamePhase.playing);
+    });
+
+    test('prepareNewRoundDeal shuffles without dealing until completion', () {
+      controller.initializeGame();
+      controller.gameState.phase = GamePhase.roundEnd;
+      controller.gameState.round = 2;
+
+      for (final player in players) {
+        player.hand.addAll(
+          List.generate(3, (_) => controller.gameState.deck.drawCard()!),
+        );
+      }
+
+      controller.prepareNewRoundDeal();
+
+      for (final player in players) {
+        expect(player.hand, isEmpty);
+        expect(player.foot, isEmpty);
+      }
+      expect(controller.gameState.phase, GamePhase.playing);
+      expect(controller.gameState.discardPile, isEmpty);
+
+      controller.completeRoundStart(earnedPerfectGrabBonus: false);
+
+      for (final player in players) {
+        expect(player.hand.length, 11);
+        expect(player.foot.length, 11);
+      }
+    });
+
+    test('initializeGame still deals immediately by default for tests', () {
+      controller.initializeGame();
+
+      for (final player in players) {
+        expect(player.hand.length, 11);
+        expect(player.foot.length, 11);
+      }
+    });
+  });
+}

--- a/test/game/perfect_grab_bonus_test.dart
+++ b/test/game/perfect_grab_bonus_test.dart
@@ -1,3 +1,6 @@
+@Tags(['perfect_grab'])
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/config/game_config.dart';
 import 'package:hand_foot_game_flutter/game/game_controller.dart';

--- a/test/game/perfect_grab_bonus_test.dart
+++ b/test/game/perfect_grab_bonus_test.dart
@@ -73,6 +73,22 @@ void main() {
       }
     });
 
+    test('completeRoundStart skips bonus when no human player exists', () {
+      final botOnlyPlayers = [
+        Player(id: '2', name: 'Bot 1', type: PlayerType.bot),
+        Player(id: '3', name: 'Bot 2', type: PlayerType.bot),
+      ];
+      final botController = GameController(players: botOnlyPlayers, seed: 99);
+      botController.initializeGame(dealCards: false);
+
+      botController.completeRoundStart(earnedPerfectGrabBonus: true);
+
+      for (final player in botOnlyPlayers) {
+        expect(player.score, 0);
+      }
+      expect(botController.gameState.phase, GamePhase.playing);
+    });
+
     test('initializeGame still deals immediately by default for tests', () {
       controller.initializeGame();
 

--- a/test/widgets/perfect_grab_mini_game_test.dart
+++ b/test/widgets/perfect_grab_mini_game_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/config/game_config.dart';
+import 'package:hand_foot_game_flutter/widgets/perfect_grab_mini_game.dart';
+
+void main() {
+  group('PerfectGrabMiniGame', () {
+    testWidgets('shows intro and can be skipped without bonus', (tester) async {
+      bool? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    result = await PerfectGrabMiniGame.show(
+                      context,
+                      roundNumber: 2,
+                    );
+                  },
+                  child: const Text('Open'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Perfect Grab'), findsOneWidget);
+      expect(
+        find.textContaining('grab exactly ${GameConfig.perfectGrabTarget}'),
+        findsOneWidget,
+      );
+      expect(find.text('GET READY'), findsOneWidget);
+      expect(find.text('GRAB!'), findsNothing);
+
+      await tester.tap(find.text('Skip (no bonus)'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(result, isFalse);
+    });
+  });
+}

--- a/test/widgets/perfect_grab_mini_game_test.dart
+++ b/test/widgets/perfect_grab_mini_game_test.dart
@@ -3,6 +3,28 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/config/game_config.dart';
 import 'package:hand_foot_game_flutter/widgets/perfect_grab_mini_game.dart';
 
+const _testDealInterval = Duration(milliseconds: 50);
+const _resultDismissDelay = Duration(milliseconds: 2200);
+
+Future<void> _startPlayingPhase(WidgetTester tester) async {
+  await tester.tap(find.text('GET READY'));
+  await tester.pump();
+  for (int i = 0; i < 3; i++) {
+    await tester.pump(const Duration(seconds: 1));
+  }
+}
+
+Future<void> _dealCards(WidgetTester tester, int count) async {
+  for (int i = 0; i < count; i++) {
+    await tester.pump(_testDealInterval);
+  }
+}
+
+Future<void> _dismissResult(WidgetTester tester) async {
+  await tester.pump(_resultDismissDelay);
+  await tester.pump();
+}
+
 void main() {
   group('PerfectGrabMiniGame', () {
     testWidgets('shows intro and can be skipped without bonus', (tester) async {
@@ -44,6 +66,84 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
+      expect(result, isFalse);
+    });
+
+    testWidgets('enters playing phase with GRAB button after countdown', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PerfectGrabMiniGame(
+            roundNumber: 1,
+            fixedDealInterval: _testDealInterval,
+            onComplete: (_) {},
+          ),
+        ),
+      );
+
+      await _startPlayingPhase(tester);
+
+      expect(find.text('GRAB!'), findsOneWidget);
+      expect(find.text('0'), findsOneWidget);
+      expect(find.text('cards grabbed'), findsOneWidget);
+    });
+
+    testWidgets('exact-target grab returns true', (tester) async {
+      bool? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PerfectGrabMiniGame(
+            roundNumber: 1,
+            fixedDealInterval: _testDealInterval,
+            onComplete: (earnedBonus) {
+              result = earnedBonus;
+            },
+          ),
+        ),
+      );
+
+      await _startPlayingPhase(tester);
+      await _dealCards(tester, GameConfig.perfectGrabTarget);
+
+      expect(find.text('${GameConfig.perfectGrabTarget}'), findsOneWidget);
+
+      await tester.tap(find.text('GRAB!'));
+      await tester.pump();
+
+      expect(find.text('Perfect Grab!'), findsOneWidget);
+      expect(
+        find.textContaining('+${GameConfig.perfectGrabBonus}'),
+        findsOneWidget,
+      );
+
+      await _dismissResult(tester);
+      expect(result, isTrue);
+    });
+
+    testWidgets('forced max-card path returns false', (tester) async {
+      bool? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PerfectGrabMiniGame(
+            roundNumber: 1,
+            fixedDealInterval: _testDealInterval,
+            onComplete: (earnedBonus) {
+              result = earnedBonus;
+            },
+          ),
+        ),
+      );
+
+      await _startPlayingPhase(tester);
+      await _dealCards(tester, 34);
+
+      expect(find.text('So Close...'), findsOneWidget);
+      expect(find.textContaining('Need exactly'), findsOneWidget);
+
+      await _dismissResult(tester);
       expect(result, isFalse);
     });
   });

--- a/test/widgets/perfect_grab_mini_game_test.dart
+++ b/test/widgets/perfect_grab_mini_game_test.dart
@@ -1,3 +1,6 @@
+@Tags(['perfect_grab'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/config/game_config.dart';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a family house-rule mini-game before each solo round deal: after the deck is shuffled, the human player tries to **grab exactly 22 cards** (11 hand + 11 foot). A perfect grab awards **+100 bonus points** at round start.

## How it works

- Appears at the start of **Round 1** and before every subsequent round in solo play
- Cards deal automatically at **accelerating speed** with timing jitter — tap **GRAB!** at exactly 22
- **Perfect Grab** → +100 points added immediately and logged in recent actions
- **Skip** option forfeits the bonus and deals normally

## Implementation

- New `PerfectGrabMiniGame` widget (`lib/widgets/perfect_grab_mini_game.dart`)
- Round dealing split into `prepareNewRoundDeal()` / `completeRoundStart()` so the mini-game runs after shuffle and before deal
- `GameConfig.perfectGrabBonus` (100) and `GameConfig.perfectGrabTarget` (22)
- Existing tests unchanged — `initializeGame()` still deals immediately by default

## Testing

- `dart format .` — clean
- `flutter analyze` — zero issues
- `flutter test` — full suite passes
- Added `test/game/perfect_grab_bonus_test.dart` and `test/widgets/perfect_grab_mini_game_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dc8a844-de70-4f74-a802-d8c1bc0907bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dc8a844-de70-4f74-a802-d8c1bc0907bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a round-start “Perfect Grab” mini-game with a precise target (hand + foot = 22 cards) for earning a 100-point bonus.
  * Bonus awarding is triggered automatically during round start, and the UI runs the mini-game between rounds.
  * Added a “Skip (no bonus)” option to end the mini-game without earning points.

* **Tests**
  * Added GameController tests for bonus application, round preparation, and correct card/discard setup.
  * Expanded PerfectGrabMiniGame widget tests for intro, exact-target success, forced-stop failure, and skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->