### PR TITLE
Fix bot hand-pile foot trap and final-turn scoring

### DIFF
--- a/lib/ai/bot_config.dart
+++ b/lib/ai/bot_config.dart
@@ -40,7 +40,8 @@ class BotConfig {
   /// Never stall on hand pile at or below this size — melt or discard to foot
   static const int handToFootCriticalHandSize = 4;
 
-  /// On hand pile: multi-meld / empty-to-foot below this size (avoids 1-card trap)
+  /// On hand pile: multi-meld / empty-to-foot at or below this size (inclusive;
+  /// e.g. 5-card hands qualify). Opponent-on-foot pressure may extend the limit.
   static const int handPileFootCompletionMaxHand = 5;
 
   /// Extra hand-size margin for aggressive bots racing foot under opponent pressure

--- a/lib/ai/bot_config.dart
+++ b/lib/ai/bot_config.dart
@@ -40,6 +40,9 @@ class BotConfig {
   /// Never stall on hand pile at or below this size — melt or discard to foot
   static const int handToFootCriticalHandSize = 4;
 
+  /// On hand pile: multi-meld / empty-to-foot below this size (avoids 1-card trap)
+  static const int handPileFootCompletionMaxHand = 5;
+
   /// Extra hand-size margin for aggressive bots racing foot under opponent pressure
   static const int handToFootRushAggressiveOpponentPressureMargin = 2;
 
@@ -266,7 +269,7 @@ class BotConfig {
   static const int humanLowRankDiscardBonus = 25;
 
   /// Bump when bot AI logic changes — stored on analytics docs for cross-version analysis.
-  static const String botAiVersion = '2026.07-personality-foot-rush';
+  static const String botAiVersion = '2026.07-hand-pile-foot-completion';
 
   // Prevent instantiation
   BotConfig._();

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -96,6 +96,12 @@ class EnhancedBotAI {
       // Set context for personality-based decisions
       _personalityManager.setCurrentPlayerContext(bot.id);
 
+      // Final turn after another player went out — maximize melded points, no holding.
+      if (gameState.finalTurnPhaseActive &&
+          gameState.isPlayerAwaitingFinalTurn(bot)) {
+        return _makeFinalTurnScoringDecision(bot, context);
+      }
+
       // CRITICAL: Finish the round when books are met — discard/meld last cards
       // before going out (empty hand required for canGoOut).
       if (gameState.turnPhase == TurnPhase.discard ||
@@ -476,6 +482,15 @@ class EnhancedBotAI {
     // Empty hand: skip meld (discard/go-out handled in discard phase)
     if (bot.currentHand.isEmpty) {
       return BotDecision(action: 'noMeld');
+    }
+
+    // PRIORITY 0: Complete hand pile → foot (multi-meld to avoid 1-card trap)
+    final handPileFootCompletion = _makeCompleteHandPileForFootDecision(
+      bot,
+      context,
+    );
+    if (handPileFootCompletion != null) {
+      return handPileFootCompletion;
     }
 
     // PRIORITY 0: Check if bot should rush to go out
@@ -1787,6 +1802,14 @@ class EnhancedBotAI {
       return false;
     }
 
+    // On hand pile without books — meld toward play-down/books, don't hoard
+    if (bot.hasPlayedDown && !bot.hasPickedUpFoot) {
+      final bookCount = bot.melds.where((m) => m.cards.length >= 7).length;
+      if (bookCount == 0) {
+        return false;
+      }
+    }
+
     // Allow trimming melds that drop hand below accumulation window (e.g. 8→5)
     final controller = context.controller as GameController?;
     if (controller != null) {
@@ -1838,6 +1861,11 @@ class EnhancedBotAI {
       }
       if (personality == BotPersonality.aggressive &&
           handSize <= BotConfig.handToFootRushAggressiveThreshold) {
+        return false;
+      }
+      // Played down but no books yet — keep melding, don't hoard on hand pile
+      final bookCount = bot.melds.where((m) => m.cards.length >= 7).length;
+      if (bot.hasPlayedDown && bookCount == 0 && handSize <= 7) {
         return false;
       }
     }
@@ -2376,6 +2404,26 @@ class EnhancedBotAI {
       return null;
     }
 
+    final handSize = bot.currentHand.length;
+    if (handSize <= BotConfig.handPileFootCompletionMaxHand) {
+      final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
+        bot,
+        controller,
+      );
+      if (maximalMelds.length >= 2) {
+        final cardsMeldable = maximalMelds.fold<int>(
+          0,
+          (sum, meld) => sum + meld.length,
+        );
+        if (cardsMeldable >= handSize - 1) {
+          return BotDecision(action: 'createMultipleMelds', data: maximalMelds);
+        }
+      } else if (maximalMelds.length == 1 &&
+          maximalMelds.first.length >= handSize - 1) {
+        return BotDecision(action: 'createMeld', data: maximalMelds.first);
+      }
+    }
+
     final cardsToAdd = _filterWildCardAdditions(
       _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
       bot,
@@ -2405,6 +2453,164 @@ class EnhancedBotAI {
     }
 
     return null;
+  }
+
+  /// True when bot should empty the hand pile to pick up foot (any personality).
+  bool _shouldCompleteHandPileForFoot(Player bot, BotGameContext context) {
+    if (!bot.hasPlayedDown || bot.hasPickedUpFoot) {
+      return false;
+    }
+    final handSize = bot.currentHand.length;
+    if (handSize == 0) {
+      return false;
+    }
+    if (handSize <= BotConfig.handPileFootCompletionMaxHand) {
+      return true;
+    }
+    if (_opponentOnFootPressure(context, bot) &&
+        handSize <= BotConfig.handToFootRushOpponentOnFootThreshold) {
+      return true;
+    }
+    return false;
+  }
+
+  /// Multi-meld / sequential rush to clear hand pile and trigger foot pickup.
+  BotDecision? _makeCompleteHandPileForFootDecision(
+    Player bot,
+    BotGameContext context,
+  ) {
+    if (!_shouldCompleteHandPileForFoot(bot, context)) {
+      return null;
+    }
+
+    DebugLogger.botDebug(
+      bot.id,
+      bot.name,
+      'HAND PILE→FOOT completion with ${bot.currentHand.length} cards',
+    );
+
+    final playAllDecision = _checkCanPlayAllCards(bot, context);
+    if (playAllDecision != null) {
+      return playAllDecision;
+    }
+
+    final controller = context.controller as GameController?;
+    if (controller == null) {
+      return null;
+    }
+
+    final handSize = bot.currentHand.length;
+    if (handSize <= BotConfig.handPileFootCompletionMaxHand) {
+      final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
+        bot,
+        controller,
+      );
+      if (maximalMelds.length >= 2) {
+        final cardsMeldable = maximalMelds.fold<int>(
+          0,
+          (sum, meld) => sum + meld.length,
+        );
+        if (cardsMeldable >= handSize - 1) {
+          return BotDecision(action: 'createMultipleMelds', data: maximalMelds);
+        }
+      } else if (maximalMelds.length == 1 &&
+          maximalMelds.first.length >= handSize - 1) {
+        return BotDecision(action: 'createMeld', data: maximalMelds.first);
+      }
+    }
+
+    final rush = _makeHandToFootRushDecision(bot, context);
+    if (rush != null) {
+      return rush;
+    }
+
+    final cardsToAdd = _filterWildCardAdditions(
+      _meldAnalyzer.findCardsToAddToExistingMelds(bot, controller),
+      bot,
+    );
+    if (cardsToAdd.isNotEmpty) {
+      return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+    }
+
+    final possibleMelds = _getCachedPossibleMelds(bot, context);
+    if (possibleMelds.isNotEmpty) {
+      return BotDecision(
+        action: 'createMeld',
+        data: _meldAnalyzer.findBestMeld(
+          possibleMelds,
+          bot: bot,
+          preferLarger: true,
+        ),
+      );
+    }
+
+    final footTransition = _footTransitionManager.handleFootTransition(
+      bot,
+      controller,
+    );
+    if (footTransition != null) {
+      return footTransition;
+    }
+
+    return BotDecision(action: 'noMeld');
+  }
+
+  /// On final turn after another player went out: meld all scorable cards.
+  BotDecision _makeFinalTurnScoringDecision(
+    Player bot,
+    BotGameContext context,
+  ) {
+    final gameState = context.gameState;
+    final controller = context.controller as GameController?;
+
+    switch (gameState.turnPhase) {
+      case TurnPhase.draw:
+        return BotDecision(action: 'drawFromDeck');
+      case TurnPhase.meld:
+        if (bot.currentHand.isEmpty) {
+          return BotDecision(action: 'noMeld');
+        }
+        if (controller != null) {
+          final playAll = _checkCanPlayAllCards(bot, context);
+          if (playAll != null) {
+            return playAll;
+          }
+
+          final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
+            bot,
+            controller,
+          );
+          if (maximalMelds.length >= 2) {
+            return BotDecision(
+              action: 'createMultipleMelds',
+              data: maximalMelds,
+            );
+          }
+
+          final cardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
+            bot,
+            controller,
+          );
+          if (cardsToAdd.isNotEmpty) {
+            return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+          }
+
+          final possibleMelds = _getCachedPossibleMelds(bot, context);
+          if (possibleMelds.isNotEmpty) {
+            return BotDecision(
+              action: 'createMeld',
+              data: _meldAnalyzer.findBestMeld(
+                possibleMelds,
+                bot: bot,
+                preferLarger: true,
+              ),
+            );
+          }
+        }
+        return BotDecision(action: 'noMeld');
+      case TurnPhase.discard:
+        return _makeDiscardDecision(bot, context);
+    }
   }
 
   /// Determine if we should hold cards based on round play-down requirements
@@ -3708,6 +3914,24 @@ class EnhancedBotAI {
   }
 
   // Getters for testing and debugging
+
+  @visibleForTesting
+  bool shouldCompleteHandPileForFoot(Player bot, BotGameContext context) {
+    return _shouldCompleteHandPileForFoot(bot, context);
+  }
+
+  @visibleForTesting
+  BotDecision? makeCompleteHandPileForFootDecision(
+    Player bot,
+    BotGameContext context,
+  ) {
+    return _makeCompleteHandPileForFootDecision(bot, context);
+  }
+
+  @visibleForTesting
+  BotDecision makeFinalTurnScoringDecision(Player bot, BotGameContext context) {
+    return _makeFinalTurnScoringDecision(bot, context);
+  }
 
   @visibleForTesting
   bool shouldRushHandToFoot(Player bot, BotGameContext context) {

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -2405,23 +2405,14 @@ class EnhancedBotAI {
     }
 
     final handSize = bot.currentHand.length;
-    if (handSize <= BotConfig.handPileFootCompletionMaxHand) {
-      final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
-        bot,
-        controller,
-      );
-      if (maximalMelds.length >= 2) {
-        final cardsMeldable = maximalMelds.fold<int>(
-          0,
-          (sum, meld) => sum + meld.length,
-        );
-        if (cardsMeldable >= handSize - 1) {
-          return BotDecision(action: 'createMultipleMelds', data: maximalMelds);
-        }
-      } else if (maximalMelds.length == 1 &&
-          maximalMelds.first.length >= handSize - 1) {
-        return BotDecision(action: 'createMeld', data: maximalMelds.first);
-      }
+    final maximalMeldsDecision = _tryMaximalMeldsForHandPileCompletion(
+      bot,
+      controller,
+      handSize,
+      context,
+    );
+    if (maximalMeldsDecision != null) {
+      return maximalMeldsDecision;
     }
 
     final cardsToAdd = _filterWildCardAdditions(
@@ -2500,23 +2491,14 @@ class EnhancedBotAI {
     }
 
     final handSize = bot.currentHand.length;
-    if (handSize <= BotConfig.handPileFootCompletionMaxHand) {
-      final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
-        bot,
-        controller,
-      );
-      if (maximalMelds.length >= 2) {
-        final cardsMeldable = maximalMelds.fold<int>(
-          0,
-          (sum, meld) => sum + meld.length,
-        );
-        if (cardsMeldable >= handSize - 1) {
-          return BotDecision(action: 'createMultipleMelds', data: maximalMelds);
-        }
-      } else if (maximalMelds.length == 1 &&
-          maximalMelds.first.length >= handSize - 1) {
-        return BotDecision(action: 'createMeld', data: maximalMelds.first);
-      }
+    final maximalMeldsDecision = _tryMaximalMeldsForHandPileCompletion(
+      bot,
+      controller,
+      handSize,
+      context,
+    );
+    if (maximalMeldsDecision != null) {
+      return maximalMeldsDecision;
     }
 
     final rush = _makeHandToFootRushDecision(bot, context);
@@ -2882,6 +2864,44 @@ class EnhancedBotAI {
   /// True when any opponent has picked up foot — bots should race to transition.
   bool _opponentOnFootPressure(BotGameContext context, Player bot) {
     return context.players.any((p) => p.id != bot.id && p.hasPickedUpFoot);
+  }
+
+  /// Hand-size ceiling for multi-meld foot completion (5 normally, up to 8 under pressure).
+  int _handPileMaximalMeldHandLimit(Player bot, BotGameContext context) {
+    if (_opponentOnFootPressure(context, bot)) {
+      return BotConfig.handToFootRushOpponentOnFootThreshold;
+    }
+    return BotConfig.handPileFootCompletionMaxHand;
+  }
+
+  /// Try multi-meld or single-meld completion when hand is small enough.
+  BotDecision? _tryMaximalMeldsForHandPileCompletion(
+    Player bot,
+    GameController controller,
+    int handSize,
+    BotGameContext context,
+  ) {
+    if (handSize > _handPileMaximalMeldHandLimit(bot, context)) {
+      return null;
+    }
+
+    final maximalMelds = _meldAnalyzer
+        .findMaximalMeldCombination(bot, controller)
+        .where((meld) => meld.length >= GameConfig.minTotalCardsForMeld)
+        .toList();
+    if (maximalMelds.length >= 2) {
+      final cardsMeldable = maximalMelds.fold<int>(
+        0,
+        (sum, meld) => sum + meld.length,
+      );
+      if (cardsMeldable >= handSize - 1) {
+        return BotDecision(action: 'createMultipleMelds', data: maximalMelds);
+      }
+    } else if (maximalMelds.length == 1 &&
+        maximalMelds.first.length >= handSize - 1) {
+      return BotDecision(action: 'createMeld', data: maximalMelds.first);
+    }
+    return null;
   }
 
   /// Enhanced book completion strategy for competitive play

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -148,6 +148,56 @@ class GameState {
     _viewerId = viewerId;
   }
 
+  /// Immutable copy of game state for analytics/logging before mutations apply.
+  GameState snapshotForAnalytics() {
+    final snapshotPlayers = players
+        .map(
+          (player) => Player(
+            id: player.id,
+            name: player.name,
+            type: player.type,
+            hand: List<PlayingCard>.from(player.hand),
+            foot: List<PlayingCard>.from(player.foot),
+            melds: player.melds
+                .map(
+                  (meld) => Meld(
+                    rank: meld.rank,
+                    cards: List<PlayingCard>.from(meld.cards),
+                  ),
+                )
+                .toList(),
+            hasPickedUpFoot: player.hasPickedUpFoot,
+            hasPlayedDown: player.hasPlayedDown,
+            score: player.score,
+          ),
+        )
+        .toList();
+
+    final snapshot = GameState(
+      players: snapshotPlayers,
+      deck: Deck.fromCards(deck.cards, seed: deck.seed),
+      discardPile: List<PlayingCard>.from(discardPile),
+      recentActions: List<GameAction>.from(recentActions),
+      currentPlayerIndex: currentPlayerIndex,
+      phase: phase,
+      turnPhase: turnPhase,
+      round: round,
+      discardPileFrozen: discardPileFrozen,
+      hasDrawnFromDeck: hasDrawnFromDeck,
+      hasMelded: hasMelded,
+      soloSettings: soloSettings,
+      finalTurnPhaseActive: finalTurnPhaseActive,
+      playerWhoWentOutIndex: playerWhoWentOutIndex,
+      playersAwaitingFinalTurn: Set<int>.from(playersAwaitingFinalTurn),
+    );
+
+    if (winner != null) {
+      snapshot.winner = snapshotPlayers.firstWhere((p) => p.id == winner!.id);
+    }
+
+    return snapshot;
+  }
+
   void _logAction(String message, {bool showCardDetails = true}) {
     // Determine if card details should be shown based on player type and action visibility
     final isHuman = currentPlayer.type == PlayerType.human;

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -148,56 +148,6 @@ class GameState {
     _viewerId = viewerId;
   }
 
-  /// Immutable copy of game state for analytics/logging before mutations apply.
-  GameState snapshotForAnalytics() {
-    final snapshotPlayers = players
-        .map(
-          (player) => Player(
-            id: player.id,
-            name: player.name,
-            type: player.type,
-            hand: List<PlayingCard>.from(player.hand),
-            foot: List<PlayingCard>.from(player.foot),
-            melds: player.melds
-                .map(
-                  (meld) => Meld(
-                    rank: meld.rank,
-                    cards: List<PlayingCard>.from(meld.cards),
-                  ),
-                )
-                .toList(),
-            hasPickedUpFoot: player.hasPickedUpFoot,
-            hasPlayedDown: player.hasPlayedDown,
-            score: player.score,
-          ),
-        )
-        .toList();
-
-    final snapshot = GameState(
-      players: snapshotPlayers,
-      deck: Deck.fromCards(deck.cards, seed: deck.seed),
-      discardPile: List<PlayingCard>.from(discardPile),
-      recentActions: List<GameAction>.from(recentActions),
-      currentPlayerIndex: currentPlayerIndex,
-      phase: phase,
-      turnPhase: turnPhase,
-      round: round,
-      discardPileFrozen: discardPileFrozen,
-      hasDrawnFromDeck: hasDrawnFromDeck,
-      hasMelded: hasMelded,
-      soloSettings: soloSettings,
-      finalTurnPhaseActive: finalTurnPhaseActive,
-      playerWhoWentOutIndex: playerWhoWentOutIndex,
-      playersAwaitingFinalTurn: Set<int>.from(playersAwaitingFinalTurn),
-    );
-
-    if (winner != null) {
-      snapshot.winner = snapshotPlayers.firstWhere((p) => p.id == winner!.id);
-    }
-
-    return snapshot;
-  }
-
   void _logAction(String message, {bool showCardDetails = true}) {
     // Determine if card details should be shown based on player type and action visibility
     final isHuman = currentPlayer.type == PlayerType.human;

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -2068,11 +2068,12 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     required String decision,
     required String reasoning,
     Map<String, dynamic>? context,
+    GameState? gameStateSnapshot,
   }) async {
     if (_analyticsSessionId == null) return;
 
     try {
-      final gameState = ref.read(currentGameStateProvider);
+      final gameState = gameStateSnapshot ?? ref.read(currentGameStateProvider);
       if (gameState == null) return;
 
       _actionSequenceNumber++; // Increment sequence for this action

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -26,6 +26,8 @@ import '../widgets/final_turn_banner.dart';
 import '../widgets/perfect_grab_mini_game.dart';
 import '../theme/balatro_theme.dart';
 import '../services/game_analytics_logger.dart';
+import '../services/analytics/bot_decision_analytics_snapshot.dart';
+import '../services/analytics/bot_decision_snapshot_mapper.dart';
 import '../services/analytics_batcher.dart';
 import '../services/analytics_fields.dart';
 import 'main_menu_screen.dart';
@@ -2068,13 +2070,19 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     required String decision,
     required String reasoning,
     Map<String, dynamic>? context,
-    GameState? gameStateSnapshot,
+    BotDecisionAnalyticsSnapshot? gameStateSnapshot,
   }) async {
     if (_analyticsSessionId == null) return;
 
     try {
-      final gameState = gameStateSnapshot ?? ref.read(currentGameStateProvider);
-      if (gameState == null) return;
+      final liveGameState = ref.read(currentGameStateProvider);
+      if (liveGameState == null && gameStateSnapshot == null) {
+        return;
+      }
+
+      final analyticsSnapshot =
+          gameStateSnapshot ??
+          BotDecisionSnapshotMapper.fromGameState(liveGameState!);
 
       _actionSequenceNumber++; // Increment sequence for this action
 
@@ -2084,13 +2092,13 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         decision: decision,
         reasoning: reasoning,
         personality: personality,
-        gameState: gameState,
+        gameState: analyticsSnapshot,
         decisionContext: {
           ...?context,
           // Add sequencing information
           'actionSequence': _actionSequenceNumber,
           'turnNumber': _totalTurns,
-          'playerTurnIndex': gameState.currentPlayerIndex,
+          'playerTurnIndex': analyticsSnapshot.currentPlayerIndex,
         },
       );
     } catch (e) {

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -206,6 +206,11 @@ class BotTurnManager {
         for (int attempt = 0; attempt < 3 && !actionSucceeded; attempt++) {
           try {
             final decision = botAI.makeDecision(botPlayer, gameController);
+            final gameStateSnapshot = gameController.gameState
+                .snapshotForAnalytics();
+            final snapshotBot = gameStateSnapshot.players.firstWhere(
+              (player) => player.id == botPlayer.id,
+            );
             actionSucceeded = executeBotDecision(decision, botPlayer);
 
             if (actionSucceeded) {
@@ -218,9 +223,9 @@ class BotTurnManager {
 
               // Log bot decision for analytics with actual strategic reasoning
               final strategicReasoning = generateBotReasoning(
-                botPlayer,
+                snapshotBot,
                 decision,
-                gameController.gameState,
+                gameStateSnapshot,
               );
 
               logBotDecision(
@@ -230,7 +235,7 @@ class BotTurnManager {
                 context: decision.data != null
                     ? {'data': decision.data.toString()}
                     : null,
-                gameStateSnapshot: gameController.gameState,
+                gameStateSnapshot: gameStateSnapshot,
               );
               break;
             }

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -11,6 +11,8 @@ import '../../config/bot_configurations.dart';
 import '../../utils/debug_logger.dart';
 import '../../config/game_config.dart';
 import '../../services/analytics_batcher.dart';
+import '../../services/analytics/bot_decision_analytics_snapshot.dart';
+import '../../services/analytics/bot_decision_snapshot_mapper.dart';
 
 /// Manages all bot-related functionality for the game screen.
 ///
@@ -27,7 +29,7 @@ class BotTurnManager {
     required String decision,
     required String reasoning,
     Map<String, dynamic>? context,
-    GameState? gameStateSnapshot,
+    BotDecisionAnalyticsSnapshot? gameStateSnapshot,
   })
   logBotDecision;
 
@@ -206,11 +208,10 @@ class BotTurnManager {
         for (int attempt = 0; attempt < 3 && !actionSucceeded; attempt++) {
           try {
             final decision = botAI.makeDecision(botPlayer, gameController);
-            final gameStateSnapshot = gameController.gameState
-                .snapshotForAnalytics();
-            final snapshotBot = gameStateSnapshot.players.firstWhere(
-              (player) => player.id == botPlayer.id,
+            final gameStateSnapshot = BotDecisionSnapshotMapper.fromGameState(
+              gameController.gameState,
             );
+            final snapshotBot = gameStateSnapshot.playerById(botPlayer.id);
             actionSucceeded = executeBotDecision(decision, botPlayer);
 
             if (actionSucceeded) {
@@ -991,9 +992,9 @@ class BotTurnManager {
 
   /// Generate strategic reasoning for bot decisions for analytics
   String generateBotReasoning(
-    Player bot,
+    AnalyticsPlayerSnapshot bot,
     BotDecision decision,
-    GameState gameState,
+    BotDecisionAnalyticsSnapshot gameState,
   ) {
     try {
       final personality = botAI.personalityManager.getPersonality(bot.id);

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -27,6 +27,7 @@ class BotTurnManager {
     required String decision,
     required String reasoning,
     Map<String, dynamic>? context,
+    GameState? gameStateSnapshot,
   })
   logBotDecision;
 
@@ -229,6 +230,7 @@ class BotTurnManager {
                 context: decision.data != null
                     ? {'data': decision.data.toString()}
                     : null,
+                gameStateSnapshot: gameController.gameState,
               );
               break;
             }

--- a/lib/services/analytics/bot_decision_analytics_snapshot.dart
+++ b/lib/services/analytics/bot_decision_analytics_snapshot.dart
@@ -27,11 +27,17 @@ class BotDecisionAnalyticsSnapshot {
     required this.playerWhoWentOutIndex,
     required Set<int> playersAwaitingFinalTurn,
     required this.winnerId,
-  }) : players = UnmodifiableListView(players),
-       deckCards = UnmodifiableListView(deckCards),
-       discardPile = UnmodifiableListView(discardPile),
-       recentActions = UnmodifiableListView(recentActions),
-       playersAwaitingFinalTurn = UnmodifiableSetView(playersAwaitingFinalTurn);
+  }) : players = UnmodifiableListView(
+         List<AnalyticsPlayerSnapshot>.from(players),
+       ),
+       deckCards = UnmodifiableListView(List<PlayingCard>.from(deckCards)),
+       discardPile = UnmodifiableListView(List<PlayingCard>.from(discardPile)),
+       recentActions = UnmodifiableListView(
+         List<GameAction>.from(recentActions),
+       ),
+       playersAwaitingFinalTurn = UnmodifiableSetView(
+         Set<int>.from(playersAwaitingFinalTurn),
+       );
 
   final UnmodifiableListView<AnalyticsPlayerSnapshot> players;
   final UnmodifiableListView<PlayingCard> deckCards;
@@ -72,11 +78,15 @@ class AnalyticsPlayerSnapshot {
     required this.hasPickedUpFoot,
     required this.hasPlayedDown,
     required this.score,
-  }) : hand = UnmodifiableListView(hand),
-       foot = UnmodifiableListView(foot),
-       melds = UnmodifiableListView(melds),
-       newlyDrawnCardIndices = UnmodifiableSetView(newlyDrawnCardIndices),
-       roundScoreHistory = UnmodifiableListView(roundScoreHistory);
+  }) : hand = UnmodifiableListView(List<PlayingCard>.from(hand)),
+       foot = UnmodifiableListView(List<PlayingCard>.from(foot)),
+       melds = UnmodifiableListView(List<AnalyticsMeldSnapshot>.from(melds)),
+       newlyDrawnCardIndices = UnmodifiableSetView(
+         Set<int>.from(newlyDrawnCardIndices),
+       ),
+       roundScoreHistory = UnmodifiableListView(
+         List<RoundScoreBreakdown>.from(roundScoreHistory),
+       );
 
   final String id;
   final String name;
@@ -102,7 +112,7 @@ class AnalyticsPlayerSnapshot {
 /// Immutable meld capture for bot-decision analytics.
 class AnalyticsMeldSnapshot {
   AnalyticsMeldSnapshot({required this.rank, required List<PlayingCard> cards})
-    : cards = UnmodifiableListView(cards);
+    : cards = UnmodifiableListView(List<PlayingCard>.from(cards));
 
   final CardRank rank;
   final UnmodifiableListView<PlayingCard> cards;

--- a/lib/services/analytics/bot_decision_analytics_snapshot.dart
+++ b/lib/services/analytics/bot_decision_analytics_snapshot.dart
@@ -1,0 +1,115 @@
+import 'dart:collection';
+
+import '../../config/game_config.dart';
+import '../../config/solo_game_settings.dart';
+import '../../models/card.dart';
+import '../../models/game_state.dart';
+import '../../models/player.dart';
+import '../../models/round_score_breakdown.dart';
+
+/// Immutable game-state capture for bot-decision analytics before mutations apply.
+class BotDecisionAnalyticsSnapshot {
+  BotDecisionAnalyticsSnapshot({
+    required List<AnalyticsPlayerSnapshot> players,
+    required List<PlayingCard> deckCards,
+    required this.deckSeed,
+    required List<PlayingCard> discardPile,
+    required List<GameAction> recentActions,
+    required this.currentPlayerIndex,
+    required this.phase,
+    required this.turnPhase,
+    required this.round,
+    required this.discardPileFrozen,
+    required this.hasDrawnFromDeck,
+    required this.hasMelded,
+    required this.soloSettings,
+    required this.finalTurnPhaseActive,
+    required this.playerWhoWentOutIndex,
+    required Set<int> playersAwaitingFinalTurn,
+    required this.winnerId,
+  }) : players = UnmodifiableListView(players),
+       deckCards = UnmodifiableListView(deckCards),
+       discardPile = UnmodifiableListView(discardPile),
+       recentActions = UnmodifiableListView(recentActions),
+       playersAwaitingFinalTurn = UnmodifiableSetView(playersAwaitingFinalTurn);
+
+  final UnmodifiableListView<AnalyticsPlayerSnapshot> players;
+  final UnmodifiableListView<PlayingCard> deckCards;
+  final int? deckSeed;
+  final UnmodifiableListView<PlayingCard> discardPile;
+  final UnmodifiableListView<GameAction> recentActions;
+  final int currentPlayerIndex;
+  final GamePhase phase;
+  final TurnPhase turnPhase;
+  final int round;
+  final bool discardPileFrozen;
+  final bool hasDrawnFromDeck;
+  final bool hasMelded;
+  final SoloGameSettings soloSettings;
+  final bool finalTurnPhaseActive;
+  final int? playerWhoWentOutIndex;
+  final UnmodifiableSetView<int> playersAwaitingFinalTurn;
+  final String? winnerId;
+
+  int get deckSize => deckCards.length;
+
+  AnalyticsPlayerSnapshot playerById(String id) {
+    return players.firstWhere((player) => player.id == id);
+  }
+}
+
+/// Immutable player capture for bot-decision analytics.
+class AnalyticsPlayerSnapshot {
+  AnalyticsPlayerSnapshot({
+    required this.id,
+    required this.name,
+    required this.type,
+    required List<PlayingCard> hand,
+    required List<PlayingCard> foot,
+    required List<AnalyticsMeldSnapshot> melds,
+    required Set<int> newlyDrawnCardIndices,
+    required List<RoundScoreBreakdown> roundScoreHistory,
+    required this.hasPickedUpFoot,
+    required this.hasPlayedDown,
+    required this.score,
+  }) : hand = UnmodifiableListView(hand),
+       foot = UnmodifiableListView(foot),
+       melds = UnmodifiableListView(melds),
+       newlyDrawnCardIndices = UnmodifiableSetView(newlyDrawnCardIndices),
+       roundScoreHistory = UnmodifiableListView(roundScoreHistory);
+
+  final String id;
+  final String name;
+  final PlayerType type;
+  final UnmodifiableListView<PlayingCard> hand;
+  final UnmodifiableListView<PlayingCard> foot;
+  final UnmodifiableListView<AnalyticsMeldSnapshot> melds;
+  final UnmodifiableSetView<int> newlyDrawnCardIndices;
+  final UnmodifiableListView<RoundScoreBreakdown> roundScoreHistory;
+  final bool hasPickedUpFoot;
+  final bool hasPlayedDown;
+  final int score;
+
+  List<PlayingCard> get currentHand => hasPickedUpFoot ? foot : hand;
+
+  bool get hasCleanBook => melds.any((meld) => meld.isBook && meld.isClean);
+
+  bool get hasDirtyBook => melds.any((meld) => meld.isBook && meld.isDirty);
+
+  bool get canGoOutWithBooks => hasCleanBook && hasDirtyBook;
+}
+
+/// Immutable meld capture for bot-decision analytics.
+class AnalyticsMeldSnapshot {
+  AnalyticsMeldSnapshot({required this.rank, required List<PlayingCard> cards})
+    : cards = UnmodifiableListView(cards);
+
+  final CardRank rank;
+  final UnmodifiableListView<PlayingCard> cards;
+
+  bool get isBook => cards.length >= GameConfig.bookSize;
+
+  bool get isClean => isBook && !cards.any((card) => card.isWild);
+
+  bool get isDirty => isBook && cards.any((card) => card.isWild);
+}

--- a/lib/services/analytics/bot_decision_snapshot_mapper.dart
+++ b/lib/services/analytics/bot_decision_snapshot_mapper.dart
@@ -1,0 +1,61 @@
+import '../../models/card.dart';
+import '../../models/game_state.dart';
+import '../../models/player.dart';
+import '../../models/round_score_breakdown.dart';
+import 'bot_decision_analytics_snapshot.dart';
+
+/// Maps live [GameState] into an immutable analytics snapshot.
+class BotDecisionSnapshotMapper {
+  BotDecisionSnapshotMapper._();
+
+  static BotDecisionAnalyticsSnapshot fromGameState(GameState source) {
+    final snapshotPlayers = source.players
+        .map(_mapPlayer)
+        .toList(growable: false);
+
+    return BotDecisionAnalyticsSnapshot(
+      players: snapshotPlayers,
+      deckCards: List<PlayingCard>.from(source.deck.cards),
+      deckSeed: source.deck.seed,
+      discardPile: List<PlayingCard>.from(source.discardPile),
+      recentActions: List<GameAction>.from(source.recentActions),
+      currentPlayerIndex: source.currentPlayerIndex,
+      phase: source.phase,
+      turnPhase: source.turnPhase,
+      round: source.round,
+      discardPileFrozen: source.discardPileFrozen,
+      hasDrawnFromDeck: source.hasDrawnFromDeck,
+      hasMelded: source.hasMelded,
+      soloSettings: source.soloSettings,
+      finalTurnPhaseActive: source.finalTurnPhaseActive,
+      playerWhoWentOutIndex: source.playerWhoWentOutIndex,
+      playersAwaitingFinalTurn: Set<int>.from(source.playersAwaitingFinalTurn),
+      winnerId: source.winner?.id,
+    );
+  }
+
+  static AnalyticsPlayerSnapshot _mapPlayer(Player player) {
+    return AnalyticsPlayerSnapshot(
+      id: player.id,
+      name: player.name,
+      type: player.type,
+      hand: List<PlayingCard>.from(player.hand),
+      foot: List<PlayingCard>.from(player.foot),
+      melds: player.melds
+          .map(
+            (meld) => AnalyticsMeldSnapshot(
+              rank: meld.rank,
+              cards: List<PlayingCard>.from(meld.cards),
+            ),
+          )
+          .toList(growable: false),
+      newlyDrawnCardIndices: Set<int>.from(player.newlyDrawnCardIndices),
+      roundScoreHistory: List<RoundScoreBreakdown>.from(
+        player.roundScoreHistory,
+      ),
+      hasPickedUpFoot: player.hasPickedUpFoot,
+      hasPlayedDown: player.hasPlayedDown,
+      score: player.score,
+    );
+  }
+}

--- a/lib/services/game_analytics_logger.dart
+++ b/lib/services/game_analytics_logger.dart
@@ -8,6 +8,7 @@ import '../ai/bot_personality.dart';
 import '../ai/bot_config.dart';
 import '../config/analytics_metadata.dart';
 import '../game/events/game_event.dart';
+import 'analytics/bot_decision_analytics_snapshot.dart';
 import 'firebase_service.dart';
 import 'device_service.dart';
 import 'analytics_batcher.dart';
@@ -245,7 +246,7 @@ class GameAnalyticsLogger {
     required String decision,
     required String reasoning,
     required BotPersonality personality,
-    required GameState gameState,
+    required BotDecisionAnalyticsSnapshot gameState,
     Map<String, dynamic>? decisionContext,
     double? confidence,
     List<String>? alternativeActions,
@@ -255,7 +256,7 @@ class GameAnalyticsLogger {
     if (_currentSessionId == null) return;
 
     try {
-      final botPlayer = gameState.players.firstWhere((p) => p.id == botId);
+      final botPlayer = gameState.playerById(botId);
 
       final decisionData = {
         'sessionId': _currentSessionId,
@@ -276,7 +277,7 @@ class GameAnalyticsLogger {
         'currentPlayerIndex': gameState.currentPlayerIndex,
         'discardPileSize': gameState.discardPile.length,
         'discardPileFrozen': gameState.discardPileFrozen,
-        'gameSeed': gameState.deck.seed, // For reproducible analysis
+        'gameSeed': gameState.deckSeed, // For reproducible analysis
         // Bot state
         'botHandSize': botPlayer.currentHand.length,
         'botHandCards': botPlayer.currentHand
@@ -302,7 +303,7 @@ class GameAnalyticsLogger {
             .toList(),
 
         // Game state context
-        'deckSize': gameState.deck.size,
+        'deckSize': gameState.deckSize,
         'topDiscardCard': gameState.discardPile.isNotEmpty
             ? gameState.discardPile.last.compactName
             : null,
@@ -995,7 +996,10 @@ class GameAnalyticsLogger {
     return 'session_$timestamp$random';
   }
 
-  static int _countDangerousOpponents(GameState gameState, String botId) {
+  static int _countDangerousOpponents(
+    BotDecisionAnalyticsSnapshot gameState,
+    String botId,
+  ) {
     return gameState.players
         .where(
           (p) =>

--- a/test/ai/bot_turn_manager_execution_test.dart
+++ b/test/ai/bot_turn_manager_execution_test.dart
@@ -9,6 +9,7 @@ import 'package:hand_foot_game_flutter/models/game_state.dart';
 import 'package:hand_foot_game_flutter/models/meld.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 import 'package:hand_foot_game_flutter/screens/managers/bot_turn_manager.dart';
+import 'package:hand_foot_game_flutter/services/analytics/bot_decision_analytics_snapshot.dart';
 
 final _immediateRoundEndSettings = SoloGameSettings(
   botCount: 1,
@@ -49,7 +50,7 @@ void main() {
               required String decision,
               required String reasoning,
               Map<String, dynamic>? context,
-              GameState? gameStateSnapshot,
+              BotDecisionAnalyticsSnapshot? gameStateSnapshot,
             }) {},
       );
     });
@@ -161,7 +162,7 @@ void main() {
               required String decision,
               required String reasoning,
               Map<String, dynamic>? context,
-              GameState? gameStateSnapshot,
+              BotDecisionAnalyticsSnapshot? gameStateSnapshot,
             }) {},
       );
 

--- a/test/ai/bot_turn_manager_execution_test.dart
+++ b/test/ai/bot_turn_manager_execution_test.dart
@@ -49,6 +49,7 @@ void main() {
               required String decision,
               required String reasoning,
               Map<String, dynamic>? context,
+              GameState? gameStateSnapshot,
             }) {},
       );
     });
@@ -160,6 +161,7 @@ void main() {
               required String decision,
               required String reasoning,
               Map<String, dynamic>? context,
+              GameState? gameStateSnapshot,
             }) {},
       );
 

--- a/test/ai/hand_pile_foot_completion_test.dart
+++ b/test/ai/hand_pile_foot_completion_test.dart
@@ -1,0 +1,187 @@
+@Tags(['hand_pile_foot_completion'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_game_context.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('Hand pile foot completion', () {
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player human;
+    late Player bot;
+
+    setUp(() {
+      botAI = EnhancedBotAI(seed: 398170);
+      human = Player(id: 'human', name: 'You', type: PlayerType.human);
+      bot = Player(id: 'bot', name: 'Bot', type: PlayerType.bot);
+      gameController = GameController(players: [human, bot], seed: 398170);
+      gameController.initializeGame();
+      botAI.assignPersonality(bot.id, BotPersonality.conservative);
+      bot.hasPlayedDown = true;
+      bot.hasPickedUpFoot = false;
+      gameController.gameState.currentPlayerIndex = 1;
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+    });
+
+    BotGameContext context() =>
+        BotGameContext(gameController.gameState, gameController);
+
+    test('shouldCompleteHandPileForFoot at 5 cards but not 6', () {
+      bot.hand
+        ..clear()
+        ..addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.six),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.seven),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+        ]);
+
+      expect(botAI.shouldCompleteHandPileForFoot(bot, context()), isTrue);
+
+      bot.hand.add(const PlayingCard(suit: Suit.spades, rank: CardRank.nine));
+      expect(botAI.shouldCompleteHandPileForFoot(bot, context()), isFalse);
+    });
+
+    test('uses createMultipleMelds to clear 3-card hand (1-card trap)', () {
+      bot.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        ])!,
+      );
+      bot.hand
+        ..clear()
+        ..addAll([
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.four),
+        ]);
+
+      final decision = botAI.makeCompleteHandPileForFootDecision(
+        bot,
+        context(),
+      );
+
+      expect(decision, isNotNull);
+      expect(
+        decision!.action,
+        isIn(['createMultipleMelds', 'addToMeld', 'createMeld']),
+      );
+    });
+
+    test(
+      'conservative bot does not hold at 8 cards with melds but zero books',
+      () {
+        bot.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.nine),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+          ])!,
+        );
+        bot.hand
+          ..clear()
+          ..addAll(
+            List<PlayingCard>.generate(
+              8,
+              (i) => PlayingCard(
+                suit: Suit.values[i % 4],
+                rank: CardRank.values[(i % 10) + 2],
+              ),
+            ),
+          );
+
+        final decision = botAI.makeDecision(bot, gameController);
+
+        expect(decision.action, isNot('noMeld'));
+      },
+    );
+  });
+
+  group('Final turn scoring', () {
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player human;
+    late Player bot;
+
+    setUp(() {
+      botAI = EnhancedBotAI(seed: 12345);
+      human = Player(id: 'human', name: 'You', type: PlayerType.human);
+      bot = Player(id: 'bot', name: 'Bot', type: PlayerType.bot);
+      gameController = GameController(
+        players: [human, bot],
+        seed: 12345,
+        soloSettings: SoloGameSettings.defaults,
+      );
+      gameController.initializeGame();
+      bot.hasPlayedDown = true;
+      bot.hasPickedUpFoot = true;
+      gameController.gameState.currentPlayerIndex = 1;
+      gameController.gameState.turnPhase = TurnPhase.meld;
+      gameController.gameState.hasDrawnFromDeck = true;
+      gameController.gameState.finalTurnPhaseActive = true;
+      gameController.gameState.playersAwaitingFinalTurn.add(1);
+      gameController.gameState.playerWhoWentOutIndex = 0;
+    });
+
+    BotGameContext context() =>
+        BotGameContext(gameController.gameState, gameController);
+
+    test('final turn melds addToMeld instead of holding', () {
+      bot.melds.add(
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+      );
+      bot.hand
+        ..clear()
+        ..addAll([
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+        ]);
+
+      final decision = botAI.makeFinalTurnScoringDecision(bot, context());
+
+      expect(decision.action, isIn(['addToMeld', 'createMeld']));
+    });
+
+    test(
+      'makeDecision routes to final turn scoring when awaiting final turn',
+      () {
+        bot.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.jack),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+          ])!,
+        );
+        bot.hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.jack),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.three),
+          ]);
+
+        final decision = botAI.makeDecision(bot, gameController);
+
+        expect(decision.action, isIn(['addToMeld', 'createMeld', 'noMeld']));
+        expect(decision.action, isNot('drawFromDeck'));
+      },
+    );
+  });
+}

--- a/test/ai/hand_pile_foot_completion_test.dart
+++ b/test/ai/hand_pile_foot_completion_test.dart
@@ -53,33 +53,31 @@ void main() {
       expect(botAI.shouldCompleteHandPileForFoot(bot, context()), isFalse);
     });
 
-    test('uses createMultipleMelds to clear 3-card hand (1-card trap)', () {
-      bot.melds.add(
-        Meld.createMeld([
-          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
-          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
-          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
-        ])!,
-      );
-      bot.hand
-        ..clear()
-        ..addAll([
-          const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
-          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
-          const PlayingCard(suit: Suit.spades, rank: CardRank.four),
-        ]);
+    test(
+      'uses createMultipleMelds to clear hand with two melds plus discard',
+      () {
+        human.hasPickedUpFoot = true;
+        bot.hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.four),
+          ]);
 
-      final decision = botAI.makeCompleteHandPileForFootDecision(
-        bot,
-        context(),
-      );
+        final decision = botAI.makeCompleteHandPileForFootDecision(
+          bot,
+          context(),
+        );
 
-      expect(decision, isNotNull);
-      expect(
-        decision!.action,
-        isIn(['createMultipleMelds', 'addToMeld', 'createMeld']),
-      );
-    });
+        expect(decision, isNotNull);
+        expect(decision!.action, 'createMultipleMelds');
+      },
+    );
 
     test(
       'conservative bot does not hold at 8 cards with melds but zero books',
@@ -183,5 +181,37 @@ void main() {
         expect(decision.action, isNot('drawFromDeck'));
       },
     );
+
+    test('final turn draw phase draws from deck', () {
+      gameController.gameState.turnPhase = TurnPhase.draw;
+      gameController.gameState.hasDrawnFromDeck = false;
+      bot.hand
+        ..clear()
+        ..add(const PlayingCard(suit: Suit.hearts, rank: CardRank.five));
+
+      final decision = botAI.makeFinalTurnScoringDecision(bot, context());
+      expect(decision.action, 'drawFromDeck');
+
+      final routeDecision = botAI.makeDecision(bot, gameController);
+      expect(routeDecision.action, 'drawFromDeck');
+    });
+
+    test('final turn discard phase discards without drawing', () {
+      gameController.gameState.turnPhase = TurnPhase.discard;
+      gameController.gameState.hasDrawnFromDeck = true;
+      bot.hand
+        ..clear()
+        ..addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.six),
+        ]);
+
+      final decision = botAI.makeFinalTurnScoringDecision(bot, context());
+      expect(decision.action, 'discard');
+
+      final routeDecision = botAI.makeDecision(bot, gameController);
+      expect(routeDecision.action, 'discard');
+      expect(routeDecision.action, isNot('drawFromDeck'));
+    });
   });
 }

--- a/test/ai/human_play_pattern_ai_test.dart
+++ b/test/ai/human_play_pattern_ai_test.dart
@@ -58,6 +58,10 @@ void main() {
             const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
             const PlayingCard(suit: Suit.spades, rank: CardRank.king),
             const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
           ])!,
         );
 
@@ -106,6 +110,10 @@ void main() {
             const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
             const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
             const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
           ])!,
         );
 
@@ -154,6 +162,10 @@ void main() {
           const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
           const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
           const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
         ])!,
       );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses follow-up PR review: analytics snapshot logic removed from the `GameState` model.

### Changes

- **Removed** `GameState.snapshotForAnalytics()` — model stays a pure game-entity class.
- **Added** `lib/services/analytics/bot_decision_analytics_snapshot.dart` — immutable DTOs (`BotDecisionAnalyticsSnapshot`, `AnalyticsPlayerSnapshot`, `AnalyticsMeldSnapshot`) with unmodifiable collections.
- **Added** `lib/services/analytics/bot_decision_snapshot_mapper.dart` — `BotDecisionSnapshotMapper.fromGameState()` deep-copies all previously snapshotted fields, including `newlyDrawnCardIndices` and `roundScoreHistory` on each player.
- **Updated** `bot_turn_manager`, `game_screen`, and `GameAnalyticsLogger.logBotDecision` to use the DTO/mapper pipeline (pre-execution snapshot timing preserved).

### Validation

- `flutter analyze` — clean
- `flutter test` — full suite passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5908-c8a4-76b4-995b-d16bfcde5bc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5908-c8a4-76b4-995b-d16bfcde5bc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced bot logic for hand-pile → foot completion, including a new qualification limit and stronger multi-meld plays.
  - Improved end-of-round behavior: when awaiting the final turn after another player goes out, bots now make dedicated final-turn scoring decisions.
- **Bug Fixes**
  - Reduced overly cautious hand holding for bots with small, non-progressed hands.
  - Improved bot decision analytics to log more accurate, snapshot-based turn and game-state context.
- **Tests**
  - Added coverage for hand-pile foot completion and final-turn scoring decision routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->