### PR TITLE
Add settings icon to PLAY SOLO button on home screen

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import '../config/solo_game_settings.dart';
 import '../theme/balatro_theme.dart';
 import 'game_screen.dart';
 import 'multiplayer_lobby_screen.dart';
@@ -166,6 +167,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                           label: 'PLAY SOLO',
                           description: 'Play against AI opponents',
                           onPressed: _startSoloGame,
+                          onSettingsPressed: _openSoloGameSettings,
                         ),
                         const SizedBox(height: 20),
                         _buildMenuButton(
@@ -211,93 +213,125 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
     required String label,
     required String description,
     required VoidCallback onPressed,
+    VoidCallback? onSettingsPressed,
     bool isPrimary = false,
   }) {
+    final accentColor = isPrimary
+        ? BalatroTheme.neonBlue
+        : BalatroTheme.neonPink;
+
     return Container(
       width: 320,
       height: 80,
       margin: const EdgeInsets.symmetric(horizontal: 20),
-      child: ElevatedButton(
-        onPressed: onPressed,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: isPrimary
-              ? BalatroTheme.neonBlue.withValues(alpha: 0.2)
-              : BalatroTheme.cardBackground,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-            side: BorderSide(
-              color: isPrimary
-                  ? BalatroTheme.neonBlue.withValues(alpha: 0.6)
-                  : BalatroTheme.neonPink.withValues(alpha: 0.3),
-              width: isPrimary ? 2 : 1,
-            ),
-          ),
-          elevation: isPrimary ? 12 : 8,
-          shadowColor: isPrimary
-              ? BalatroTheme.neonBlue.withValues(alpha: 0.5)
+      decoration: BoxDecoration(
+        color: isPrimary
+            ? BalatroTheme.neonBlue.withValues(alpha: 0.2)
+            : BalatroTheme.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isPrimary
+              ? BalatroTheme.neonBlue.withValues(alpha: 0.6)
               : BalatroTheme.neonPink.withValues(alpha: 0.3),
+          width: isPrimary ? 2 : 1,
         ),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            children: [
+        boxShadow: [
+          BoxShadow(
+            color: isPrimary
+                ? BalatroTheme.neonBlue.withValues(alpha: 0.5)
+                : BalatroTheme.neonPink.withValues(alpha: 0.3),
+            blurRadius: isPrimary ? 12 : 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: Row(
+          children: [
+            Expanded(
+              child: InkWell(
+                onTap: onPressed,
+                borderRadius: BorderRadius.circular(12),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: isPrimary
+                              ? BalatroTheme.neonBlue.withValues(alpha: 0.3)
+                              : BalatroTheme.neonPink.withValues(alpha: 0.2),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Icon(icon, color: accentColor, size: 24),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Flexible(
+                              child: Text(
+                                label,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Flexible(
+                              child: Text(
+                                description,
+                                style: TextStyle(
+                                  color: Colors.white.withValues(alpha: 0.7),
+                                  fontSize: 12,
+                                ),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      if (onSettingsPressed == null)
+                        Icon(
+                          Icons.arrow_forward_ios,
+                          color: BalatroTheme.neonBlue,
+                          size: 16,
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            if (onSettingsPressed != null) ...[
               Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: isPrimary
-                      ? BalatroTheme.neonBlue.withValues(alpha: 0.3)
-                      : BalatroTheme.neonPink.withValues(alpha: 0.2),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Icon(
-                  icon,
-                  color: isPrimary
-                      ? BalatroTheme.neonBlue
-                      : BalatroTheme.neonPink,
-                  size: 24,
-                ),
+                width: 1,
+                height: 48,
+                color: accentColor.withValues(alpha: 0.3),
               ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Flexible(
-                      child: Text(
-                        label,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Flexible(
-                      child: Text(
-                        description,
-                        style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.7),
-                          fontSize: 12,
-                        ),
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ],
+              Tooltip(
+                message: 'Game settings',
+                child: IconButton(
+                  onPressed: onSettingsPressed,
+                  icon: Icon(Icons.settings, color: accentColor, size: 22),
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  constraints: const BoxConstraints(
+                    minWidth: 48,
+                    minHeight: 48,
+                  ),
                 ),
-              ),
-              Icon(
-                Icons.arrow_forward_ios,
-                color: BalatroTheme.neonBlue,
-                size: 16,
               ),
             ],
-          ),
+          ],
         ),
       ),
     );
@@ -579,15 +613,30 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
   void _startSoloGame() async {
     setState(() => _isLoading = true);
 
-    if (mounted) {
-      Navigator.of(context).push(
-        MaterialPageRoute(builder: (context) => const SoloGameSetupScreen()),
-      );
+    try {
+      final settings = await SoloGameSettings.loadFromPreferences();
+      if (mounted) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (context) => GameScreen(settings: settings),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        _showErrorDialog('Failed to start game: ${e.toString()}');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
+  }
 
-    if (mounted) {
-      setState(() => _isLoading = false);
-    }
+  void _openSoloGameSettings() {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (context) => const SoloGameSetupScreen()),
+    );
   }
 
   void _createMultiplayerGame() async {

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -11,6 +11,42 @@ import '../services/game_save_service.dart';
 import '../services/multiplayer_resume_service.dart';
 import '../models/player.dart';
 
+/// Layout and styling constants for main menu buttons.
+abstract final class _MenuButtonLayout {
+  static const double width = 320;
+  static const double height = 80;
+  static const double horizontalMargin = 20;
+  static const double borderRadius = 12;
+  static const double iconContainerRadius = 8;
+  static const double primaryBorderWidth = 2;
+  static const double secondaryBorderWidth = 1;
+  static const double primaryShadowBlur = 12;
+  static const double secondaryShadowBlur = 8;
+  static const Offset shadowOffset = Offset(0, 4);
+  static const double contentPadding = 16;
+  static const double iconContainerPadding = 8;
+  static const double iconSpacing = 16;
+  static const double labelDescriptionGap = 2;
+  static const double mainIconSize = 24;
+  static const double arrowIconSize = 16;
+  static const double settingsIconSize = 22;
+  static const double labelFontSize = 18;
+  static const double descriptionFontSize = 12;
+  static const double dividerWidth = 1;
+  static const double dividerHeight = 48;
+  static const double settingsButtonMinSize = 48;
+  static const double settingsButtonHorizontalPadding = 12;
+
+  static const double primaryBackgroundAlpha = 0.2;
+  static const double primaryBorderAlpha = 0.6;
+  static const double secondaryBorderAlpha = 0.3;
+  static const double primaryShadowAlpha = 0.5;
+  static const double primaryIconBackgroundAlpha = 0.3;
+  static const double secondaryIconBackgroundAlpha = 0.2;
+  static const double descriptionTextAlpha = 0.7;
+  static const double dividerAlpha = 0.3;
+}
+
 class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
 
@@ -221,27 +257,43 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
         : BalatroTheme.neonPink;
 
     return Container(
-      width: 320,
-      height: 80,
-      margin: const EdgeInsets.symmetric(horizontal: 20),
+      width: _MenuButtonLayout.width,
+      height: _MenuButtonLayout.height,
+      margin: const EdgeInsets.symmetric(
+        horizontal: _MenuButtonLayout.horizontalMargin,
+      ),
       decoration: BoxDecoration(
         color: isPrimary
-            ? BalatroTheme.neonBlue.withValues(alpha: 0.2)
+            ? BalatroTheme.neonBlue.withValues(
+                alpha: _MenuButtonLayout.primaryBackgroundAlpha,
+              )
             : BalatroTheme.cardBackground,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(_MenuButtonLayout.borderRadius),
         border: Border.all(
           color: isPrimary
-              ? BalatroTheme.neonBlue.withValues(alpha: 0.6)
-              : BalatroTheme.neonPink.withValues(alpha: 0.3),
-          width: isPrimary ? 2 : 1,
+              ? BalatroTheme.neonBlue.withValues(
+                  alpha: _MenuButtonLayout.primaryBorderAlpha,
+                )
+              : BalatroTheme.neonPink.withValues(
+                  alpha: _MenuButtonLayout.secondaryBorderAlpha,
+                ),
+          width: isPrimary
+              ? _MenuButtonLayout.primaryBorderWidth
+              : _MenuButtonLayout.secondaryBorderWidth,
         ),
         boxShadow: [
           BoxShadow(
             color: isPrimary
-                ? BalatroTheme.neonBlue.withValues(alpha: 0.5)
-                : BalatroTheme.neonPink.withValues(alpha: 0.3),
-            blurRadius: isPrimary ? 12 : 8,
-            offset: const Offset(0, 4),
+                ? BalatroTheme.neonBlue.withValues(
+                    alpha: _MenuButtonLayout.primaryShadowAlpha,
+                  )
+                : BalatroTheme.neonPink.withValues(
+                    alpha: _MenuButtonLayout.secondaryBorderAlpha,
+                  ),
+            blurRadius: isPrimary
+                ? _MenuButtonLayout.primaryShadowBlur
+                : _MenuButtonLayout.secondaryShadowBlur,
+            offset: _MenuButtonLayout.shadowOffset,
           ),
         ],
       ),
@@ -252,22 +304,40 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
             Expanded(
               child: InkWell(
                 onTap: onPressed,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(
+                  _MenuButtonLayout.borderRadius,
+                ),
                 child: Padding(
-                  padding: const EdgeInsets.all(16),
+                  padding: const EdgeInsets.all(
+                    _MenuButtonLayout.contentPadding,
+                  ),
                   child: Row(
                     children: [
                       Container(
-                        padding: const EdgeInsets.all(8),
+                        padding: const EdgeInsets.all(
+                          _MenuButtonLayout.iconContainerPadding,
+                        ),
                         decoration: BoxDecoration(
                           color: isPrimary
-                              ? BalatroTheme.neonBlue.withValues(alpha: 0.3)
-                              : BalatroTheme.neonPink.withValues(alpha: 0.2),
-                          borderRadius: BorderRadius.circular(8),
+                              ? BalatroTheme.neonBlue.withValues(
+                                  alpha: _MenuButtonLayout
+                                      .primaryIconBackgroundAlpha,
+                                )
+                              : BalatroTheme.neonPink.withValues(
+                                  alpha: _MenuButtonLayout
+                                      .secondaryIconBackgroundAlpha,
+                                ),
+                          borderRadius: BorderRadius.circular(
+                            _MenuButtonLayout.iconContainerRadius,
+                          ),
                         ),
-                        child: Icon(icon, color: accentColor, size: 24),
+                        child: Icon(
+                          icon,
+                          color: accentColor,
+                          size: _MenuButtonLayout.mainIconSize,
+                        ),
                       ),
-                      const SizedBox(width: 16),
+                      const SizedBox(width: _MenuButtonLayout.iconSpacing),
                       Expanded(
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
@@ -279,20 +349,26 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                                 label,
                                 style: const TextStyle(
                                   color: Colors.white,
-                                  fontSize: 18,
+                                  fontSize: _MenuButtonLayout.labelFontSize,
                                   fontWeight: FontWeight.bold,
                                 ),
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ),
-                            const SizedBox(height: 2),
+                            const SizedBox(
+                              height: _MenuButtonLayout.labelDescriptionGap,
+                            ),
                             Flexible(
                               child: Text(
                                 description,
                                 style: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.7),
-                                  fontSize: 12,
+                                  color: Colors.white.withValues(
+                                    alpha:
+                                        _MenuButtonLayout.descriptionTextAlpha,
+                                  ),
+                                  fontSize:
+                                      _MenuButtonLayout.descriptionFontSize,
                                 ),
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
@@ -302,10 +378,10 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                         ),
                       ),
                       if (onSettingsPressed == null)
-                        Icon(
+                        const Icon(
                           Icons.arrow_forward_ios,
                           color: BalatroTheme.neonBlue,
-                          size: 16,
+                          size: _MenuButtonLayout.arrowIconSize,
                         ),
                     ],
                   ),
@@ -314,19 +390,28 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
             ),
             if (onSettingsPressed != null) ...[
               Container(
-                width: 1,
-                height: 48,
-                color: accentColor.withValues(alpha: 0.3),
+                width: _MenuButtonLayout.dividerWidth,
+                height: _MenuButtonLayout.dividerHeight,
+                color: accentColor.withValues(
+                  alpha: _MenuButtonLayout.dividerAlpha,
+                ),
               ),
               Tooltip(
                 message: 'Game settings',
                 child: IconButton(
                   onPressed: onSettingsPressed,
-                  icon: Icon(Icons.settings, color: accentColor, size: 22),
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  icon: Icon(
+                    Icons.settings,
+                    color: accentColor,
+                    size: _MenuButtonLayout.settingsIconSize,
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal:
+                        _MenuButtonLayout.settingsButtonHorizontalPadding,
+                  ),
                   constraints: const BoxConstraints(
-                    minWidth: 48,
-                    minHeight: 48,
+                    minWidth: _MenuButtonLayout.settingsButtonMinSize,
+                    minHeight: _MenuButtonLayout.settingsButtonMinSize,
                   ),
                 ),
               ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a settings gear icon to the **PLAY SOLO** button on the home screen so players can choose between quick start and custom configuration.

## Changes

- **Main button tap** — Starts a solo game immediately using saved preferences (falls back to defaults on first launch)
- **Settings icon** — Opens the existing `SoloGameSetupScreen` to customize bot count, personalities, and rule toggles
- Refactored `_buildMenuButton` to support an optional settings affordance with a visual divider
- Extracted `_MenuButtonLayout` constants for button sizing/spacing/opacity (review follow-up)
- Marked trailing arrow `Icon` as `const` (review follow-up)

## Behavior

| Action | Result |
|--------|--------|
| Tap PLAY SOLO | `GameScreen` with `SoloGameSettings.loadFromPreferences()` |
| Tap ⚙️ settings | `SoloGameSetupScreen` for full configuration |

Settings chosen in the setup screen are persisted and used on subsequent quick starts.

## Testing

- `dart format` — clean
- `flutter analyze` — zero issues
- `flutter test` — full suite passes (863 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f567f-9149-7603-9bed-4bec2698e1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f567f-9149-7603-9bed-4bec2698e1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a settings button to the **Play Solo** menu option.
  * Solo games now load the player’s saved settings before starting.
* **Bug Fixes**
  * Show an error message when solo-game settings cannot be loaded.
  * Improved loading-state handling to ensure the menu never remains stuck after an error or successful launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->