### PR TITLE
Fix final-turn phase so only other players get one turn after go-out

### DIFF
--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -236,9 +236,10 @@ class GameController implements GameInterface {
     }
 
     final roundBefore = _gameState.round;
+    final roundEndingPlayer = _captureRoundEndingPlayer(player);
     final roundEnded = _gameState.handlePlayerWentOut();
     if (roundEnded) {
-      _publishRoundOrGameEndEvents(player, roundBefore);
+      _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
     } else {
       publishTurnEndedEvent(player);
     }
@@ -246,6 +247,17 @@ class GameController implements GameInterface {
   }
 
   SoloGameSettings get soloSettings => _gameState.soloSettings;
+
+  /// Snapshot the player credited with going out before state resets it.
+  Player _captureRoundEndingPlayer(Player actingPlayer) {
+    final wentOutIndex = _gameState.playerWhoWentOutIndex;
+    if (wentOutIndex != null &&
+        wentOutIndex >= 0 &&
+        wentOutIndex < _gameState.players.length) {
+      return _gameState.players[wentOutIndex];
+    }
+    return actingPlayer;
+  }
 
   void _publishRoundOrGameEndEvents(Player player, int roundBefore) {
     final phase = _gameState.phase;
@@ -277,6 +289,8 @@ class GameController implements GameInterface {
     final player = _gameState.currentPlayer;
     final phaseBefore = _gameState.phase;
     final roundBefore = _gameState.round;
+    final roundEndingPlayer = _captureRoundEndingPlayer(player);
+    final currentIndexBefore = _gameState.currentPlayerIndex;
     final result = _gameState.discard(card);
     _gameState.validateGameState();
 
@@ -284,11 +298,9 @@ class GameController implements GameInterface {
       _eventBus.publish(CardDiscardedEvent(card: card, player: player));
 
       if (_gameState.phase != phaseBefore) {
-        _publishRoundOrGameEndEvents(player, roundBefore);
+        _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
       } else if (_gameState.finalTurnPhaseActive &&
-          _gameState.playerWhoWentOutIndex != null &&
-          _gameState.players[_gameState.playerWhoWentOutIndex!].id ==
-              player.id) {
+          _gameState.currentPlayerIndex != currentIndexBefore) {
         publishTurnEndedEvent(player);
       } else {
         // Check if turn ended (player changed or phase changed)
@@ -332,10 +344,11 @@ class GameController implements GameInterface {
   bool advanceTurnAfterAction(Player previousPlayer) {
     final phaseBefore = _gameState.phase;
     final roundBefore = _gameState.round;
+    final roundEndingPlayer = _captureRoundEndingPlayer(previousPlayer);
     final roundEnded = _gameState.completeTurn();
 
     if (_gameState.phase != phaseBefore) {
-      _publishRoundOrGameEndEvents(previousPlayer, roundBefore);
+      _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
       return true;
     }
 
@@ -366,6 +379,8 @@ class GameController implements GameInterface {
     final hadPickedUpFoot = player.hasPickedUpFoot;
     final roundBefore = _gameState.round;
     final phaseBefore = _gameState.phase;
+    final roundEndingPlayer = _captureRoundEndingPlayer(player);
+    final currentIndexBefore = _gameState.currentPlayerIndex;
 
     final result = _gameState.playMeld(cards);
     _gameState.validateGameState();
@@ -394,11 +409,9 @@ class GameController implements GameInterface {
 
       // Check if player went out (round or game ended)
       if (_gameState.phase != phaseBefore) {
-        _publishRoundOrGameEndEvents(player, roundBefore);
+        _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
       } else if (_gameState.finalTurnPhaseActive &&
-          _gameState.playerWhoWentOutIndex != null &&
-          _gameState.players[_gameState.playerWhoWentOutIndex!].id ==
-              player.id) {
+          _gameState.currentPlayerIndex != currentIndexBefore) {
         publishTurnEndedEvent(player);
       }
     }
@@ -441,6 +454,8 @@ class GameController implements GameInterface {
     final hadPickedUpFoot = player.hasPickedUpFoot;
     final roundBefore = _gameState.round;
     final phaseBefore = _gameState.phase;
+    final roundEndingPlayer = _captureRoundEndingPlayer(player);
+    final currentIndexBefore = _gameState.currentPlayerIndex;
     final meld = player.melds[meldIndex];
     final result = _gameState.addToMeld(meldIndex, card);
     _gameState.validateGameState();
@@ -462,11 +477,9 @@ class GameController implements GameInterface {
 
       // Check if player went out (round or game ended)
       if (_gameState.phase != phaseBefore) {
-        _publishRoundOrGameEndEvents(player, roundBefore);
+        _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
       } else if (_gameState.finalTurnPhaseActive &&
-          _gameState.playerWhoWentOutIndex != null &&
-          _gameState.players[_gameState.playerWhoWentOutIndex!].id ==
-              player.id) {
+          _gameState.currentPlayerIndex != currentIndexBefore) {
         publishTurnEndedEvent(player);
       }
     }

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -284,6 +284,24 @@ class GameController implements GameInterface {
     }
   }
 
+  void _publishPostActionEvents({
+    required GamePhase phaseBefore,
+    required int roundBefore,
+    required Player actingPlayer,
+    required Player roundEndingPlayer,
+    required int currentIndexBefore,
+  }) {
+    if (_gameState.phase != phaseBefore) {
+      _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
+      return;
+    }
+
+    if (_gameState.finalTurnPhaseActive &&
+        _gameState.currentPlayerIndex != currentIndexBefore) {
+      publishTurnEndedEvent(actingPlayer);
+    }
+  }
+
   @override
   bool discardCard(PlayingCard card) {
     final player = _gameState.currentPlayer;
@@ -297,12 +315,17 @@ class GameController implements GameInterface {
     if (result) {
       _eventBus.publish(CardDiscardedEvent(card: card, player: player));
 
-      if (_gameState.phase != phaseBefore) {
-        _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
-      } else if (_gameState.finalTurnPhaseActive &&
-          _gameState.currentPlayerIndex != currentIndexBefore) {
-        publishTurnEndedEvent(player);
-      } else {
+      _publishPostActionEvents(
+        phaseBefore: phaseBefore,
+        roundBefore: roundBefore,
+        actingPlayer: player,
+        roundEndingPlayer: roundEndingPlayer,
+        currentIndexBefore: currentIndexBefore,
+      );
+
+      if (_gameState.phase == phaseBefore &&
+          (!_gameState.finalTurnPhaseActive ||
+              _gameState.currentPlayerIndex == currentIndexBefore)) {
         // Check if turn ended (player changed or phase changed)
         final newPlayer = _gameState.currentPlayer;
         if (newPlayer.id != player.id ||
@@ -408,12 +431,13 @@ class GameController implements GameInterface {
       }
 
       // Check if player went out (round or game ended)
-      if (_gameState.phase != phaseBefore) {
-        _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
-      } else if (_gameState.finalTurnPhaseActive &&
-          _gameState.currentPlayerIndex != currentIndexBefore) {
-        publishTurnEndedEvent(player);
-      }
+      _publishPostActionEvents(
+        phaseBefore: phaseBefore,
+        roundBefore: roundBefore,
+        actingPlayer: player,
+        roundEndingPlayer: roundEndingPlayer,
+        currentIndexBefore: currentIndexBefore,
+      );
     }
 
     return result;
@@ -476,12 +500,13 @@ class GameController implements GameInterface {
       }
 
       // Check if player went out (round or game ended)
-      if (_gameState.phase != phaseBefore) {
-        _publishRoundOrGameEndEvents(roundEndingPlayer, roundBefore);
-      } else if (_gameState.finalTurnPhaseActive &&
-          _gameState.currentPlayerIndex != currentIndexBefore) {
-        publishTurnEndedEvent(player);
-      }
+      _publishPostActionEvents(
+        phaseBefore: phaseBefore,
+        roundBefore: roundBefore,
+        actingPlayer: player,
+        roundEndingPlayer: roundEndingPlayer,
+        currentIndexBefore: currentIndexBefore,
+      );
     }
 
     return result;

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -326,6 +326,26 @@ class GameController implements GameInterface {
     );
   }
 
+  /// Advance play after a completed turn, publishing turn-end or round-end events.
+  ///
+  /// Returns true when the round or game ended.
+  bool advanceTurnAfterAction(Player previousPlayer) {
+    final phaseBefore = _gameState.phase;
+    final roundBefore = _gameState.round;
+    final roundEnded = _gameState.completeTurn();
+
+    if (_gameState.phase != phaseBefore) {
+      _publishRoundOrGameEndEvents(previousPlayer, roundBefore);
+      return true;
+    }
+
+    if (!roundEnded) {
+      publishTurnEndedEvent(previousPlayer);
+    }
+
+    return roundEnded;
+  }
+
   @override
   void nextRound({bool dealCards = true}) {
     if (_gameState.phase == GamePhase.roundEnd) {

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -6,6 +6,7 @@ import 'meld.dart';
 import '../config/game_config.dart';
 import '../config/solo_game_settings.dart';
 import '../game/managers/game_rules_engine.dart';
+import '../utils/debug_logger.dart';
 
 enum GamePhase { setup, playing, roundEnd, gameEnd }
 
@@ -238,9 +239,8 @@ class GameState {
       nextIndex = (nextIndex + 1) % playerCount;
     }
 
-    print(
-      'Warning: No player awaiting final turn found; '
-      'awaiting=$playersAwaitingFinalTurn',
+    DebugLogger.warning(
+      'No player awaiting final turn found; awaiting=$playersAwaitingFinalTurn',
     );
   }
 

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -202,7 +202,16 @@ class GameState {
   }
 
   void nextPlayer() {
+    if (finalTurnPhaseActive) {
+      _advanceToNextAwaitingFinalTurnPlayer();
+      return;
+    }
+
     currentPlayerIndex = (currentPlayerIndex + 1) % players.length;
+    _beginCurrentPlayerTurn();
+  }
+
+  void _beginCurrentPlayerTurn() {
     turnPhase = TurnPhase.draw;
     hasDrawnFromDeck = false;
     hasMelded = false;
@@ -212,12 +221,34 @@ class GameState {
     currentPlayer.clearNewlyDrawnCards();
   }
 
+  void _advanceToNextAwaitingFinalTurnPlayer() {
+    if (playersAwaitingFinalTurn.isEmpty) {
+      return;
+    }
+
+    final playerCount = players.length;
+    var nextIndex = (currentPlayerIndex + 1) % playerCount;
+
+    for (var i = 0; i < playerCount; i++) {
+      if (playersAwaitingFinalTurn.contains(nextIndex)) {
+        currentPlayerIndex = nextIndex;
+        _beginCurrentPlayerTurn();
+        return;
+      }
+      nextIndex = (nextIndex + 1) % playerCount;
+    }
+
+    print(
+      'Warning: No player awaiting final turn found; '
+      'awaiting=$playersAwaitingFinalTurn',
+    );
+  }
+
   /// Complete the active turn, advance play, and end the round if final turns are done.
   ///
   /// Returns true when [endRound] was triggered (round or game ended).
   bool completeTurn() {
     final finishedIndex = currentPlayerIndex;
-    nextPlayer();
 
     if (finalTurnPhaseActive) {
       playersAwaitingFinalTurn.remove(finishedIndex);
@@ -226,8 +257,11 @@ class GameState {
         endRound();
         return true;
       }
+      _advanceToNextAwaitingFinalTurnPlayer();
+      return false;
     }
 
+    nextPlayer();
     return phase == GamePhase.roundEnd || phase == GamePhase.gameEnd;
   }
 
@@ -237,7 +271,13 @@ class GameState {
   bool handlePlayerWentOut() {
     if (finalTurnPhaseActive) {
       _logAction('🏆 went out!');
-      nextPlayer();
+      playersAwaitingFinalTurn.remove(currentPlayerIndex);
+      if (playersAwaitingFinalTurn.isEmpty) {
+        _logAction('Final turns complete — round ending');
+        endRound();
+        return true;
+      }
+      _advanceToNextAwaitingFinalTurnPlayer();
       return false;
     }
 
@@ -257,11 +297,6 @@ class GameState {
         playersAwaitingFinalTurn.add(i);
       }
     }
-    for (var i = 0; i < players.length; i++) {
-      if (i != playerWhoWentOutIndex) {
-        playersAwaitingFinalTurn.add(i);
-      }
-    }
 
     if (playersAwaitingFinalTurn.isEmpty) {
       _logAction('🏆 went out and ended the round!');
@@ -270,7 +305,7 @@ class GameState {
     }
 
     _logAction('Final turns — one last chance for other players');
-    nextPlayer();
+    _advanceToNextAwaitingFinalTurnPlayer();
     return false;
   }
 

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -875,7 +875,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
   void _forceNextTurn() {
     final controller = _gameController;
     if (controller != null) {
-      controller.gameState.nextPlayer();
+      final previousPlayer = controller.gameState.currentPlayer;
+      controller.advanceTurnAfterAction(previousPlayer);
       // UI will update automatically via provider reactivity
       processCurrentPlayerTurn();
     }

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -507,8 +507,12 @@ class BotTurnManager {
     onStateChanged();
   }
 
-  /// Handle state after discard action
-  void handlePostDiscardState(Player player) {
+  /// Handle state after discard action.
+  ///
+  /// Returns true when play was already advanced (go-out handled or turn changed).
+  bool handlePostDiscardState(Player player) {
+    final gameState = gameController.gameState;
+
     // Check if player needs to pick up foot
     if (player.currentHand.isEmpty &&
         !player.hasPickedUpFoot &&
@@ -521,9 +525,18 @@ class BotTurnManager {
     if (player.hasPickedUpFoot &&
         player.currentHand.isEmpty &&
         player.canGoOut) {
+      if (gameState.phase == GamePhase.roundEnd ||
+          gameState.phase == GamePhase.gameEnd ||
+          gameState.currentPlayer.id != player.id) {
+        return true;
+      }
+
       endRoundForBot(player);
       DebugLogger.debug('Bot ${player.name} went out by discard');
+      return true;
     }
+
+    return false;
   }
 
   /// Attempt a meld during forced turn completion to shrink hand toward foot.
@@ -695,10 +708,13 @@ class BotTurnManager {
         );
 
         // Check for foot pickup after discard
-        handlePostDiscardState(botPlayer);
-
-        // ADVANCE TURN - this is guaranteed to work
-        _completeTurnAndNotify(botPlayer);
+        final turnAdvanced = handlePostDiscardState(botPlayer);
+        if (!turnAdvanced) {
+          // ADVANCE TURN - this is guaranteed to work
+          _completeTurnAndNotify(botPlayer);
+        } else {
+          onStateChanged();
+        }
         return;
       }
 

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -507,6 +507,15 @@ class BotTurnManager {
     onStateChanged();
   }
 
+  void _finishForcedDiscard(Player botPlayer) {
+    final turnAdvanced = handlePostDiscardState(botPlayer);
+    if (!turnAdvanced) {
+      _completeTurnAndNotify(botPlayer);
+    } else {
+      onStateChanged();
+    }
+  }
+
   /// Handle state after discard action.
   ///
   /// Returns true when play was already advanced (go-out handled or turn changed).
@@ -708,13 +717,7 @@ class BotTurnManager {
         );
 
         // Check for foot pickup after discard
-        final turnAdvanced = handlePostDiscardState(botPlayer);
-        if (!turnAdvanced) {
-          // ADVANCE TURN - this is guaranteed to work
-          _completeTurnAndNotify(botPlayer);
-        } else {
-          onStateChanged();
-        }
+        _finishForcedDiscard(botPlayer);
         return;
       }
 
@@ -741,8 +744,7 @@ class BotTurnManager {
           );
         }
 
-        _completeTurnAndNotify(botPlayer);
-        onStateChanged();
+        _finishForcedDiscard(botPlayer);
         return;
       }
 
@@ -877,20 +879,7 @@ class BotTurnManager {
           ),
         );
 
-        // Check for foot pickup after manual discard
-        if (botPlayer.isHandEmpty && !botPlayer.hasPickedUpFoot) {
-          botPlayer.pickUpFoot();
-          gameState.recentActions.add(
-            GameAction(
-              message: 'picked up foot after emergency discard',
-              playerName: botPlayer.name,
-            ),
-          );
-        }
-
-        // Complete turn legally
-        _completeTurnAndNotify(botPlayer);
-        onStateChanged();
+        _finishForcedDiscard(botPlayer);
         return;
       }
 
@@ -916,15 +905,13 @@ class BotTurnManager {
             ),
           );
 
-          // Complete turn legally
-          _completeTurnAndNotify(botPlayer);
-          onStateChanged();
+          _finishForcedDiscard(botPlayer);
           return;
         }
       }
 
-      // STEP 5: Check if bot can go out (end game)
-      if (botPlayer.canGoOut) {
+      // Empty hand/foot with books already satisfied — go out without discarding.
+      if (botPlayer.currentHand.isEmpty && botPlayer.canGoOut) {
         endRoundForBot(
           botPlayer,
           actionMessage: '🎉 went out and ended the round!',

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -396,8 +396,7 @@ class BotTurnManager {
           DebugLogger.debug(
             'Bot ${botPlayer.name} requesting emergency turn end',
           );
-          gameState.nextPlayer();
-          gameController.publishTurnEndedEvent(botPlayer);
+          _completeTurnAndNotify(botPlayer);
           success = true;
           break;
 
@@ -500,6 +499,12 @@ class BotTurnManager {
         DebugLogger.debug('Bot ${player.name} went out by melding');
       }
     }
+  }
+
+  void _completeTurnAndNotify(Player previousPlayer) {
+    gameController.advanceTurnAfterAction(previousPlayer);
+    AnalyticsBatcher.flushOnTurnCompletion();
+    onStateChanged();
   }
 
   /// Handle state after discard action
@@ -693,13 +698,7 @@ class BotTurnManager {
         handlePostDiscardState(botPlayer);
 
         // ADVANCE TURN - this is guaranteed to work
-        final previousPlayer = botPlayer;
-        gameState.nextPlayer();
-        // Publish event so UI knows turn changed
-        gameController.publishTurnEndedEvent(previousPlayer);
-        // Flush analytics on turn completion for better timing
-        AnalyticsBatcher.flushOnTurnCompletion();
-        onStateChanged();
+        _completeTurnAndNotify(botPlayer);
         return;
       }
 
@@ -726,9 +725,7 @@ class BotTurnManager {
           );
         }
 
-        final previousPlayer2 = botPlayer;
-        gameState.nextPlayer();
-        gameController.publishTurnEndedEvent(previousPlayer2);
+        _completeTurnAndNotify(botPlayer);
         onStateChanged();
         return;
       }
@@ -758,24 +755,18 @@ class BotTurnManager {
           );
 
           // Force advance turn to prevent infinite loop
-          final previousPlayer3 = botPlayer;
-          gameState.nextPlayer();
-          gameController.publishTurnEndedEvent(previousPlayer3);
+          _completeTurnAndNotify(botPlayer);
           onStateChanged();
           return;
         }
       }
 
-      final previousPlayer4 = botPlayer;
-      gameState.nextPlayer();
-      gameController.publishTurnEndedEvent(previousPlayer4);
+      _completeTurnAndNotify(botPlayer);
       onStateChanged();
     } catch (e) {
       DebugLogger.error('CRITICAL ERROR in absolutelyGuaranteedDiscard: $e');
       // Even if everything fails, force advance turn to prevent infinite loops
-      final previousPlayer5 = botPlayer;
-      gameState.nextPlayer();
-      gameController.publishTurnEndedEvent(previousPlayer5);
+      _completeTurnAndNotify(botPlayer);
       onStateChanged();
     }
   }
@@ -882,8 +873,7 @@ class BotTurnManager {
         }
 
         // Complete turn legally
-        gameState.nextPlayer();
-        gameController.publishTurnEndedEvent(botPlayer);
+        _completeTurnAndNotify(botPlayer);
         onStateChanged();
         return;
       }
@@ -911,8 +901,7 @@ class BotTurnManager {
           );
 
           // Complete turn legally
-          gameState.nextPlayer();
-          gameController.publishTurnEndedEvent(botPlayer);
+          _completeTurnAndNotify(botPlayer);
           onStateChanged();
           return;
         }
@@ -943,14 +932,12 @@ class BotTurnManager {
       );
 
       // Complete turn without polluting discard pile with synthetic cards
-      gameState.nextPlayer();
-      gameController.publishTurnEndedEvent(botPlayer);
+      _completeTurnAndNotify(botPlayer);
       onStateChanged();
     } catch (e) {
       DebugLogger.error('CRITICAL ERROR in emergencyCompleteBotTurn: $e');
       // Even if everything fails, force advance turn to prevent infinite loops
-      gameState.nextPlayer();
-      gameController.publishTurnEndedEvent(botPlayer);
+      _completeTurnAndNotify(botPlayer);
       onStateChanged();
     }
   }

--- a/lib/screens/managers/game_state_manager.dart
+++ b/lib/screens/managers/game_state_manager.dart
@@ -183,15 +183,8 @@ class GameStateManager {
     try {
       DebugLogger.debug('Forcing turn advancement (emergency)');
 
-      final gameState = gameController.gameState;
-
-      // Reset turn state
-      gameState.turnPhase = TurnPhase.draw;
-      gameState.hasDrawnFromDeck = false;
-      gameState.hasMelded = false;
-
-      // Advance to next player
-      gameState.nextPlayer();
+      final previousPlayer = gameController.gameState.currentPlayer;
+      gameController.advanceTurnAfterAction(previousPlayer);
 
       onStateChanged();
 

--- a/test/game/bot_go_out_round_transition_regression_test.dart
+++ b/test/game/bot_go_out_round_transition_regression_test.dart
@@ -23,6 +23,13 @@ final _threePlayerImmediateRoundEndSettings = SoloGameSettings(
   enableFinalTurnAfterGoingOut: false,
 );
 
+final _threePlayerFinalTurnSettings = SoloGameSettings(
+  botCount: 2,
+  botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
+  enableGoingOutBonus: true,
+  enableFinalTurnAfterGoingOut: true,
+);
+
 void main() {
   group('GameController round transition regression', () {
     test(
@@ -181,6 +188,48 @@ void main() {
 
       snapshot.assertUnchanged(controller, roundEndedEvents);
     });
+
+    test(
+      'final-turn completion credits original go-out player in PlayerWentOutEvent',
+      () async {
+        final eventBus = GameEventBus();
+        final wentOutEvents = <PlayerWentOutEvent>[];
+        final subscription = eventBus.subscribe((event) {
+          if (event is PlayerWentOutEvent) {
+            wentOutEvents.add(event);
+          }
+        });
+        addTearDown(subscription.cancel);
+
+        final human = Player(id: '1', name: 'You', type: PlayerType.human);
+        final rita = Player(id: '2', name: 'Rita', type: PlayerType.bot);
+        final alex = Player(id: '3', name: 'Alex', type: PlayerType.bot);
+        final controller = GameController(
+          players: [human, rita, alex],
+          eventBus: eventBus,
+          soloSettings: _threePlayerFinalTurnSettings,
+        );
+        controller.initializeGame();
+
+        _setupPlayerToGoOut(human);
+        controller.gameState.currentPlayerIndex = 0;
+        controller.endRoundForPlayer(human);
+
+        expect(controller.gameState.finalTurnPhaseActive, isTrue);
+        expect(controller.gameState.currentPlayer.id, rita.id);
+
+        controller.advanceTurnAfterAction(rita);
+        expect(controller.gameState.currentPlayer.id, alex.id);
+
+        controller.advanceTurnAfterAction(alex);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(controller.gameState.phase, GamePhase.roundEnd);
+        expect(wentOutEvents, hasLength(1));
+        expect(wentOutEvents.single.player, isNotNull);
+        expect(wentOutEvents.single.player!.id, human.id);
+      },
+    );
   });
 }
 

--- a/test/models/final_turn_phase_test.dart
+++ b/test/models/final_turn_phase_test.dart
@@ -121,8 +121,72 @@ void main() {
       gameState.handlePlayerWentOut();
 
       expect(gameState.playerWhoWentOutIndex, 0);
-      expect(gameState.playersAwaitingFinalTurn, {1, 2});
+      expect(gameState.playersAwaitingFinalTurn, {2});
       expect(gameState.currentPlayerIndex, 2);
+    });
+
+    test('went-out player never receives a turn during final turn phase', () {
+      final players = [
+        Player(id: '1', name: 'You', type: PlayerType.human),
+        Player(id: '2', name: 'Rita', type: PlayerType.bot),
+        Player(id: '3', name: 'Bob', type: PlayerType.bot),
+      ];
+      final gameState = GameState(
+        players: players,
+        deck: Deck.createHandAndFootDeck(players.length),
+        soloSettings: _withFinalTurnSettings,
+      );
+
+      gameState.phase = GamePhase.playing;
+      _setupPlayerToGoOut(players[0]);
+      gameState.currentPlayerIndex = 0;
+      gameState.handlePlayerWentOut();
+
+      expect(gameState.finalTurnPhaseActive, isTrue);
+      expect(gameState.currentPlayerIndex, 1);
+
+      gameState.completeTurn();
+      expect(gameState.currentPlayerIndex, 2);
+      expect(gameState.currentPlayerIndex, isNot(0));
+
+      final roundEnded = gameState.completeTurn();
+      expect(roundEnded, isTrue);
+      expect(gameState.phase, GamePhase.roundEnd);
+      expect(gameState.currentPlayerIndex, isNot(0));
+    });
+
+    test('four players each get exactly one final turn after early go-out', () {
+      final players = [
+        Player(id: '1', name: 'You', type: PlayerType.human),
+        Player(id: '2', name: 'Rita', type: PlayerType.bot),
+        Player(id: '3', name: 'Bob', type: PlayerType.bot),
+        Player(id: '4', name: 'Alex', type: PlayerType.bot),
+      ];
+      final gameState = GameState(
+        players: players,
+        deck: Deck.createHandAndFootDeck(players.length),
+        soloSettings: _withFinalTurnSettings,
+      );
+
+      gameState.phase = GamePhase.playing;
+      _setupPlayerToGoOut(players[0]);
+      gameState.currentPlayerIndex = 0;
+      gameState.handlePlayerWentOut();
+
+      expect(gameState.playersAwaitingFinalTurn, {1, 2, 3});
+      expect(gameState.currentPlayerIndex, 1);
+
+      final turnsTaken = <int>[];
+      while (gameState.finalTurnPhaseActive) {
+        turnsTaken.add(gameState.currentPlayerIndex);
+        final ended = gameState.completeTurn();
+        if (ended) {
+          break;
+        }
+      }
+
+      expect(turnsTaken, [1, 2, 3]);
+      expect(gameState.phase, GamePhase.roundEnd);
     });
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes bugs in the "one final turn for other players after someone goes out" solo rule (`enableFinalTurnAfterGoingOut`).

## Problems found

1. **Went-out player could get another turn** — `completeTurn()` advanced with plain `nextPlayer()`, which wrapped around to the player who already went out before ending the round.
2. **Duplicate awaiting-player loop** — `handlePlayerWentOut()` added other players to `playersAwaitingFinalTurn` twice (harmless for a `Set`, but confusing).
3. **Secondary go-out during final turns** — If another player went out during the final-turn phase, they stayed in the awaiting set and the round could stall or give extra turns.
4. **Bot emergency paths bypassed final-turn tracking** — `BotTurnManager` and emergency helpers called `nextPlayer()` directly instead of `completeTurn()`, so final turns were not decremented and the round might never end correctly.

## Fix

- Track final turns with `_advanceToNextAwaitingFinalTurnPlayer()` so only players in `playersAwaitingFinalTurn` become active.
- End the round immediately once the awaiting set is empty (without landing on the went-out player).
- Remove a player from the awaiting set when they go out during the final-turn phase.
- Add `GameController.advanceTurnAfterAction()` and route bot/emergency turn advances through it so events and final-turn state stay in sync.
- Add regression tests for went-out-player exclusion and 4-player final-turn ordering.

## Testing

- `flutter analyze` — clean
- `flutter test` — full suite passes
- Added/updated tests in `test/models/final_turn_phase_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8edd1dfb-c6fc-4c18-a45f-bd792f4ac6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8edd1dfb-c6fc-4c18-a45f-bd792f4ac6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined final-turn sequencing so players who go out don’t receive further turns.
  * Ensured remaining eligible players each get exactly one final turn before round end.
  * Improved round/game-end handling and corrected attribution of round-ending events across player, bot, and emergency turn flows.
* **Tests**
  * Added final-turn phase tests for early go-outs and correct progression/order.
  * Added a regression test verifying `PlayerWentOutEvent` credits the original go-out player.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->