### PR TITLE
Fix hand-pile foot transition AI (session 139404 regressions)

### DIFF
--- a/lib/ai/bot_config.dart
+++ b/lib/ai/bot_config.dart
@@ -270,7 +270,7 @@ class BotConfig {
   static const int humanLowRankDiscardBonus = 25;
 
   /// Bump when bot AI logic changes — stored on analytics docs for cross-version analysis.
-  static const String botAiVersion = '2026.07-hand-pile-foot-completion';
+  static const String botAiVersion = '2026.07-hand-pile-foot-rush';
 
   // Prevent instantiation
   BotConfig._();

--- a/lib/ai/bot_foot_transition_manager.dart
+++ b/lib/ai/bot_foot_transition_manager.dart
@@ -264,7 +264,10 @@ class BotFootTransitionManager {
         return BotDecision(action: 'error');
       }
       final cardToDiscard = _chooseCardToDiscard(bot);
-      return BotDecision(action: 'discard', data: cardToDiscard);
+      return _phaseAwareTransitionDecision(
+        controller,
+        BotDecision(action: 'discard', data: cardToDiscard),
+      );
     }
 
     // Priority 1: Use wild cards aggressively when transitioning to foot
@@ -321,7 +324,10 @@ class BotFootTransitionManager {
         return BotDecision(action: 'error');
       }
       final cardToDiscard = _chooseCardToDiscard(bot);
-      return BotDecision(action: 'discard', data: cardToDiscard);
+      return _phaseAwareTransitionDecision(
+        controller,
+        BotDecision(action: 'discard', data: cardToDiscard),
+      );
     }
 
     // Add multiple cards to existing melds if possible (analyzer already sorted)

--- a/lib/ai/bot_foot_transition_manager.dart
+++ b/lib/ai/bot_foot_transition_manager.dart
@@ -1,5 +1,6 @@
 import '../models/player.dart';
 import '../models/card.dart';
+import '../models/game_state.dart';
 import '../game/game_controller.dart';
 import '../config/game_config.dart';
 import 'bot_decision.dart';
@@ -19,6 +20,18 @@ class BotFootTransitionManager {
 
   BotFootTransitionManager({BotMeldAnalyzer? meldAnalyzer})
     : _meldAnalyzer = meldAnalyzer ?? BotMeldAnalyzer();
+
+  /// Meld phase cannot discard — defer to discard phase via [noMeld].
+  BotDecision _phaseAwareTransitionDecision(
+    GameController controller,
+    BotDecision decision,
+  ) {
+    if (controller.gameState.turnPhase == TurnPhase.meld &&
+        decision.action == 'discard') {
+      return BotDecision(action: 'noMeld');
+    }
+    return decision;
+  }
 
   /// Main entry point for foot transition decisions.
   ///
@@ -116,7 +129,10 @@ class BotFootTransitionManager {
       return BotDecision(action: 'error');
     }
     final cardToDiscard = _chooseCardToDiscard(bot);
-    return BotDecision(action: 'discard', data: cardToDiscard);
+    return _phaseAwareTransitionDecision(
+      controller,
+      BotDecision(action: 'discard', data: cardToDiscard),
+    );
   }
 
   /// Check if bot should make an aggressive transition
@@ -218,7 +234,7 @@ class BotFootTransitionManager {
     return hasBooks &&
         hasMultipleMelds &&
         bot.hasPlayedDown &&
-        remainingCards >= 5;
+        remainingCards >= 3;
   }
 
   /// Check if bot should transition when most cards can be played
@@ -285,7 +301,10 @@ class BotFootTransitionManager {
       return BotDecision(action: 'error');
     }
     final cardToDiscard = _chooseCardToDiscard(bot);
-    return BotDecision(action: 'discard', data: cardToDiscard);
+    return _phaseAwareTransitionDecision(
+      controller,
+      BotDecision(action: 'discard', data: cardToDiscard),
+    );
   }
 
   /// Try transition due to hand size pressure
@@ -333,7 +352,10 @@ class BotFootTransitionManager {
       return BotDecision(action: 'error');
     }
     final cardToDiscard = _chooseCardToDiscard(bot);
-    return BotDecision(action: 'discard', data: cardToDiscard);
+    return _phaseAwareTransitionDecision(
+      controller,
+      BotDecision(action: 'discard', data: cardToDiscard),
+    );
   }
 
   /// Try transition in later rounds where foot access is more valuable
@@ -366,7 +388,10 @@ class BotFootTransitionManager {
       return BotDecision(action: 'error');
     }
     final cardToDiscard = _chooseCardToDiscard(bot);
-    return BotDecision(action: 'discard', data: cardToDiscard);
+    return _phaseAwareTransitionDecision(
+      controller,
+      BotDecision(action: 'discard', data: cardToDiscard),
+    );
   }
 
   /// Try transition after playing down
@@ -396,7 +421,10 @@ class BotFootTransitionManager {
       return BotDecision(action: 'error');
     }
     final cardToDiscard = _chooseCardToDiscard(bot);
-    return BotDecision(action: 'discard', data: cardToDiscard);
+    return _phaseAwareTransitionDecision(
+      controller,
+      BotDecision(action: 'discard', data: cardToDiscard),
+    );
   }
 
   /// Try transition based on hand quality assessment
@@ -422,7 +450,10 @@ class BotFootTransitionManager {
       return BotDecision(action: 'error');
     }
     final cardToDiscard = _chooseCardToDiscard(bot);
-    return BotDecision(action: 'discard', data: cardToDiscard);
+    return _phaseAwareTransitionDecision(
+      controller,
+      BotDecision(action: 'discard', data: cardToDiscard),
+    );
   }
 
   /// Try transition when most cards can be played
@@ -451,7 +482,10 @@ class BotFootTransitionManager {
       return BotDecision(action: 'error');
     }
     final cardToDiscard = _chooseCardToDiscard(bot);
-    return BotDecision(action: 'discard', data: cardToDiscard);
+    return _phaseAwareTransitionDecision(
+      controller,
+      BotDecision(action: 'discard', data: cardToDiscard),
+    );
   }
 
   /// Determine if bot should transition based on hand quality

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -784,7 +784,13 @@ class EnhancedBotAI {
     }
 
     // RULE ENFORCEMENT: Bot must discard a card to follow Hand & Foot rules
-    final cardToDiscard = _chooseCardToDiscard(bot, context.gameState);
+    PlayingCard? cardToDiscard;
+    if (bot.hasPlayedDown &&
+        !bot.hasPickedUpFoot &&
+        bot.currentHand.length <= BotConfig.handPileFootCompletionMaxHand) {
+      cardToDiscard = _chooseHandPileTransitionDiscard(bot);
+    }
+    cardToDiscard ??= _chooseCardToDiscard(bot, context.gameState);
     if (cardToDiscard == null) {
       return BotDecision(action: 'error');
     }
@@ -1839,6 +1845,10 @@ class EnhancedBotAI {
       return false;
     }
 
+    if (_shouldCompleteHandPileForFoot(bot, context)) {
+      return false;
+    }
+
     // On foot without both book types — keep melding, never hoard toward go-out
     if (bot.hasPickedUpFoot && !bot.canGoOutWithBooks) {
       return false;
@@ -2534,7 +2544,7 @@ class EnhancedBotAI {
       return footTransition;
     }
 
-    return BotDecision(action: 'noMeld');
+    return null;
   }
 
   /// On final turn after another player went out: meld all scorable cards.
@@ -2889,19 +2899,44 @@ class EnhancedBotAI {
         .findMaximalMeldCombination(bot, controller)
         .where((meld) => meld.length >= GameConfig.minTotalCardsForMeld)
         .toList();
+    final minCardsToClear = _opponentOnFootPressure(context, bot)
+        ? handSize - 2
+        : handSize - 1;
+    if (minCardsToClear < 1) {
+      return null;
+    }
+
     if (maximalMelds.length >= 2) {
       final cardsMeldable = maximalMelds.fold<int>(
         0,
         (sum, meld) => sum + meld.length,
       );
-      if (cardsMeldable >= handSize - 1) {
+      if (cardsMeldable >= minCardsToClear) {
         return BotDecision(action: 'createMultipleMelds', data: maximalMelds);
       }
     } else if (maximalMelds.length == 1 &&
-        maximalMelds.first.length >= handSize - 1) {
+        maximalMelds.first.length >= minCardsToClear) {
       return BotDecision(action: 'createMeld', data: maximalMelds.first);
     }
     return null;
+  }
+
+  /// Discard choice when clearing a small hand pile toward foot pickup.
+  PlayingCard? _chooseHandPileTransitionDiscard(Player bot) {
+    final hand = bot.currentHand;
+    if (hand.isEmpty) {
+      return null;
+    }
+
+    final threes = hand.where((card) => card.rank == CardRank.three).toList();
+    if (threes.isNotEmpty) {
+      threes.sort((a, b) => a.pointValue.compareTo(b.pointValue));
+      return threes.first;
+    }
+
+    final sortedHand = List<PlayingCard>.from(hand);
+    sortedHand.sort((a, b) => a.pointValue.compareTo(b.pointValue));
+    return sortedHand.first;
   }
 
   /// Enhanced book completion strategy for competitive play
@@ -2910,6 +2945,10 @@ class EnhancedBotAI {
     GameState gameState,
     BotPersonality personality,
   ) {
+    if (bot.hasPlayedDown && !bot.hasPickedUpFoot) {
+      return false;
+    }
+
     // Start considering book completion earlier (round 2+) for competitiveness
     if (gameState.round < 2) return false;
 

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -1045,7 +1045,8 @@ class BotTurnManager {
           if (!bot.hasPlayedDown) {
             return '$personality bot waiting for better play-down opportunity ($handSize cards)';
           } else if (!bot.hasPickedUpFoot &&
-              handSize <= ai_bot_config.BotConfig.handPileFootCompletionMaxHand) {
+              handSize <=
+                  ai_bot_config.BotConfig.handPileFootCompletionMaxHand) {
             return '$personality bot completing hand pile for foot (no meld available, $handSize cards)';
           } else {
             return '$personality bot holding cards strategically ($handSize cards, $hasBooks books)';

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -1043,6 +1043,9 @@ class BotTurnManager {
         case 'noMeld':
           if (!bot.hasPlayedDown) {
             return '$personality bot waiting for better play-down opportunity ($handSize cards)';
+          } else if (!bot.hasPickedUpFoot &&
+              handSize <= BotConfig.handPileFootCompletionMaxHand) {
+            return '$personality bot completing hand pile for foot (no meld available, $handSize cards)';
           } else {
             return '$personality bot holding cards strategically ($handSize cards, $hasBooks books)';
           }

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -7,6 +7,7 @@ import '../../game/game_controller.dart';
 import '../../ai/enhanced_bot_ai.dart';
 import '../../ai/bot_decision.dart';
 import '../../ai/bot_personality.dart';
+import '../../ai/bot_config.dart' as ai_bot_config;
 import '../../config/bot_configurations.dart';
 import '../../utils/debug_logger.dart';
 import '../../config/game_config.dart';
@@ -1044,7 +1045,7 @@ class BotTurnManager {
           if (!bot.hasPlayedDown) {
             return '$personality bot waiting for better play-down opportunity ($handSize cards)';
           } else if (!bot.hasPickedUpFoot &&
-              handSize <= BotConfig.handPileFootCompletionMaxHand) {
+              handSize <= ai_bot_config.BotConfig.handPileFootCompletionMaxHand) {
             return '$personality bot completing hand pile for foot (no meld available, $handSize cards)';
           } else {
             return '$personality bot holding cards strategically ($handSize cards, $hasBooks books)';

--- a/test/ai/aggressive_hand_to_foot_rush_test.dart
+++ b/test/ai/aggressive_hand_to_foot_rush_test.dart
@@ -206,8 +206,7 @@ void main() {
 
         final rushDecision = botAI.makeHandToFootRushDecision(bot, context());
         expect(rushDecision, isNotNull);
-        expect(rushDecision!.action, equals('discard'));
-        expect(rushDecision.data, isA<PlayingCard>());
+        expect(rushDecision!.action, equals('noMeld'));
 
         configureBot(
           personality: BotPersonality.conservative,
@@ -228,7 +227,7 @@ void main() {
           context(),
         );
         expect(rushAtThreshold, isNotNull);
-        expect(rushAtThreshold!.action, equals('discard'));
+        expect(rushAtThreshold!.action, equals('noMeld'));
 
         configureBot(
           personality: BotPersonality.conservative,
@@ -249,7 +248,7 @@ void main() {
           context(),
         );
         expect(rushAtThreshold, isNotNull);
-        expect(rushAtThreshold!.action, equals('discard'));
+        expect(rushAtThreshold!.action, equals('noMeld'));
 
         configureBot(
           personality: BotPersonality.aggressive,
@@ -274,7 +273,7 @@ void main() {
           context(),
         );
         expect(rushAtThreshold, isNotNull);
-        expect(rushAtThreshold!.action, equals('discard'));
+        expect(rushAtThreshold!.action, equals('noMeld'));
 
         configureBot(
           personality: BotPersonality.aggressive,
@@ -295,8 +294,12 @@ void main() {
 
         expect(botAI.makeHandToFootRushDecision(bot, context()), isNotNull);
         final belowThresholdDecision = botAI.makeDecision(bot, gameController);
-        expect(belowThresholdDecision.action, equals('discard'));
-        expect(belowThresholdDecision.data, isA<PlayingCard>());
+        expect(belowThresholdDecision.action, equals('noMeld'));
+
+        gameController.gameState.turnPhase = TurnPhase.discard;
+        final discardDecision = botAI.makeDecision(bot, gameController);
+        expect(discardDecision.action, equals('discard'));
+        expect(discardDecision.data, isA<PlayingCard>());
 
         configureBot(
           personality: BotPersonality.conservative,
@@ -310,10 +313,13 @@ void main() {
           isNull,
           reason: 'rush hook must be inactive above opponent threshold',
         );
+        expect(aboveThresholdDecision.action, equals('noMeld'));
+
+        gameController.gameState.turnPhase = TurnPhase.discard;
         expect(
-          aboveThresholdDecision.action,
-          isNot('noMeld'),
-          reason: 'foot transition may still act above rush threshold',
+          botAI.makeDecision(bot, gameController).action,
+          equals('discard'),
+          reason: 'foot transition still discards above rush threshold',
         );
       });
 
@@ -330,7 +336,13 @@ void main() {
             bot,
             gameController,
           );
-          expect(belowThresholdDecision.action, equals('discard'));
+          expect(belowThresholdDecision.action, equals('noMeld'));
+
+          gameController.gameState.turnPhase = TurnPhase.discard;
+          expect(
+            botAI.makeDecision(bot, gameController).action,
+            equals('discard'),
+          );
 
           configureBot(
             personality: BotPersonality.aggressive,
@@ -342,11 +354,14 @@ void main() {
             bot,
             gameController,
           );
+          expect(aboveThresholdDecision.action, equals('noMeld'));
+
+          gameController.gameState.turnPhase = TurnPhase.discard;
           expect(
-            aboveThresholdDecision.action,
-            isNot('noMeld'),
+            botAI.makeDecision(bot, gameController).action,
+            equals('discard'),
             reason:
-                'foot transition may still discard above aggressive rush threshold',
+                'foot transition still discards above aggressive rush threshold',
           );
         },
       );
@@ -364,7 +379,13 @@ void main() {
             bot,
             gameController,
           );
-          expect(belowThresholdDecision.action, equals('discard'));
+          expect(belowThresholdDecision.action, equals('noMeld'));
+
+          gameController.gameState.turnPhase = TurnPhase.discard;
+          expect(
+            botAI.makeDecision(bot, gameController).action,
+            equals('discard'),
+          );
 
           configureBot(
             personality: BotPersonality.conservative,
@@ -376,11 +397,14 @@ void main() {
             bot,
             gameController,
           );
+          expect(aboveThresholdDecision.action, equals('noMeld'));
+
+          gameController.gameState.turnPhase = TurnPhase.discard;
           expect(
-            aboveThresholdDecision.action,
-            isNot('noMeld'),
+            botAI.makeDecision(bot, gameController).action,
+            equals('discard'),
             reason:
-                'foot transition may still discard above critical rush threshold',
+                'foot transition still discards above critical rush threshold',
           );
         },
       );

--- a/test/ai/aggressive_hand_to_foot_rush_test.dart
+++ b/test/ai/aggressive_hand_to_foot_rush_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_foot_game_flutter/ai/bot_config.dart';
+import 'package:hand_foot_game_flutter/ai/bot_decision.dart';
 import 'package:hand_foot_game_flutter/ai/bot_game_context.dart';
 import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
 import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
@@ -77,6 +78,21 @@ void main() {
 
     BotGameContext context() =>
         BotGameContext(gameController.gameState, gameController);
+
+    void expectMeldPhaseDefersThenDiscards({
+      required BotDecision meldPhaseDecision,
+      String? discardReason,
+      bool expectPlayingCardData = false,
+    }) {
+      expect(meldPhaseDecision.action, equals('noMeld'));
+
+      gameController.gameState.turnPhase = TurnPhase.discard;
+      final discardDecision = botAI.makeDecision(bot, gameController);
+      expect(discardDecision.action, equals('discard'), reason: discardReason);
+      if (expectPlayingCardData) {
+        expect(discardDecision.data, isA<PlayingCard>());
+      }
+    }
 
     setUp(() {
       botAI = EnhancedBotAI(seed: 577904);
@@ -198,46 +214,52 @@ void main() {
     });
 
     group('makeHandToFootRushDecision', () {
-      test('returns discard rush action below threshold, null above', () {
-        configureBot(
-          personality: BotPersonality.conservative,
-          handSize: BotConfig.handToFootCriticalHandSize,
-        );
+      test(
+        'returns meld-phase noMeld rush action below threshold, null above',
+        () {
+          configureBot(
+            personality: BotPersonality.conservative,
+            handSize: BotConfig.handToFootCriticalHandSize,
+          );
 
-        final rushDecision = botAI.makeHandToFootRushDecision(bot, context());
-        expect(rushDecision, isNotNull);
-        expect(rushDecision!.action, equals('noMeld'));
+          final rushDecision = botAI.makeHandToFootRushDecision(bot, context());
+          expect(rushDecision, isNotNull);
+          expect(rushDecision!.action, equals('noMeld'));
 
-        configureBot(
-          personality: BotPersonality.conservative,
-          handSize: BotConfig.handToFootCriticalHandSize + 1,
-        );
-        expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
-      });
+          configureBot(
+            personality: BotPersonality.conservative,
+            handSize: BotConfig.handToFootCriticalHandSize + 1,
+          );
+          expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+        },
+      );
 
-      test('opponent pressure boundary returns rush discard at 8 only', () {
-        configureBot(
-          personality: BotPersonality.conservative,
-          handSize: BotConfig.handToFootRushOpponentOnFootThreshold,
-          opponentOnFoot: true,
-        );
+      test(
+        'opponent pressure boundary returns meld-phase noMeld at 8 only',
+        () {
+          configureBot(
+            personality: BotPersonality.conservative,
+            handSize: BotConfig.handToFootRushOpponentOnFootThreshold,
+            opponentOnFoot: true,
+          );
 
-        final rushAtThreshold = botAI.makeHandToFootRushDecision(
-          bot,
-          context(),
-        );
-        expect(rushAtThreshold, isNotNull);
-        expect(rushAtThreshold!.action, equals('noMeld'));
+          final rushAtThreshold = botAI.makeHandToFootRushDecision(
+            bot,
+            context(),
+          );
+          expect(rushAtThreshold, isNotNull);
+          expect(rushAtThreshold!.action, equals('noMeld'));
 
-        configureBot(
-          personality: BotPersonality.conservative,
-          handSize: BotConfig.handToFootRushOpponentOnFootThreshold + 1,
-          opponentOnFoot: true,
-        );
-        expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
-      });
+          configureBot(
+            personality: BotPersonality.conservative,
+            handSize: BotConfig.handToFootRushOpponentOnFootThreshold + 1,
+            opponentOnFoot: true,
+          );
+          expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+        },
+      );
 
-      test('aggressive boundary returns rush discard at 6 only', () {
+      test('aggressive boundary returns meld-phase noMeld at 6 only', () {
         configureBot(
           personality: BotPersonality.aggressive,
           handSize: BotConfig.handToFootRushAggressiveThreshold,
@@ -257,31 +279,34 @@ void main() {
         expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
       });
 
-      test('aggressive opponent margin returns rush discard at 10 only', () {
-        final rushAtMargin =
-            BotConfig.handToFootRushOpponentOnFootThreshold +
-            BotConfig.handToFootRushAggressiveOpponentPressureMargin;
+      test(
+        'aggressive opponent margin returns meld-phase noMeld at 10 only',
+        () {
+          final rushAtMargin =
+              BotConfig.handToFootRushOpponentOnFootThreshold +
+              BotConfig.handToFootRushAggressiveOpponentPressureMargin;
 
-        configureBot(
-          personality: BotPersonality.aggressive,
-          handSize: rushAtMargin,
-          opponentOnFoot: true,
-        );
+          configureBot(
+            personality: BotPersonality.aggressive,
+            handSize: rushAtMargin,
+            opponentOnFoot: true,
+          );
 
-        final rushAtThreshold = botAI.makeHandToFootRushDecision(
-          bot,
-          context(),
-        );
-        expect(rushAtThreshold, isNotNull);
-        expect(rushAtThreshold!.action, equals('noMeld'));
+          final rushAtThreshold = botAI.makeHandToFootRushDecision(
+            bot,
+            context(),
+          );
+          expect(rushAtThreshold, isNotNull);
+          expect(rushAtThreshold!.action, equals('noMeld'));
 
-        configureBot(
-          personality: BotPersonality.aggressive,
-          handSize: rushAtMargin + 1,
-          opponentOnFoot: true,
-        );
-        expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
-      });
+          configureBot(
+            personality: BotPersonality.aggressive,
+            handSize: rushAtMargin + 1,
+            opponentOnFoot: true,
+          );
+          expect(botAI.makeHandToFootRushDecision(bot, context()), isNull);
+        },
+      );
     });
 
     group('makeDecision integration', () {
@@ -293,13 +318,10 @@ void main() {
         );
 
         expect(botAI.makeHandToFootRushDecision(bot, context()), isNotNull);
-        final belowThresholdDecision = botAI.makeDecision(bot, gameController);
-        expect(belowThresholdDecision.action, equals('noMeld'));
-
-        gameController.gameState.turnPhase = TurnPhase.discard;
-        final discardDecision = botAI.makeDecision(bot, gameController);
-        expect(discardDecision.action, equals('discard'));
-        expect(discardDecision.data, isA<PlayingCard>());
+        expectMeldPhaseDefersThenDiscards(
+          meldPhaseDecision: botAI.makeDecision(bot, gameController),
+          expectPlayingCardData: true,
+        );
 
         configureBot(
           personality: BotPersonality.conservative,
@@ -332,16 +354,8 @@ void main() {
           );
 
           expect(botAI.makeHandToFootRushDecision(bot, context()), isNotNull);
-          final belowThresholdDecision = botAI.makeDecision(
-            bot,
-            gameController,
-          );
-          expect(belowThresholdDecision.action, equals('noMeld'));
-
-          gameController.gameState.turnPhase = TurnPhase.discard;
-          expect(
-            botAI.makeDecision(bot, gameController).action,
-            equals('discard'),
+          expectMeldPhaseDefersThenDiscards(
+            meldPhaseDecision: botAI.makeDecision(bot, gameController),
           );
 
           configureBot(
@@ -375,16 +389,8 @@ void main() {
           );
 
           expect(botAI.makeHandToFootRushDecision(bot, context()), isNotNull);
-          final belowThresholdDecision = botAI.makeDecision(
-            bot,
-            gameController,
-          );
-          expect(belowThresholdDecision.action, equals('noMeld'));
-
-          gameController.gameState.turnPhase = TurnPhase.discard;
-          expect(
-            botAI.makeDecision(bot, gameController).action,
-            equals('discard'),
+          expectMeldPhaseDefersThenDiscards(
+            meldPhaseDecision: botAI.makeDecision(bot, gameController),
           );
 
           configureBot(

--- a/test/ai/bot_foot_transition_test.dart
+++ b/test/ai/bot_foot_transition_test.dart
@@ -152,10 +152,7 @@ void main() {
           gameController,
         );
         expect(decision, isNotNull);
-        expect(
-          decision!.action,
-          anyOf(['endTurn', 'discard']),
-        ); // May choose to discard instead
+        expect(decision!.action, 'noMeld');
       });
     });
   });

--- a/test/ai/bot_go_out_test.dart
+++ b/test/ai/bot_go_out_test.dart
@@ -140,9 +140,13 @@ void main() {
       // Make decision
       final decision = botAI.makeDecision(botPlayer, gameController);
 
-      // Should return discard decision (since no melds possible with 3s)
-      expect(decision.action, equals('discard'));
-      expect(decision.data, isA<PlayingCard>());
+      // Meld phase defers discard; discard phase executes it
+      expect(decision.action, equals('noMeld'));
+
+      gameController.gameState.turnPhase = TurnPhase.discard;
+      final discardDecision = botAI.makeDecision(botPlayer, gameController);
+      expect(discardDecision.action, equals('discard'));
+      expect(discardDecision.data, isA<PlayingCard>());
     });
   });
 }

--- a/test/ai/hand_pile_foot_completion_test.dart
+++ b/test/ai/hand_pile_foot_completion_test.dart
@@ -108,7 +108,7 @@ void main() {
     );
 
     test(
-      'makeCompleteHandPileForFootDecision returns null when no melds exist',
+      'makeCompleteHandPileForFootDecision defers discard when no melds in meld phase',
       () {
         bot.hand
           ..clear()
@@ -130,7 +130,11 @@ void main() {
           context(),
         );
 
-        expect(decision, isNull);
+        expect(decision?.action, 'noMeld');
+
+        gameController.gameState.turnPhase = TurnPhase.discard;
+        final discardDecision = botAI.makeDecision(bot, gameController);
+        expect(discardDecision.action, 'discard');
       },
     );
 

--- a/test/ai/hand_pile_foot_completion_test.dart
+++ b/test/ai/hand_pile_foot_completion_test.dart
@@ -80,6 +80,61 @@ void main() {
     );
 
     test(
+      'does not strategically hold during hand-pile foot completion window',
+      () {
+        human.hasPickedUpFoot = true;
+        bot.hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.four),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.five),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.six),
+          ]);
+        bot.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+          ])!,
+        );
+
+        expect(botAI.shouldCompleteHandPileForFoot(bot, context()), isTrue);
+
+        final decision = botAI.makeDecision(bot, gameController);
+
+        expect(decision.action, isNot('noMeld'));
+      },
+    );
+
+    test(
+      'makeCompleteHandPileForFootDecision returns null when no melds exist',
+      () {
+        bot.hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.six),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+          ]);
+        bot.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          ])!,
+        );
+
+        final decision = botAI.makeCompleteHandPileForFootDecision(
+          bot,
+          context(),
+        );
+
+        expect(decision, isNull);
+      },
+    );
+
+    test(
       'conservative bot does not hold at 8 cards with melds but zero books',
       () {
         bot.melds.add(

--- a/test/regression/firestore_session_17839500130143014_test.dart
+++ b/test/regression/firestore_session_17839500130143014_test.dart
@@ -48,10 +48,9 @@ void main() {
 
     test('bots still draw from deck at start of turn on small hand pile', () {
       for (final bot in [alex, carl]) {
-        bot
-          ..hasPlayedDown = true
-          ..hasPickedUpFoot = false
-          ..hand
+        bot.hasPlayedDown = true;
+        bot.hasPickedUpFoot = false;
+        bot.hand
           ..clear()
           ..addAll([
             const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
@@ -75,10 +74,9 @@ void main() {
       'Carl conservative melds at hand=3 with 1 book while opponent on foot',
       () {
         human.hasPickedUpFoot = true;
-        carl
-          ..hasPlayedDown = true
-          ..hasPickedUpFoot = false
-          ..melds
+        carl.hasPlayedDown = true;
+        carl.hasPickedUpFoot = false;
+        carl.melds
           ..clear()
           ..addAll([
             Meld.createMeld([
@@ -119,12 +117,11 @@ void main() {
     );
 
     test(
-      'hand pile completion returns null instead of blocking noMeld when stuck',
+      'hand pile completion defers discard in meld phase when no melds available',
       () {
-        carl
-          ..hasPlayedDown = true
-          ..hasPickedUpFoot = false
-          ..melds
+        carl.hasPlayedDown = true;
+        carl.hasPickedUpFoot = false;
+        carl.melds
           ..clear()
           ..add(
             Meld.createMeld([
@@ -146,12 +143,15 @@ void main() {
 
         expect(botAI.shouldCompleteHandPileForFoot(carl, context()), isTrue);
 
-        final completion = botAI.makeCompleteHandPileForFootDecision(
+        final meldDecision = botAI.makeCompleteHandPileForFootDecision(
           carl,
           context(),
         );
+        expect(meldDecision?.action, 'noMeld');
 
-        expect(completion, isNull);
+        gameController.gameState.turnPhase = TurnPhase.discard;
+        final discardDecision = botAI.makeDecision(carl, gameController);
+        expect(discardDecision.action, 'discard');
       },
     );
 
@@ -159,10 +159,9 @@ void main() {
       'Alex adaptive uses multi-meld rush at hand=7 with opponent on foot',
       () {
         human.hasPickedUpFoot = true;
-        alex
-          ..hasPlayedDown = true
-          ..hasPickedUpFoot = false
-          ..melds.clear();
+        alex.hasPlayedDown = true;
+        alex.hasPickedUpFoot = false;
+        alex.melds.clear();
         alex.hand
           ..clear()
           ..addAll([

--- a/test/regression/firestore_session_17839500130143014_test.dart
+++ b/test/regression/firestore_session_17839500130143014_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_game_context.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+/// Regression tests from Firestore session_17839500130143014 (gameSeed 139404).
+///
+/// Failure modes: draw-loop hoarding on hand pile, Carl noMeld at hand=3 with 1
+/// book while opponent on foot, Alex failing to multi-meld toward foot.
+void main() {
+  group('Firestore session_17839500130143014 regressions', () {
+    const sessionSeed = 139404;
+
+    late EnhancedBotAI botAI;
+    late GameController gameController;
+    late Player human;
+    late Player carl;
+    late Player alex;
+
+    setUp(() {
+      botAI = EnhancedBotAI(seed: sessionSeed);
+      human = Player(id: '1', name: 'You', type: PlayerType.human);
+      alex = Player(id: '2', name: 'Alex', type: PlayerType.bot);
+      carl = Player(id: '3', name: 'Carl', type: PlayerType.bot);
+      gameController = GameController(
+        players: [human, alex, carl],
+        seed: sessionSeed,
+      );
+      gameController.initializeGame();
+      botAI.assignPersonality(alex.id, BotPersonality.adaptive);
+      botAI.assignPersonality(carl.id, BotPersonality.conservative);
+    });
+
+    BotGameContext context() =>
+        BotGameContext(gameController.gameState, gameController);
+
+    void setCurrentPlayer(Player bot) {
+      gameController.gameState.currentPlayerIndex = gameController
+          .gameState
+          .players
+          .indexWhere((p) => p.id == bot.id);
+    }
+
+    test('bots still draw from deck at start of turn on small hand pile', () {
+      for (final bot in [alex, carl]) {
+        bot
+          ..hasPlayedDown = true
+          ..hasPickedUpFoot = false
+          ..hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.six),
+          ]);
+        setCurrentPlayer(bot);
+        gameController.gameState.turnPhase = TurnPhase.draw;
+        gameController.gameState.hasDrawnFromDeck = false;
+
+        final decision = botAI.makeDecision(bot, gameController);
+
+        expect(
+          decision.action,
+          'drawFromDeck',
+          reason: '${bot.name} must draw before melding',
+        );
+      }
+    });
+
+    test(
+      'Carl conservative melds at hand=3 with 1 book while opponent on foot',
+      () {
+        human.hasPickedUpFoot = true;
+        carl
+          ..hasPlayedDown = true
+          ..hasPickedUpFoot = false
+          ..melds
+          ..clear()
+          ..addAll([
+            Meld.createMeld([
+              const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+              const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+              const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+              const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+              const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+              const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+              const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+            ])!,
+            Meld.createMeld([
+              const PlayingCard(suit: Suit.hearts, rank: CardRank.ten),
+              const PlayingCard(suit: Suit.spades, rank: CardRank.ten),
+              const PlayingCard(suit: Suit.clubs, rank: CardRank.ten),
+              const PlayingCard(suit: Suit.diamonds, rank: CardRank.ten),
+            ])!,
+          ]);
+        carl.hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.ten),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.six),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+          ]);
+        setCurrentPlayer(carl);
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        final decision = botAI.makeDecision(carl, gameController);
+
+        expect(decision.action, isNot('noMeld'));
+        expect(
+          decision.action,
+          anyOf('addToMeld', 'createMeld', 'createMultipleMelds'),
+        );
+      },
+    );
+
+    test(
+      'hand pile completion returns null instead of blocking noMeld when stuck',
+      () {
+        carl
+          ..hasPlayedDown = true
+          ..hasPickedUpFoot = false
+          ..melds
+          ..clear()
+          ..add(
+            Meld.createMeld([
+              const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+              const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+              const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+            ])!,
+          );
+        carl.hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.four),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.six),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.nine),
+          ]);
+        setCurrentPlayer(carl);
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        expect(botAI.shouldCompleteHandPileForFoot(carl, context()), isTrue);
+
+        final completion = botAI.makeCompleteHandPileForFootDecision(
+          carl,
+          context(),
+        );
+
+        expect(completion, isNull);
+      },
+    );
+
+    test(
+      'Alex adaptive uses multi-meld rush at hand=7 with opponent on foot',
+      () {
+        human.hasPickedUpFoot = true;
+        alex
+          ..hasPlayedDown = true
+          ..hasPickedUpFoot = false
+          ..melds.clear();
+        alex.hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.seven),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.eight),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.four),
+          ]);
+        setCurrentPlayer(alex);
+        gameController.gameState.turnPhase = TurnPhase.meld;
+        gameController.gameState.hasDrawnFromDeck = true;
+
+        final decision = botAI.makeDecision(alex, gameController);
+
+        expect(decision.action, isNot('noMeld'));
+        expect(
+          decision.action,
+          anyOf('createMultipleMelds', 'createMeld', 'addToMeld'),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes bots stalling on small hand piles before picking up foot, based on investigation of Firestore session `session_17839500130143014` (seed **139404**). Neither bot ever picked up foot in that game; Carl hit `noMeld` at hand=3 with 1 book while the human was on foot.

Bots still **draw at the start of every turn** — no draw-skipping cheat.

## Changes

### `enhanced_bot_ai.dart`
- Hand-pile completion final fallback returns `null` instead of blocking `noMeld`
- Disable strategic hold and book-completion hold while clearing hand pile toward foot
- Relax maximal-meld threshold (`handSize - 2`) under opponent-on-foot pressure
- Add `_chooseHandPileTransitionDiscard` for small hand-pile discards

### `bot_foot_transition_manager.dart`
- Phase-aware transitions: `discard` → `noMeld` during meld phase (defer to discard phase)
- All discard branches (including large-hand emergency paths) now pass through `_phaseAwareTransitionDecision`
- Lower meld-completion transition threshold from 5 → 3 cards

### `bot_turn_manager.dart`
- Analytics reasoning distinguishes hand-pile completion `noMeld` from strategic holds

### `bot_config.dart`
- Bump `botAiVersion` to `2026.07-hand-pile-foot-rush`

## Tests
- New regression suite: `test/regression/firestore_session_17839500143014_test.dart`
- Extended `hand_pile_foot_completion_test.dart`
- Updated `bot_foot_transition_test.dart` and rush integration tests for meld-phase deferral
- Renamed rush decision test names; added `expectMeldPhaseDefersThenDiscards` helper

## Verification
- `dart format .` — clean
- `flutter analyze` — zero issues
- `flutter test` — full suite passed (887 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5bbc-9e3c-77a6-9367-31460c3fc6e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5bbc-9e3c-77a6-9367-31460c3fc6e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bot decision-making to be phase-aware, so meld-phase decisions properly defer discarding and shift to discard-phase actions when appropriate.
  - Enhanced hand-pile-to-foot completion behavior, including more accurate thresholds and more reliable selection of meld/add or fallback discard.
  - Adjusted holding/hoarding logic around imminent foot pickup to prevent premature holds.

- **Tests**
  - Updated and expanded unit/integration coverage to reflect the new meld-vs-discard action expectations and reasoning.
  - Added a new regression test suite covering turn-phase behavior and specific bot decision scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->