### PR TITLE
Add visual cues for final-turn-after-go-out phase

### DIFF
--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -107,6 +107,29 @@ class GameState {
 
   PlayingCard? get topDiscard => discardPile.isEmpty ? null : discardPile.last;
 
+  /// Player who went out this round, if any.
+  Player? get playerWhoWentOut {
+    final index = playerWhoWentOutIndex;
+    if (index == null || index < 0 || index >= players.length) {
+      return null;
+    }
+    return players[index];
+  }
+
+  /// Whether [currentPlayer] is taking their one final turn after a go-out.
+  bool get isCurrentPlayerFinalTurn =>
+      finalTurnPhaseActive &&
+      playersAwaitingFinalTurn.contains(currentPlayerIndex);
+
+  /// Whether the given [player] still has a final turn owed.
+  bool isPlayerAwaitingFinalTurn(Player player) {
+    final index = players.indexWhere((p) => p.id == player.id);
+    if (index < 0) {
+      return false;
+    }
+    return playersAwaitingFinalTurn.contains(index);
+  }
+
   /// Sets the game to multiplayer mode with optional viewer ID for privacy controls
   ///
   /// When [isMultiplayer] is true, action logging will respect multiplayer privacy rules,

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -22,6 +22,7 @@ import '../widgets/game_action_buttons.dart';
 import '../widgets/game_app_bar.dart';
 import '../widgets/game_session_info_menu.dart';
 import '../widgets/card_animation_host.dart';
+import '../widgets/final_turn_banner.dart';
 import '../widgets/perfect_grab_mini_game.dart';
 import '../theme/balatro_theme.dart';
 import '../services/game_analytics_logger.dart';
@@ -1950,6 +1951,10 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           ],
         ),
       );
+    }
+
+    if (gameState.finalTurnPhaseActive) {
+      return FinalTurnBanner(gameState: gameState);
     }
 
     return null;

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -10,6 +10,7 @@ import '../widgets/melds_section.dart';
 import '../widgets/game_hand_display.dart';
 import '../widgets/advanced_meld_selector.dart';
 import '../widgets/game_board_layout.dart';
+import '../widgets/final_turn_banner.dart';
 import '../widgets/turn_timer.dart';
 import '../widgets/card_animation_host.dart';
 import '../game/events/game_event_bus.dart';
@@ -516,6 +517,12 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
                     ),
                   ],
                 ],
+                aboveMelds: gameState.finalTurnPhaseActive
+                    ? FinalTurnBanner(
+                        gameState: gameState,
+                        localPlayerId: _gameController.userId,
+                      )
+                    : null,
                 meldsSection: MeldsSection(
                   gameState: gameState,
                   humanPlayer: humanPlayer,

--- a/lib/widgets/compact_player_scores.dart
+++ b/lib/widgets/compact_player_scores.dart
@@ -192,10 +192,16 @@ class _PlayerChip extends StatelessWidget {
                   ],
                   if (isWentOut) ...[
                     const SizedBox(width: 3),
-                    _StatusBadge(label: 'OUT', color: BalatroTheme.neonGreen),
+                    const _StatusBadge(
+                      label: 'OUT',
+                      color: BalatroTheme.neonGreen,
+                    ),
                   ] else if (isAwaitingFinalTurn) ...[
                     const SizedBox(width: 3),
-                    _StatusBadge(label: 'LAST', color: BalatroTheme.neonOrange),
+                    const _StatusBadge(
+                      label: 'LAST',
+                      color: BalatroTheme.neonOrange,
+                    ),
                   ],
                 ],
               ),

--- a/lib/widgets/compact_player_scores.dart
+++ b/lib/widgets/compact_player_scores.dart
@@ -45,6 +45,7 @@ class CompactPlayerScores extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 3),
               child: _PlayerChip(
+                gameState: gameState,
                 player: player,
                 isViewing: isViewing,
                 isCurrent: isCurrent,
@@ -62,6 +63,7 @@ class CompactPlayerScores extends StatelessWidget {
 }
 
 class _PlayerChip extends StatelessWidget {
+  final GameState gameState;
   final Player player;
   final bool isViewing;
   final bool isCurrent;
@@ -71,6 +73,7 @@ class _PlayerChip extends StatelessWidget {
   final BotPersonalityManager? botPersonalityManager;
 
   const _PlayerChip({
+    required this.gameState,
     required this.player,
     required this.isViewing,
     required this.isCurrent,
@@ -82,8 +85,17 @@ class _PlayerChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final wentOutIndex = gameState.playerWhoWentOutIndex;
+    final playerIndex = gameState.players.indexWhere((p) => p.id == player.id);
+    final isWentOut = wentOutIndex != null && playerIndex == wentOutIndex;
+    final isAwaitingFinalTurn =
+        gameState.finalTurnPhaseActive &&
+        gameState.isPlayerAwaitingFinalTurn(player);
+
     final accent = isViewing
         ? BalatroTheme.neonGreen
+        : isAwaitingFinalTurn
+        ? BalatroTheme.neonOrange
         : isCurrent
         ? BalatroTheme.neonBlue
         : Colors.white.withValues(alpha: 0.35);
@@ -104,7 +116,7 @@ class _PlayerChip extends StatelessWidget {
             borderRadius: BorderRadius.circular(10),
             border: Border.all(
               color: accent,
-              width: isViewing || isCurrent ? 1.5 : 1,
+              width: isViewing || isCurrent || isAwaitingFinalTurn ? 1.5 : 1,
             ),
           ),
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 5),
@@ -178,6 +190,13 @@ class _PlayerChip extends StatelessWidget {
                       ),
                     ),
                   ],
+                  if (isWentOut) ...[
+                    const SizedBox(width: 3),
+                    _StatusBadge(label: 'OUT', color: BalatroTheme.neonGreen),
+                  ] else if (isAwaitingFinalTurn) ...[
+                    const SizedBox(width: 3),
+                    _StatusBadge(label: 'LAST', color: BalatroTheme.neonOrange),
+                  ],
                 ],
               ),
             ],
@@ -212,5 +231,32 @@ class _PlayerChip extends StatelessWidget {
       case BotPersonality.adaptive:
         return PersonalityIcons.adaptive;
     }
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  final String label;
+  final Color color;
+
+  const _StatusBadge({required this.label, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: color.withValues(alpha: 0.8)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: UIConstants.playerScoresHandFootFontSize,
+          fontWeight: FontWeight.bold,
+          color: color,
+        ),
+      ),
+    );
   }
 }

--- a/lib/widgets/final_turn_banner.dart
+++ b/lib/widgets/final_turn_banner.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import '../models/game_state.dart';
+import '../models/player.dart';
+import '../theme/balatro_theme.dart';
+
+/// Prominent banner shown while other players take one final turn after a go-out.
+class FinalTurnBanner extends StatelessWidget {
+  final GameState gameState;
+
+  /// Local human player id (solo) or multiplayer user id. When null, uses
+  /// the first [PlayerType.human] in [GameState.players].
+  final String? localPlayerId;
+
+  const FinalTurnBanner({
+    super.key,
+    required this.gameState,
+    this.localPlayerId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!gameState.finalTurnPhaseActive) {
+      return const SizedBox.shrink();
+    }
+
+    final wentOut = gameState.playerWhoWentOut;
+    final localPlayer = _resolveLocalPlayer();
+    final isLocalFinalTurn =
+        localPlayer != null && gameState.isPlayerAwaitingFinalTurn(localPlayer);
+    final remaining = gameState.playersAwaitingFinalTurn.length;
+    final urgencyColor = isLocalFinalTurn
+        ? BalatroTheme.neonOrange
+        : BalatroTheme.neonYellow;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            urgencyColor.withValues(alpha: 0.28),
+            BalatroTheme.neonPink.withValues(alpha: 0.18),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: urgencyColor, width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: urgencyColor.withValues(alpha: 0.35),
+            blurRadius: 12,
+            spreadRadius: 1,
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            isLocalFinalTurn ? Icons.timer : Icons.hourglass_bottom,
+            color: urgencyColor,
+            size: 26,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _headline(isLocalFinalTurn),
+                  style: TextStyle(
+                    color: urgencyColor,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                    letterSpacing: 0.3,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  _body(wentOut?.name, isLocalFinalTurn, remaining),
+                  style: const TextStyle(
+                    color: BalatroTheme.primaryText,
+                    fontSize: 12,
+                    height: 1.35,
+                  ),
+                ),
+                if (isLocalFinalTurn) ...[
+                  const SizedBox(height: 6),
+                  Text(
+                    'Meld every card you can — leftover hand & foot cards '
+                    'become penalty points when the round ends.',
+                    style: TextStyle(
+                      color: urgencyColor.withValues(alpha: 0.95),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Player? _resolveLocalPlayer() {
+    if (localPlayerId != null) {
+      for (final player in gameState.players) {
+        if (player.id == localPlayerId) {
+          return player;
+        }
+      }
+      return null;
+    }
+
+    for (final player in gameState.players) {
+      if (player.type == PlayerType.human) {
+        return player;
+      }
+    }
+    return null;
+  }
+
+  String _headline(bool isLocalFinalTurn) {
+    if (isLocalFinalTurn) {
+      return 'YOUR FINAL TURN';
+    }
+    return 'FINAL TURNS IN PROGRESS';
+  }
+
+  String _body(String? wentOutName, bool isLocalFinalTurn, int remaining) {
+    final who = wentOutName ?? 'Someone';
+    if (isLocalFinalTurn) {
+      return '$who went out. This is your last turn before scoring — '
+          'play down as much as you can.';
+    }
+
+    final turnWord = remaining == 1 ? 'turn' : 'turns';
+    return '$who went out. Each other player gets one more $turnWord '
+        '($remaining remaining).';
+  }
+}

--- a/lib/widgets/game_compact_header.dart
+++ b/lib/widgets/game_compact_header.dart
@@ -77,6 +77,15 @@ class GameCompactHeader extends StatelessWidget {
                 _RoundBadge(round: gameState.round),
                 const SizedBox(width: 6),
                 _PhaseChip(label: _phaseLabel(), color: _phaseColor()),
+                if (gameState.finalTurnPhaseActive) ...[
+                  const SizedBox(width: 6),
+                  _PhaseChip(
+                    label: gameState.isCurrentPlayerFinalTurn
+                        ? 'Final turn'
+                        : 'Final turns',
+                    color: BalatroTheme.neonOrange,
+                  ),
+                ],
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(

--- a/lib/widgets/game_compact_header.dart
+++ b/lib/widgets/game_compact_header.dart
@@ -80,7 +80,7 @@ class GameCompactHeader extends StatelessWidget {
                 if (gameState.finalTurnPhaseActive) ...[
                   const SizedBox(width: 6),
                   _PhaseChip(
-                    label: gameState.isCurrentPlayerFinalTurn
+                    label: gameState.playersAwaitingFinalTurn.length == 1
                         ? 'Final turn'
                         : 'Final turns',
                     color: BalatroTheme.neonOrange,

--- a/test/widgets/final_turn_banner_test.dart
+++ b/test/widgets/final_turn_banner_test.dart
@@ -78,5 +78,36 @@ void main() {
       expect(find.textContaining('You went out'), findsOneWidget);
       expect(find.textContaining('1 remaining'), findsOneWidget);
     });
+
+    testWidgets(
+      'shows plural waiting message when multiple final turns remain',
+      (tester) async {
+        final bot2 = Player(id: 'bot2', name: 'Bot 2', type: PlayerType.bot);
+        gameState = GameState(
+          players: [human, bot, bot2],
+          deck: Deck.createHandAndFootDeck(3),
+        );
+        gameState.finalTurnPhaseActive = true;
+        gameState.playerWhoWentOutIndex = 0;
+        gameState.playersAwaitingFinalTurn.addAll([1, 2]);
+        gameState.currentPlayerIndex = 1;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: FinalTurnBanner(
+                gameState: gameState,
+                localPlayerId: human.id,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('FINAL TURNS IN PROGRESS'), findsOneWidget);
+        expect(find.textContaining('You went out'), findsOneWidget);
+        expect(find.textContaining('one more turns'), findsOneWidget);
+        expect(find.textContaining('2 remaining'), findsOneWidget);
+      },
+    );
   });
 }

--- a/test/widgets/final_turn_banner_test.dart
+++ b/test/widgets/final_turn_banner_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/deck.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/widgets/final_turn_banner.dart';
+
+void main() {
+  group('FinalTurnBanner', () {
+    late GameState gameState;
+    late Player human;
+    late Player bot;
+
+    setUp(() {
+      human = Player(id: 'human', name: 'You', type: PlayerType.human);
+      bot = Player(id: 'bot', name: 'Bot 1', type: PlayerType.bot);
+      gameState = GameState(
+        players: [human, bot],
+        deck: Deck.createHandAndFootDeck(2),
+      );
+    });
+
+    testWidgets('hidden when final turn phase is inactive', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: FinalTurnBanner(gameState: gameState)),
+        ),
+      );
+
+      expect(find.text('YOUR FINAL TURN'), findsNothing);
+      expect(find.text('FINAL TURNS IN PROGRESS'), findsNothing);
+    });
+
+    testWidgets('shows urgent message for local player final turn', (
+      tester,
+    ) async {
+      gameState.finalTurnPhaseActive = true;
+      gameState.playerWhoWentOutIndex = 1;
+      gameState.playersAwaitingFinalTurn.add(0);
+      gameState.currentPlayerIndex = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FinalTurnBanner(
+              gameState: gameState,
+              localPlayerId: human.id,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('YOUR FINAL TURN'), findsOneWidget);
+      expect(find.textContaining('Bot 1 went out'), findsOneWidget);
+      expect(find.textContaining('Meld every card you can'), findsOneWidget);
+    });
+
+    testWidgets('shows waiting message when local player already went out', (
+      tester,
+    ) async {
+      gameState.finalTurnPhaseActive = true;
+      gameState.playerWhoWentOutIndex = 0;
+      gameState.playersAwaitingFinalTurn.add(1);
+      gameState.currentPlayerIndex = 1;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FinalTurnBanner(
+              gameState: gameState,
+              localPlayerId: human.id,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('FINAL TURNS IN PROGRESS'), findsOneWidget);
+      expect(find.textContaining('You went out'), findsOneWidget);
+      expect(find.textContaining('1 remaining'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the "one more turn after going out" rule is enabled, players now get clear in-game visual cues that the round is in its final-turn phase and they should meld down as much as possible to avoid penalty points.

## Changes

- **Prominent banner** (`FinalTurnBanner`) above the melds area in solo and multiplayer:
  - **YOUR FINAL TURN** with urgency styling when it's the local player's last turn
  - Explains that leftover hand/foot cards become penalty points
  - Shows who went out and how many final turns remain for other players
- **Header chip** in `GameCompactHeader`: orange "Final turn" / "Final turns" badge during the phase
- **Player score chips**: `OUT` badge on the player who went out, `LAST` badge on players still owed a final turn (orange border highlight)
- **GameState helpers**: `playerWhoWentOut`, `isCurrentPlayerFinalTurn`, `isPlayerAwaitingFinalTurn`

## Testing

- `flutter analyze` — clean
- `flutter test test/widgets/final_turn_banner_test.dart` — 3 new widget tests
- `flutter test test/models/final_turn_phase_test.dart` — existing regression tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f58bb-e45b-73e3-aeec-c502283abc75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f58bb-e45b-73e3-aeec-c502283abc75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a final-turn phase experience with a dedicated banner shown during the active final-turn window.
  * Updated the game header to include a “Final turn(s)” indicator during the final-turn phase.
  * Enhanced player score chips with “LAST” (awaiting final turn) and “OUT” (went out) badges plus updated styling.
* **Bug Fixes**
  * Added safer game-state helpers to map and determine final-turn eligibility reliably.
* **Tests**
  * Added widget tests covering inactive, urgent (your final turn), and in-progress final-turn banner states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->