### PR TITLE
Show scoreboard at round end before starting next round

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -609,8 +609,13 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         _botTurnManager
             .resetProcessingState(); // Clear any stuck bot processing flag
         if (mounted) {
-          // UI will update automatically via provider reactivity
-          _gameStateManager.checkForRoundTransition();
+          if (controller.gameState.phase == GamePhase.roundEnd) {
+            _handleRoundTransition().catchError((error) {
+              DebugLogger.error(
+                'Error handling round transition from human turn: $error',
+              );
+            });
+          }
         }
         return;
       }
@@ -647,8 +652,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     try {
       await _logRoundEndAnalytics();
 
-      // Brief pause to show scores
-      await Future.delayed(const Duration(seconds: 2));
+      await _dialogManager.showRoundEndScoreboard();
       if (_disposed || !mounted) {
         return;
       }

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -234,11 +234,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         processCurrentPlayerTurn();
       },
       onRoundEndDetected: () {
-        _handleRoundTransition().catchError((error) {
-          DebugLogger.error(
-            'Error handling round transition from event: $error',
-          );
-        });
+        _triggerRoundTransition('event');
       },
     );
 
@@ -543,9 +539,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         DebugLogger.debug(
           'Round has ended - handling transition (Round ${gameState.round})',
         );
-        _handleRoundTransition().catchError((error) {
-          DebugLogger.error('Error handling round transition: $error');
-        });
+        _triggerRoundTransition('');
         return;
       }
 
@@ -610,11 +604,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
             .resetProcessingState(); // Clear any stuck bot processing flag
         if (mounted) {
           if (controller.gameState.phase == GamePhase.roundEnd) {
-            _handleRoundTransition().catchError((error) {
-              DebugLogger.error(
-                'Error handling round transition from human turn: $error',
-              );
-            });
+            _triggerRoundTransition('human turn');
           }
         }
         return;
@@ -629,6 +619,16 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       DebugLogger.error('Error in processCurrentPlayerTurn: $e');
       _handleCriticalError(e);
     }
+  }
+
+  /// Fire-and-forget round transition with source-tagged error logging.
+  void _triggerRoundTransition(String source) {
+    _handleRoundTransition().catchError((error) {
+      final message = source.isEmpty
+          ? 'Error handling round transition: $error'
+          : 'Error handling round transition from $source: $error';
+      DebugLogger.error(message);
+    });
   }
 
   /// Handle complete round transition with proper state management
@@ -651,6 +651,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
     try {
       await _logRoundEndAnalytics();
+      if (_disposed || !mounted) {
+        return;
+      }
 
       await _dialogManager.showRoundEndScoreboard();
       if (_disposed || !mounted) {

--- a/lib/screens/managers/dialog_manager.dart
+++ b/lib/screens/managers/dialog_manager.dart
@@ -343,6 +343,21 @@ class DialogManager {
     );
   }
 
+  /// Show scoreboard after a round ends and wait until the user dismisses it.
+  Future<void> showRoundEndScoreboard() {
+    final completedRound = gameController.gameState.round - 1;
+
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => ScoreboardModal(
+        gameState: gameController.gameState,
+        completedRoundNumber: completedRound < 1 ? 1 : completedRound,
+        showContinueButton: true,
+      ),
+    );
+  }
+
   /// Show emergency round end dialog
   void showEmergencyRoundEndDialog() {
     EmergencyRoundEndDialog.show(

--- a/lib/widgets/scoreboard_modal.dart
+++ b/lib/widgets/scoreboard_modal.dart
@@ -7,8 +7,15 @@ import '../theme/balatro_theme.dart';
 
 class ScoreboardModal extends StatefulWidget {
   final GameState gameState;
+  final int? completedRoundNumber;
+  final bool showContinueButton;
 
-  const ScoreboardModal({super.key, required this.gameState});
+  const ScoreboardModal({
+    super.key,
+    required this.gameState,
+    this.completedRoundNumber,
+    this.showContinueButton = false,
+  });
 
   @override
   State<ScoreboardModal> createState() => _ScoreboardModalState();
@@ -395,6 +402,9 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
     );
   }
 
+  int get _displayRoundNumber =>
+      widget.completedRoundNumber ?? widget.gameState.round;
+
   @override
   Widget build(BuildContext context) {
     // Sort players by score once per build
@@ -409,7 +419,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
     final leaderName = _displayNameForPlayer(leaderIndex, duplicateNames);
 
     return Semantics(
-      label: 'Scoreboard for Round ${widget.gameState.round}',
+      label: 'Scoreboard for Round $_displayRoundNumber',
       child: Dialog(
         backgroundColor: Colors.transparent,
         child: Container(
@@ -449,7 +459,9 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
                   children: [
                     Flexible(
                       child: Text(
-                        '🏆 Scoreboard - Round ${widget.gameState.round}',
+                        widget.showContinueButton
+                            ? '🏆 Round $_displayRoundNumber Complete'
+                            : '🏆 Scoreboard - Round $_displayRoundNumber',
                         style: Theme.of(context).textTheme.displayMedium
                             ?.copyWith(color: Colors.white),
                         overflow: TextOverflow.ellipsis,
@@ -518,6 +530,32 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
                   },
                 ),
               ),
+
+              if (widget.showContinueButton)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: BalatroTheme.neonGreen,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: const Text(
+                        'Continue to Next Round',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
             ],
           ),
         ),

--- a/lib/widgets/scoreboard_modal.dart
+++ b/lib/widgets/scoreboard_modal.dart
@@ -24,6 +24,9 @@ class ScoreboardModal extends StatefulWidget {
 class _ScoreboardModalState extends State<ScoreboardModal> {
   int? expandedPlayerIndex;
 
+  int get _displayRoundNumber =>
+      widget.completedRoundNumber ?? widget.gameState.round;
+
   Map<String, dynamic> _calculateScoreBreakdown(int playerIndex) {
     int meldPoints = 0;
     int cleanBooks = 0;
@@ -48,7 +51,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
     final currentRoundTotal = meldPoints;
 
     // Calculate previous rounds score (only if not first round)
-    final previousRoundsTotal = widget.gameState.round > 1
+    final previousRoundsTotal = _displayRoundNumber > 1
         ? player.score - currentRoundTotal
         : 0;
 
@@ -104,7 +107,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
     final accessibilityLabel =
         '$displayName, '
         'Total score: ${breakdown['gameTotal']}, '
-        'Round ${widget.gameState.round} score: ${breakdown['currentRoundTotal']}, '
+        'Round $_displayRoundNumber score: ${breakdown['currentRoundTotal']}, '
         '${canGoOut ? 'Can go out, ' : ''}'
         '${isCurrentPlayer ? 'Current player' : ''}';
 
@@ -220,7 +223,7 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
                     ),
 
                   // Show previous rounds if any (and not first round)
-                  if (widget.gameState.round > 1 &&
+                  if (_displayRoundNumber > 1 &&
                       breakdown['previousRoundsTotal'] != 0)
                     _buildScoreRow(
                       'Previous Rounds',
@@ -401,9 +404,6 @@ class _ScoreboardModalState extends State<ScoreboardModal> {
       ),
     );
   }
-
-  int get _displayRoundNumber =>
-      widget.completedRoundNumber ?? widget.gameState.round;
 
   @override
   Widget build(BuildContext context) {

--- a/test/widgets/scoreboard_modal_test.dart
+++ b/test/widgets/scoreboard_modal_test.dart
@@ -464,6 +464,31 @@ void main() {
         expect(find.textContaining('Clean Books'), findsAtLeastNWidgets(1));
         expect(find.textContaining('This Round'), findsAtLeastNWidgets(1));
       });
+
+      testWidgets(
+        'shows continue button and completed round title at round end',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Material(
+                child: MediaQuery(
+                  data: const MediaQueryData(size: Size(800, 600)),
+                  child: ScoreboardModal(
+                    gameState: gameState,
+                    completedRoundNumber: 1,
+                    showContinueButton: true,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(find.text('🏆 Round 1 Complete'), findsOneWidget);
+          expect(find.text('Continue to Next Round'), findsOneWidget);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a player goes out and the round ends, the game now shows the scoreboard modal and waits for the user to dismiss it before starting the next round. This replaces the previous 2-second auto-advance delay.

## Changes

- **`ScoreboardModal`**: Added optional `completedRoundNumber` and `showContinueButton` props for round-end display (shows "Round X Complete" title and a "Continue to Next Round" button)
- **`DialogManager`**: Added `showRoundEndScoreboard()` that blocks until the user closes the modal
- **`GameScreen`**: `_handleRoundTransition()` now awaits the scoreboard dismissal before dealing the next round; human-turn round-end path uses the same transition flow

## Behavior

1. Player goes out → round ends
2. Scoreboard appears with final scores for the completed round
3. User taps **Continue to Next Round** (or the close button)
4. Perfect Grab mini-game (if applicable) and next round deal proceed as before

Game-end flow (8500+ points) is unchanged — it still shows the game-over dialog directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b01b714-ce4f-44d2-8906-c6b1ae582253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b01b714-ce4f-44d2-8906-c6b1ae582253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a round-end scoreboard modal showing the completed round’s results.
  * Added a “Continue to Next Round” button option for progressing after the scoreboard.
  * Improved completed-round numbering to display the correct round number in the modal.

* **Bug Fixes**
  * Updated round-transition flow to wait for the round-end scoreboard to complete/dismiss before starting the next round.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->