### PR TITLE
Add WASD keyboard shortcuts for desktop play

### DIFF
--- a/lib/constants/keyboard_shortcuts.dart
+++ b/lib/constants/keyboard_shortcuts.dart
@@ -1,13 +1,17 @@
-/// A single keyboard shortcut entry for help UI and tooltips.
+import 'package:flutter/services.dart';
+
+/// A single keyboard shortcut entry for help UI, tooltips, and dispatch.
 class KeyboardShortcutEntry {
   final String keyLabel;
   final String action;
   final String? phase;
+  final LogicalKeyboardKey? logicalKey;
 
   const KeyboardShortcutEntry({
     required this.keyLabel,
     required this.action,
     this.phase,
+    this.logicalKey,
   });
 }
 
@@ -33,11 +37,13 @@ class KeyboardShortcuts {
       keyLabel: drawKey,
       action: 'Draw from deck',
       phase: 'Draw',
+      logicalKey: LogicalKeyboardKey.keyW,
     ),
     KeyboardShortcutEntry(
       keyLabel: takeDiscardKey,
       action: 'Take discard pile',
       phase: 'Draw',
+      logicalKey: LogicalKeyboardKey.keyQ,
     ),
   ];
 
@@ -46,36 +52,65 @@ class KeyboardShortcuts {
       keyLabel: playCardsKey,
       action: 'Open Play Cards',
       phase: 'Meld',
+      logicalKey: LogicalKeyboardKey.keyE,
     ),
     KeyboardShortcutEntry(
       keyLabel: discardKey,
       action: 'Discard / Go to Foot / Go Out',
       phase: 'Meld',
+      logicalKey: LogicalKeyboardKey.space,
     ),
     KeyboardShortcutEntry(
       keyLabel: discardAltKey,
       action: 'Same as Space',
       phase: 'Meld',
+      logicalKey: LogicalKeyboardKey.enter,
     ),
   ];
 
   static const List<KeyboardShortcutEntry> navigation = [
-    KeyboardShortcutEntry(keyLabel: prevCardKey, action: 'Focus previous card'),
-    KeyboardShortcutEntry(keyLabel: nextCardKey, action: 'Focus next card'),
+    KeyboardShortcutEntry(
+      keyLabel: prevCardKey,
+      action: 'Focus previous card',
+      logicalKey: LogicalKeyboardKey.keyA,
+    ),
+    KeyboardShortcutEntry(
+      keyLabel: nextCardKey,
+      action: 'Focus next card',
+      logicalKey: LogicalKeyboardKey.keyD,
+    ),
     KeyboardShortcutEntry(
       keyLabel: toggleSelectKey,
       action: 'Toggle select focused card',
+      logicalKey: LogicalKeyboardKey.keyF,
     ),
-    KeyboardShortcutEntry(keyLabel: sortKey, action: 'Sort hand by rank'),
-    KeyboardShortcutEntry(keyLabel: clearKey, action: 'Clear selection'),
-    KeyboardShortcutEntry(keyLabel: 'Esc', action: 'Clear selection'),
+    KeyboardShortcutEntry(
+      keyLabel: sortKey,
+      action: 'Sort hand by rank',
+      logicalKey: LogicalKeyboardKey.keyS,
+    ),
+    KeyboardShortcutEntry(
+      keyLabel: clearKey,
+      action: 'Clear selection',
+      logicalKey: LogicalKeyboardKey.keyC,
+    ),
+    KeyboardShortcutEntry(
+      keyLabel: 'Esc',
+      action: 'Clear selection',
+      logicalKey: LogicalKeyboardKey.escape,
+    ),
   ];
 
   static const List<KeyboardShortcutEntry> utility = [
-    KeyboardShortcutEntry(keyLabel: scoreboardKey, action: 'Open scoreboard'),
+    KeyboardShortcutEntry(
+      keyLabel: scoreboardKey,
+      action: 'Open scoreboard',
+      logicalKey: LogicalKeyboardKey.keyR,
+    ),
     KeyboardShortcutEntry(
       keyLabel: helpKey,
       action: 'Toggle keyboard shortcuts help',
+      logicalKey: LogicalKeyboardKey.keyH,
     ),
     KeyboardShortcutEntry(
       keyLabel: '?',
@@ -89,6 +124,45 @@ class KeyboardShortcuts {
     ...navigation,
     ...utility,
   ];
+
+  /// Canonical draw binding (W).
+  static final LogicalKeyboardKey draw = drawPhase.first.logicalKey!;
+
+  /// Canonical take-discard binding (Q).
+  static final LogicalKeyboardKey takeDiscard = drawPhase[1].logicalKey!;
+
+  /// Canonical play-cards binding (E).
+  static final LogicalKeyboardKey playCards = meldPhase.first.logicalKey!;
+
+  /// Discard primary binding (Space).
+  static final LogicalKeyboardKey discard = meldPhase[1].logicalKey!;
+
+  /// Discard alternate binding (Enter).
+  static final LogicalKeyboardKey discardAlt = meldPhase[2].logicalKey!;
+
+  /// Focus previous card (A).
+  static final LogicalKeyboardKey prevCard = navigation[0].logicalKey!;
+
+  /// Focus next card (D).
+  static final LogicalKeyboardKey nextCard = navigation[1].logicalKey!;
+
+  /// Toggle select focused card (F).
+  static final LogicalKeyboardKey toggleSelect = navigation[2].logicalKey!;
+
+  /// Sort hand (S).
+  static final LogicalKeyboardKey sort = navigation[3].logicalKey!;
+
+  /// Clear selection (C).
+  static final LogicalKeyboardKey clear = navigation[4].logicalKey!;
+
+  /// Clear / dismiss (Esc).
+  static final LogicalKeyboardKey escape = navigation[5].logicalKey!;
+
+  /// Scoreboard (R).
+  static final LogicalKeyboardKey scoreboard = utility.first.logicalKey!;
+
+  /// Help overlay (H).
+  static final LogicalKeyboardKey help = utility[1].logicalKey!;
 
   /// WASD layout rows for the help overlay diagram.
   static const List<List<String>> wasdLayout = [

--- a/lib/constants/keyboard_shortcuts.dart
+++ b/lib/constants/keyboard_shortcuts.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/services.dart';
+import '../models/game_state.dart';
 
 /// A single keyboard shortcut entry for help UI, tooltips, and dispatch.
 class KeyboardShortcutEntry {
   final String keyLabel;
   final String action;
-  final String? phase;
+  final TurnPhase? phase;
   final LogicalKeyboardKey? logicalKey;
 
   const KeyboardShortcutEntry({
@@ -32,18 +33,57 @@ class KeyboardShortcuts {
   static const String scoreboardKey = 'R';
   static const String helpKey = 'H';
 
+  /// Canonical draw binding (W).
+  static const LogicalKeyboardKey draw = LogicalKeyboardKey.keyW;
+
+  /// Canonical take-discard binding (Q).
+  static const LogicalKeyboardKey takeDiscard = LogicalKeyboardKey.keyQ;
+
+  /// Canonical play-cards binding (E).
+  static const LogicalKeyboardKey playCards = LogicalKeyboardKey.keyE;
+
+  /// Discard primary binding (Space).
+  static const LogicalKeyboardKey discard = LogicalKeyboardKey.space;
+
+  /// Discard alternate binding (Enter).
+  static const LogicalKeyboardKey discardAlt = LogicalKeyboardKey.enter;
+
+  /// Focus previous card (A).
+  static const LogicalKeyboardKey prevCard = LogicalKeyboardKey.keyA;
+
+  /// Focus next card (D).
+  static const LogicalKeyboardKey nextCard = LogicalKeyboardKey.keyD;
+
+  /// Toggle select focused card (F).
+  static const LogicalKeyboardKey toggleSelect = LogicalKeyboardKey.keyF;
+
+  /// Sort hand (S).
+  static const LogicalKeyboardKey sort = LogicalKeyboardKey.keyS;
+
+  /// Clear selection (C).
+  static const LogicalKeyboardKey clear = LogicalKeyboardKey.keyC;
+
+  /// Clear / dismiss (Esc).
+  static const LogicalKeyboardKey escape = LogicalKeyboardKey.escape;
+
+  /// Scoreboard (R).
+  static const LogicalKeyboardKey scoreboard = LogicalKeyboardKey.keyR;
+
+  /// Help overlay (H).
+  static const LogicalKeyboardKey help = LogicalKeyboardKey.keyH;
+
   static const List<KeyboardShortcutEntry> drawPhase = [
     KeyboardShortcutEntry(
       keyLabel: drawKey,
       action: 'Draw from deck',
-      phase: 'Draw',
-      logicalKey: LogicalKeyboardKey.keyW,
+      phase: TurnPhase.draw,
+      logicalKey: draw,
     ),
     KeyboardShortcutEntry(
       keyLabel: takeDiscardKey,
       action: 'Take discard pile',
-      phase: 'Draw',
-      logicalKey: LogicalKeyboardKey.keyQ,
+      phase: TurnPhase.draw,
+      logicalKey: takeDiscard,
     ),
   ];
 
@@ -51,20 +91,20 @@ class KeyboardShortcuts {
     KeyboardShortcutEntry(
       keyLabel: playCardsKey,
       action: 'Open Play Cards',
-      phase: 'Meld',
-      logicalKey: LogicalKeyboardKey.keyE,
+      phase: TurnPhase.meld,
+      logicalKey: playCards,
     ),
     KeyboardShortcutEntry(
       keyLabel: discardKey,
       action: 'Discard / Go to Foot / Go Out',
-      phase: 'Meld',
-      logicalKey: LogicalKeyboardKey.space,
+      phase: TurnPhase.meld,
+      logicalKey: discard,
     ),
     KeyboardShortcutEntry(
       keyLabel: discardAltKey,
       action: 'Same as Space',
-      phase: 'Meld',
-      logicalKey: LogicalKeyboardKey.enter,
+      phase: TurnPhase.meld,
+      logicalKey: discardAlt,
     ),
   ];
 
@@ -72,32 +112,32 @@ class KeyboardShortcuts {
     KeyboardShortcutEntry(
       keyLabel: prevCardKey,
       action: 'Focus previous card',
-      logicalKey: LogicalKeyboardKey.keyA,
+      logicalKey: prevCard,
     ),
     KeyboardShortcutEntry(
       keyLabel: nextCardKey,
       action: 'Focus next card',
-      logicalKey: LogicalKeyboardKey.keyD,
+      logicalKey: nextCard,
     ),
     KeyboardShortcutEntry(
       keyLabel: toggleSelectKey,
       action: 'Toggle select focused card',
-      logicalKey: LogicalKeyboardKey.keyF,
+      logicalKey: toggleSelect,
     ),
     KeyboardShortcutEntry(
       keyLabel: sortKey,
       action: 'Sort hand by rank',
-      logicalKey: LogicalKeyboardKey.keyS,
+      logicalKey: sort,
     ),
     KeyboardShortcutEntry(
       keyLabel: clearKey,
       action: 'Clear selection',
-      logicalKey: LogicalKeyboardKey.keyC,
+      logicalKey: clear,
     ),
     KeyboardShortcutEntry(
       keyLabel: 'Esc',
       action: 'Clear selection',
-      logicalKey: LogicalKeyboardKey.escape,
+      logicalKey: escape,
     ),
   ];
 
@@ -105,12 +145,12 @@ class KeyboardShortcuts {
     KeyboardShortcutEntry(
       keyLabel: scoreboardKey,
       action: 'Open scoreboard',
-      logicalKey: LogicalKeyboardKey.keyR,
+      logicalKey: scoreboard,
     ),
     KeyboardShortcutEntry(
       keyLabel: helpKey,
       action: 'Toggle keyboard shortcuts help',
-      logicalKey: LogicalKeyboardKey.keyH,
+      logicalKey: help,
     ),
     KeyboardShortcutEntry(
       keyLabel: '?',
@@ -124,45 +164,6 @@ class KeyboardShortcuts {
     ...navigation,
     ...utility,
   ];
-
-  /// Canonical draw binding (W).
-  static final LogicalKeyboardKey draw = drawPhase.first.logicalKey!;
-
-  /// Canonical take-discard binding (Q).
-  static final LogicalKeyboardKey takeDiscard = drawPhase[1].logicalKey!;
-
-  /// Canonical play-cards binding (E).
-  static final LogicalKeyboardKey playCards = meldPhase.first.logicalKey!;
-
-  /// Discard primary binding (Space).
-  static final LogicalKeyboardKey discard = meldPhase[1].logicalKey!;
-
-  /// Discard alternate binding (Enter).
-  static final LogicalKeyboardKey discardAlt = meldPhase[2].logicalKey!;
-
-  /// Focus previous card (A).
-  static final LogicalKeyboardKey prevCard = navigation[0].logicalKey!;
-
-  /// Focus next card (D).
-  static final LogicalKeyboardKey nextCard = navigation[1].logicalKey!;
-
-  /// Toggle select focused card (F).
-  static final LogicalKeyboardKey toggleSelect = navigation[2].logicalKey!;
-
-  /// Sort hand (S).
-  static final LogicalKeyboardKey sort = navigation[3].logicalKey!;
-
-  /// Clear selection (C).
-  static final LogicalKeyboardKey clear = navigation[4].logicalKey!;
-
-  /// Clear / dismiss (Esc).
-  static final LogicalKeyboardKey escape = navigation[5].logicalKey!;
-
-  /// Scoreboard (R).
-  static final LogicalKeyboardKey scoreboard = utility.first.logicalKey!;
-
-  /// Help overlay (H).
-  static final LogicalKeyboardKey help = utility[1].logicalKey!;
 
   /// WASD layout rows for the help overlay diagram.
   static const List<List<String>> wasdLayout = [

--- a/lib/constants/keyboard_shortcuts.dart
+++ b/lib/constants/keyboard_shortcuts.dart
@@ -1,0 +1,113 @@
+/// A single keyboard shortcut entry for help UI and tooltips.
+class KeyboardShortcutEntry {
+  final String keyLabel;
+  final String action;
+  final String? phase;
+
+  const KeyboardShortcutEntry({
+    required this.keyLabel,
+    required this.action,
+    this.phase,
+  });
+}
+
+/// Canonical WASD-centric keyboard shortcuts for desktop/web play.
+class KeyboardShortcuts {
+  KeyboardShortcuts._();
+
+  static const String drawKey = 'W';
+  static const String takeDiscardKey = 'Q';
+  static const String playCardsKey = 'E';
+  static const String discardKey = 'Space';
+  static const String discardAltKey = 'Enter';
+  static const String prevCardKey = 'A';
+  static const String nextCardKey = 'D';
+  static const String toggleSelectKey = 'F';
+  static const String sortKey = 'S';
+  static const String clearKey = 'C';
+  static const String scoreboardKey = 'R';
+  static const String helpKey = 'H';
+
+  static const List<KeyboardShortcutEntry> drawPhase = [
+    KeyboardShortcutEntry(
+      keyLabel: drawKey,
+      action: 'Draw from deck',
+      phase: 'Draw',
+    ),
+    KeyboardShortcutEntry(
+      keyLabel: takeDiscardKey,
+      action: 'Take discard pile',
+      phase: 'Draw',
+    ),
+  ];
+
+  static const List<KeyboardShortcutEntry> meldPhase = [
+    KeyboardShortcutEntry(
+      keyLabel: playCardsKey,
+      action: 'Open Play Cards',
+      phase: 'Meld',
+    ),
+    KeyboardShortcutEntry(
+      keyLabel: discardKey,
+      action: 'Discard / Go to Foot / Go Out',
+      phase: 'Meld',
+    ),
+    KeyboardShortcutEntry(
+      keyLabel: discardAltKey,
+      action: 'Same as Space',
+      phase: 'Meld',
+    ),
+  ];
+
+  static const List<KeyboardShortcutEntry> navigation = [
+    KeyboardShortcutEntry(keyLabel: prevCardKey, action: 'Focus previous card'),
+    KeyboardShortcutEntry(keyLabel: nextCardKey, action: 'Focus next card'),
+    KeyboardShortcutEntry(
+      keyLabel: toggleSelectKey,
+      action: 'Toggle select focused card',
+    ),
+    KeyboardShortcutEntry(keyLabel: sortKey, action: 'Sort hand by rank'),
+    KeyboardShortcutEntry(keyLabel: clearKey, action: 'Clear selection'),
+    KeyboardShortcutEntry(keyLabel: 'Esc', action: 'Clear selection'),
+  ];
+
+  static const List<KeyboardShortcutEntry> utility = [
+    KeyboardShortcutEntry(keyLabel: scoreboardKey, action: 'Open scoreboard'),
+    KeyboardShortcutEntry(
+      keyLabel: helpKey,
+      action: 'Toggle keyboard shortcuts help',
+    ),
+    KeyboardShortcutEntry(
+      keyLabel: '?',
+      action: 'Toggle keyboard shortcuts help',
+    ),
+  ];
+
+  static const List<KeyboardShortcutEntry> all = [
+    ...drawPhase,
+    ...meldPhase,
+    ...navigation,
+    ...utility,
+  ];
+
+  /// WASD layout rows for the help overlay diagram.
+  static const List<List<String>> wasdLayout = [
+    ['Q', 'W', 'E'],
+    ['A', 'S', 'D'],
+    ['F', 'C', 'Space'],
+  ];
+
+  static const Map<String, String> wasdLayoutLabels = {
+    'Q': 'Take discard',
+    'W': 'Draw',
+    'E': 'Play Cards',
+    'A': 'Prev card',
+    'S': 'Sort',
+    'D': 'Next card',
+    'F': 'Toggle select',
+    'C': 'Clear',
+    'Space': 'Discard',
+  };
+
+  static String tooltipSuffix(String key) => ' ($key)';
+}

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1479,21 +1479,11 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
     setState(() {
       _selectedCardIndices.clear();
-      _keyboardFocusedCardIndex = _clampKeyboardFocus(
-        _keyboardFocusedCardIndex,
-        humanPlayer.currentHand.length,
+      _keyboardFocusedCardIndex = clampKeyboardFocus(
+        index: _keyboardFocusedCardIndex,
+        handLength: humanPlayer.currentHand.length,
       );
     });
-  }
-
-  int? _clampKeyboardFocus(int? index, int handLength) {
-    if (handLength <= 0 || index == null) {
-      return null;
-    }
-    if (index >= handLength) {
-      return handLength - 1;
-    }
-    return index;
   }
 
   void _onFocusPreviousCard() {
@@ -1543,9 +1533,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       canUnlockDiscard: controller?.canUnlockDiscard() ?? false,
       selectedCardCount: _selectedCardIndices.length,
       handLength: handLength,
-      focusedCardIndex: _clampKeyboardFocus(
-        _keyboardFocusedCardIndex,
-        handLength,
+      focusedCardIndex: clampKeyboardFocus(
+        index: _keyboardFocusedCardIndex,
+        handLength: handLength,
       ),
       isHumanTurn: gameState.currentPlayer.type == PlayerType.human,
       isAnimating: _isCardAnimationActive,
@@ -1851,9 +1841,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
                   handDisplay: GameHandDisplay(
                     player: humanPlayer,
                     selectedCardIndices: _selectedCardIndices,
-                    keyboardFocusedCardIndex: _clampKeyboardFocus(
-                      _keyboardFocusedCardIndex,
-                      humanPlayer.currentHand.length,
+                    keyboardFocusedCardIndex: clampKeyboardFocus(
+                      index: _keyboardFocusedCardIndex,
+                      handLength: humanPlayer.currentHand.length,
                     ),
                     onCardTap:
                         currentPlayer.type == PlayerType.human &&

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/card.dart';
 import '../models/player.dart';
@@ -38,6 +37,9 @@ import 'managers/dialog_manager.dart';
 import 'managers/game_state_manager.dart';
 import 'managers/persistence_manager.dart';
 import 'managers/event_based_game_state_manager.dart';
+import '../widgets/game_keyboard_shortcuts.dart';
+import '../widgets/keyboard_shortcuts_overlay.dart';
+import '../utils/game_responsive_layout.dart';
 import '../providers/game_providers.dart';
 import '../providers/computed_providers.dart';
 
@@ -98,7 +100,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
   bool _isCardAnimationActive = false;
 
   // Keyboard shortcuts
-  final FocusNode _focusNode = FocusNode();
+  int? _keyboardFocusedCardIndex;
+  bool _showKeyboardHelp = false;
 
   // Card draw animation anchors
   final GlobalKey _deckKey = GlobalKey();
@@ -119,7 +122,6 @@ class _GameScreenState extends ConsumerState<GameScreen> {
   @override
   void dispose() {
     _disposed = true;
-    _focusNode.dispose();
     _handScrollController.dispose();
     // Dispose event-based manager to clean up subscriptions
     _eventBasedGameStateManager?.dispose();
@@ -714,6 +716,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
     _hasPlayerInteractedSinceDraw = true; // Mark that player has interacted
     setState(() {
+      _keyboardFocusedCardIndex = cardIndex;
       if (_selectedCardIndices.contains(cardIndex)) {
         _selectedCardIndices.remove(cardIndex);
       } else {
@@ -1474,8 +1477,99 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         break;
     }
 
-    setState(() {});
-    _selectedCardIndices.clear();
+    setState(() {
+      _selectedCardIndices.clear();
+      _keyboardFocusedCardIndex = _clampKeyboardFocus(
+        _keyboardFocusedCardIndex,
+        humanPlayer.currentHand.length,
+      );
+    });
+  }
+
+  int? _clampKeyboardFocus(int? index, int handLength) {
+    if (handLength <= 0 || index == null) {
+      return null;
+    }
+    if (index >= handLength) {
+      return handLength - 1;
+    }
+    return index;
+  }
+
+  void _onFocusPreviousCard() {
+    final humanPlayer = ref.read(humanPlayerProvider);
+    if (humanPlayer == null) {
+      return;
+    }
+    setState(() {
+      _keyboardFocusedCardIndex = focusPreviousCardIndex(
+        currentIndex: _keyboardFocusedCardIndex,
+        handLength: humanPlayer.currentHand.length,
+      );
+    });
+  }
+
+  void _onFocusNextCard() {
+    final humanPlayer = ref.read(humanPlayerProvider);
+    if (humanPlayer == null) {
+      return;
+    }
+    setState(() {
+      _keyboardFocusedCardIndex = focusNextCardIndex(
+        currentIndex: _keyboardFocusedCardIndex,
+        handLength: humanPlayer.currentHand.length,
+      );
+    });
+  }
+
+  void _onToggleSelectFocusedCard() {
+    if (_keyboardFocusedCardIndex != null) {
+      _onCardTap(_keyboardFocusedCardIndex!);
+    }
+  }
+
+  void _toggleKeyboardHelp() {
+    setState(() {
+      _showKeyboardHelp = !_showKeyboardHelp;
+    });
+  }
+
+  GameKeyboardContext _buildKeyboardContext(GameState gameState) {
+    final controller = _gameController;
+    final humanPlayer = ref.read(humanPlayerProvider);
+    final handLength = humanPlayer?.currentHand.length ?? 0;
+    return GameKeyboardContext(
+      turnPhase: gameState.turnPhase,
+      canUnlockDiscard: controller?.canUnlockDiscard() ?? false,
+      selectedCardCount: _selectedCardIndices.length,
+      handLength: handLength,
+      focusedCardIndex: _clampKeyboardFocus(
+        _keyboardFocusedCardIndex,
+        handLength,
+      ),
+      isHumanTurn: gameState.currentPlayer.type == PlayerType.human,
+      isAnimating: _isCardAnimationActive,
+      hasInteractedSinceDraw: _hasPlayerInteractedSinceDraw,
+      isHelpVisible: _showKeyboardHelp,
+    );
+  }
+
+  GameKeyboardActions _buildKeyboardActions() {
+    return GameKeyboardActions(
+      onDrawFromDeck: _onDrawFromDeck,
+      onUnlockDiscard: _onUnlockDiscard,
+      onOpenMeldModal: () => _dialogManager.showAdvancedMeldSelector(
+        onMeldsCreated: _executeAdvancedMeldCreation,
+      ),
+      onDiscard: _onDiscard,
+      onClearSelection: () => setState(() => _selectedCardIndices.clear()),
+      onSortHand: () => _sortHand('rank'),
+      onToggleSelectFocused: _onToggleSelectFocusedCard,
+      onFocusPrevious: _onFocusPreviousCard,
+      onFocusNext: _onFocusNextCard,
+      onShowScoreboard: () => _dialogManager.showScoreboard(),
+      onToggleHelp: _toggleKeyboardHelp,
+    );
   }
 
   void _showWildCardConfirmation(
@@ -1598,107 +1692,6 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     }
   }
 
-  /// Handle keyboard shortcuts for desktop users
-  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
-    // Only handle key down events
-    if (event is! KeyDownEvent) {
-      return KeyEventResult.ignored;
-    }
-
-    if (_isCardAnimationActive) {
-      return KeyEventResult.ignored;
-    }
-
-    // Only handle shortcuts during human turn
-    final currentPlayer = ref.read(currentPlayerProvider);
-    if (currentPlayer?.type != PlayerType.human) {
-      return KeyEventResult.ignored;
-    }
-
-    final gameState = ref.read(currentGameStateProvider);
-    if (gameState == null) return KeyEventResult.ignored;
-
-    final humanPlayer = ref.read(humanPlayerProvider);
-    if (humanPlayer == null) return KeyEventResult.ignored;
-
-    final key = event.logicalKey;
-
-    // D = Draw from deck
-    if (key == LogicalKeyboardKey.keyD) {
-      if (gameState.turnPhase == TurnPhase.draw) {
-        _onDrawFromDeck();
-        return KeyEventResult.handled;
-      }
-    }
-
-    // T = Take/unlock discard pile
-    if (key == LogicalKeyboardKey.keyT) {
-      final controller = _gameController;
-      if (controller != null &&
-          gameState.turnPhase == TurnPhase.draw &&
-          controller.canUnlockDiscard()) {
-        _onUnlockDiscard();
-        return KeyEventResult.handled;
-      }
-    }
-
-    // M = Open meld selector
-    if (key == LogicalKeyboardKey.keyM) {
-      if (gameState.turnPhase == TurnPhase.meld && _selectedCards.isNotEmpty) {
-        _dialogManager.showAdvancedMeldSelector(
-          onMeldsCreated: _executeAdvancedMeldCreation,
-        );
-        return KeyEventResult.handled;
-      }
-    }
-
-    // Enter/Space = Discard (if 1 card selected)
-    if (key == LogicalKeyboardKey.enter || key == LogicalKeyboardKey.space) {
-      if (gameState.turnPhase == TurnPhase.meld && _selectedCards.length == 1) {
-        _onDiscard();
-        return KeyEventResult.handled;
-      }
-    }
-
-    // Escape = Clear selection
-    if (key == LogicalKeyboardKey.escape) {
-      if (_selectedCardIndices.isNotEmpty) {
-        setState(() => _selectedCardIndices.clear());
-        return KeyEventResult.handled;
-      }
-    }
-
-    // S = Sort hand by rank
-    if (key == LogicalKeyboardKey.keyS) {
-      _sortHand('rank');
-      return KeyEventResult.handled;
-    }
-
-    // Number keys 1-9 = Toggle card selection
-    final numberKeys = {
-      LogicalKeyboardKey.digit1: 0,
-      LogicalKeyboardKey.digit2: 1,
-      LogicalKeyboardKey.digit3: 2,
-      LogicalKeyboardKey.digit4: 3,
-      LogicalKeyboardKey.digit5: 4,
-      LogicalKeyboardKey.digit6: 5,
-      LogicalKeyboardKey.digit7: 6,
-      LogicalKeyboardKey.digit8: 7,
-      LogicalKeyboardKey.digit9: 8,
-      LogicalKeyboardKey.digit0: 9,
-    };
-
-    if (numberKeys.containsKey(key)) {
-      final index = numberKeys[key]!;
-      if (index < humanPlayer.currentHand.length) {
-        _onCardTap(index);
-        return KeyEventResult.handled;
-      }
-    }
-
-    return KeyEventResult.ignored;
-  }
-
   @override
   Widget build(BuildContext context) {
     // Use providers for reactive state access
@@ -1721,157 +1714,177 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       'UI BUILD: Current player=${currentPlayer.name} (${currentPlayer.type}), version=${controllerState?.version}',
     );
 
-    return Focus(
-      focusNode: _focusNode,
-      autofocus: true,
-      onKeyEvent: _handleKeyEvent,
-      child: Container(
-        decoration: const BoxDecoration(gradient: BalatroTheme.primaryGradient),
-        child: Scaffold(
-          backgroundColor: Colors.transparent,
-          appBar: GameAppBar(
-            gameState: gameState,
-            isMultiplayer: false,
-            sessionInfo: _soloSessionInfo(gameState),
-            additionalActions: [
-              IconButton(
-                icon: const Icon(
-                  Icons.leaderboard,
-                  color: BalatroTheme.neonYellow,
-                ),
-                tooltip: 'View Scoreboard',
-                onPressed: () {
-                  _dialogManager.showScoreboard();
-                },
-              ),
-            ],
-            onNewGame: () {
-              _dialogManager.showNewGameConfirmation(_startNewGame);
-            },
-            onCopySeed: () {
-              _persistenceManager.copySeedToClipboard(context);
-            },
-            onExportGame: () {
-              _persistenceManager.copyGameStateToClipboard(context);
-            },
-            onLoadGame: () {
-              _dialogManager.showLoadGameDialog(
-                (inputText) =>
-                    _persistenceManager.loadGameFromJson(inputText, context),
-              );
-            },
-            onHowToPlay: () {
-              _dialogManager.showHowToPlayDialog();
-            },
-          ),
-          body: CardAnimationHost(
-            eventBus: ref.read(gameEventBusProvider),
-            deckKey: _deckKey,
-            discardKey: _discardKey,
-            handStackKey: _handStackKey,
-            meldAreaKey: _meldAreaKey,
-            handScrollController: _handScrollController,
-            onAnimationStateChanged: (isAnimating) {
-              if (_isCardAnimationActive != isAnimating) {
-                setState(() {
-                  _isCardAnimationActive = isAnimating;
-                });
-              }
-            },
-            child: GameBoardLayout(
-              gameState: gameState,
-              viewingPlayerMelds: _viewingPlayerMelds,
-              onPlayerTap: (player) {
-                setState(() {
-                  _viewingPlayerMelds = player.id == humanPlayer.id
-                      ? null
-                      : player;
-                });
-              },
-              deckKey: _deckKey,
-              discardKey: _discardKey,
-              meldAreaKey: _meldAreaKey,
-              headerExpanded: _statusExpanded,
-              onHeaderToggle: () {
-                setState(() {
-                  _statusExpanded = !_statusExpanded;
-                });
-              },
-              botPersonalityManager: _botAI.personalityManager,
-              useDesktopRecentActions: true,
-              recentActionsExpanded: _actionsExpanded,
-              onRecentActionsToggle: () {
-                setState(() {
-                  _actionsExpanded = !_actionsExpanded;
-                });
-              },
-              aboveMelds: _buildAboveMeldsBanner(
-                context,
-                gameState,
-                currentPlayer,
-              ),
-              meldsSection: MeldsSection(
+    final showDesktopKeyboardHints = !GameResponsiveLayout.isMobile(context);
+
+    return GameKeyboardShortcuts(
+      getContext: () => _buildKeyboardContext(gameState),
+      actions: _buildKeyboardActions(),
+      child: Stack(
+        children: [
+          Container(
+            decoration: const BoxDecoration(
+              gradient: BalatroTheme.primaryGradient,
+            ),
+            child: Scaffold(
+              backgroundColor: Colors.transparent,
+              appBar: GameAppBar(
                 gameState: gameState,
-                humanPlayer: humanPlayer,
-                viewingPlayerMelds: _viewingPlayerMelds,
-                onViewPlayerMelds: (player) {
-                  setState(() {
-                    _viewingPlayerMelds = player;
-                  });
-                },
-                onAddCardToMeld: _onAddCardToMeld,
-                onSelectAllCardsForMeld: _selectAllCardsForMeld,
-                canAddCardToMeld: _canAddCardToMeld,
-                getCompatibleCardsInfo: _getCompatibleCardsInfo,
-              ),
-              actionButtons: GameActionButtons(
-                gameState: gameState,
-                humanPlayer: humanPlayer,
-                selectedCardIndices: _selectedCardIndices,
-                onDrawFromDeck: _onDrawFromDeck,
-                onUnlockDiscard: () {
-                  final controller = _gameController;
-                  return (controller != null && controller.canUnlockDiscard())
-                      ? _onUnlockDiscard
-                      : null;
-                }(),
-                onShowAdvancedMeldSelector: () =>
-                    _dialogManager.showAdvancedMeldSelector(
-                      onMeldsCreated: _executeAdvancedMeldCreation,
+                isMultiplayer: false,
+                sessionInfo: _soloSessionInfo(gameState),
+                additionalActions: [
+                  IconButton(
+                    icon: const Icon(
+                      Icons.leaderboard,
+                      color: BalatroTheme.neonYellow,
                     ),
-                onDiscard: _selectedCards.length == 1 ? _onDiscard : null,
-                onClearSelection: () =>
-                    setState(() => _selectedCardIndices.clear()),
-              ),
-              handDisplay: GameHandDisplay(
-                player: humanPlayer,
-                selectedCardIndices: _selectedCardIndices,
-                onCardTap:
-                    currentPlayer.type == PlayerType.human &&
-                        gameState.phase != GamePhase.gameEnd
-                    ? _onCardTap
-                    : null,
-                onCardDoubleTap:
-                    currentPlayer.type == PlayerType.human &&
-                        gameState.phase != GamePhase.gameEnd
-                    ? _onCardDoubleTap
-                    : null,
-                isCardPlayable: _isCardPlayable,
-                viewingPlayerMelds: _viewingPlayerMelds,
-                onReturnToHand: () {
-                  setState(() {
-                    _viewingPlayerMelds = null;
-                  });
+                    tooltip: 'View Scoreboard',
+                    onPressed: () {
+                      _dialogManager.showScoreboard();
+                    },
+                  ),
+                ],
+                onNewGame: () {
+                  _dialogManager.showNewGameConfirmation(_startNewGame);
                 },
-                isCurrentPlayerTurn:
-                    currentPlayer.type == PlayerType.human &&
-                    gameState.phase != GamePhase.gameEnd,
+                onCopySeed: () {
+                  _persistenceManager.copySeedToClipboard(context);
+                },
+                onExportGame: () {
+                  _persistenceManager.copyGameStateToClipboard(context);
+                },
+                onLoadGame: () {
+                  _dialogManager.showLoadGameDialog(
+                    (inputText) => _persistenceManager.loadGameFromJson(
+                      inputText,
+                      context,
+                    ),
+                  );
+                },
+                onHowToPlay: () {
+                  _dialogManager.showHowToPlayDialog();
+                },
+              ),
+              body: CardAnimationHost(
+                eventBus: ref.read(gameEventBusProvider),
+                deckKey: _deckKey,
+                discardKey: _discardKey,
                 handStackKey: _handStackKey,
+                meldAreaKey: _meldAreaKey,
                 handScrollController: _handScrollController,
+                onAnimationStateChanged: (isAnimating) {
+                  if (_isCardAnimationActive != isAnimating) {
+                    setState(() {
+                      _isCardAnimationActive = isAnimating;
+                    });
+                  }
+                },
+                child: GameBoardLayout(
+                  gameState: gameState,
+                  viewingPlayerMelds: _viewingPlayerMelds,
+                  onPlayerTap: (player) {
+                    setState(() {
+                      _viewingPlayerMelds = player.id == humanPlayer.id
+                          ? null
+                          : player;
+                    });
+                  },
+                  deckKey: _deckKey,
+                  discardKey: _discardKey,
+                  meldAreaKey: _meldAreaKey,
+                  headerExpanded: _statusExpanded,
+                  onHeaderToggle: () {
+                    setState(() {
+                      _statusExpanded = !_statusExpanded;
+                    });
+                  },
+                  botPersonalityManager: _botAI.personalityManager,
+                  useDesktopRecentActions: true,
+                  recentActionsExpanded: _actionsExpanded,
+                  onRecentActionsToggle: () {
+                    setState(() {
+                      _actionsExpanded = !_actionsExpanded;
+                    });
+                  },
+                  headerExtras: showDesktopKeyboardHints
+                      ? [KeyboardShortcutsHelpChip(onTap: _toggleKeyboardHelp)]
+                      : const [],
+                  aboveMelds: _buildAboveMeldsBanner(
+                    context,
+                    gameState,
+                    currentPlayer,
+                  ),
+                  meldsSection: MeldsSection(
+                    gameState: gameState,
+                    humanPlayer: humanPlayer,
+                    viewingPlayerMelds: _viewingPlayerMelds,
+                    onViewPlayerMelds: (player) {
+                      setState(() {
+                        _viewingPlayerMelds = player;
+                      });
+                    },
+                    onAddCardToMeld: _onAddCardToMeld,
+                    onSelectAllCardsForMeld: _selectAllCardsForMeld,
+                    canAddCardToMeld: _canAddCardToMeld,
+                    getCompatibleCardsInfo: _getCompatibleCardsInfo,
+                  ),
+                  actionButtons: GameActionButtons(
+                    gameState: gameState,
+                    humanPlayer: humanPlayer,
+                    selectedCardIndices: _selectedCardIndices,
+                    showKeyboardHints: showDesktopKeyboardHints,
+                    onDrawFromDeck: _onDrawFromDeck,
+                    onUnlockDiscard: () {
+                      final controller = _gameController;
+                      return (controller != null &&
+                              controller.canUnlockDiscard())
+                          ? _onUnlockDiscard
+                          : null;
+                    }(),
+                    onShowAdvancedMeldSelector: () =>
+                        _dialogManager.showAdvancedMeldSelector(
+                          onMeldsCreated: _executeAdvancedMeldCreation,
+                        ),
+                    onDiscard: _selectedCards.length == 1 ? _onDiscard : null,
+                    onClearSelection: () =>
+                        setState(() => _selectedCardIndices.clear()),
+                  ),
+                  handDisplay: GameHandDisplay(
+                    player: humanPlayer,
+                    selectedCardIndices: _selectedCardIndices,
+                    keyboardFocusedCardIndex: _clampKeyboardFocus(
+                      _keyboardFocusedCardIndex,
+                      humanPlayer.currentHand.length,
+                    ),
+                    onCardTap:
+                        currentPlayer.type == PlayerType.human &&
+                            gameState.phase != GamePhase.gameEnd
+                        ? _onCardTap
+                        : null,
+                    onCardDoubleTap:
+                        currentPlayer.type == PlayerType.human &&
+                            gameState.phase != GamePhase.gameEnd
+                        ? _onCardDoubleTap
+                        : null,
+                    isCardPlayable: _isCardPlayable,
+                    viewingPlayerMelds: _viewingPlayerMelds,
+                    onReturnToHand: () {
+                      setState(() {
+                        _viewingPlayerMelds = null;
+                      });
+                    },
+                    isCurrentPlayerTurn:
+                        currentPlayer.type == PlayerType.human &&
+                        gameState.phase != GamePhase.gameEnd,
+                    handStackKey: _handStackKey,
+                    handScrollController: _handScrollController,
+                  ),
+                ),
               ),
             ),
           ),
-        ),
+          if (_showKeyboardHelp && showDesktopKeyboardHints)
+            KeyboardShortcutsOverlay(onDismiss: _toggleKeyboardHelp),
+        ],
       ),
     );
   }

--- a/lib/screens/managers/dialog_manager.dart
+++ b/lib/screens/managers/dialog_manager.dart
@@ -5,6 +5,7 @@ import '../../game/game_controller.dart';
 import '../../widgets/advanced_meld_selector.dart';
 import '../../widgets/emergency_round_end_dialog.dart';
 import '../../widgets/scoreboard_modal.dart';
+import '../../constants/keyboard_shortcuts.dart';
 import '../../theme/balatro_theme.dart';
 
 /// Manages all dialogs and modals for the game screen.
@@ -713,6 +714,8 @@ class DialogManager {
               children: [
                 _buildRulesSection(),
                 const SizedBox(height: 20),
+                _buildKeyboardShortcutsSection(),
+                const SizedBox(height: 20),
                 _buildPersonalitiesSection(),
               ],
             ),
@@ -759,6 +762,55 @@ class DialogManager {
         _buildRuleItem('🚫', 'Restrictions', 'Wilds ≤ naturals in any meld'),
         _buildRuleItem('🎲', 'Play Down', 'Round 1: 60 pts, +30 each round'),
         _buildRuleItem('🏁', 'Going Out', 'Need both clean AND dirty book'),
+      ],
+    );
+  }
+
+  Widget _buildKeyboardShortcutsSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Keyboard Shortcuts (Desktop)',
+          style: TextStyle(
+            color: BalatroTheme.neonGreen,
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Left hand on WASD — right hand on mouse. Press H in-game for the full overlay.',
+          style: TextStyle(color: Colors.white70, fontSize: 12),
+        ),
+        const SizedBox(height: 12),
+        ...KeyboardShortcuts.wasdLayout.map((row) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: row.map((keyLabel) {
+                final action =
+                    KeyboardShortcuts.wasdLayoutLabels[keyLabel] ?? keyLabel;
+                return Text(
+                  '[$keyLabel] $action',
+                  style: const TextStyle(color: Colors.white70, fontSize: 12),
+                );
+              }).toList(),
+            ),
+          );
+        }),
+        const SizedBox(height: 8),
+        ...KeyboardShortcuts.utility.map((entry) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2),
+            child: Text(
+              '[${entry.keyLabel}] ${entry.action}',
+              style: const TextStyle(color: Colors.white60, fontSize: 12),
+            ),
+          );
+        }),
       ],
     );
   }

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -15,6 +15,9 @@ import '../widgets/turn_timer.dart';
 import '../widgets/card_animation_host.dart';
 import '../game/events/game_event_bus.dart';
 import '../services/multiplayer_resume_service.dart';
+import '../widgets/game_keyboard_shortcuts.dart';
+import '../widgets/keyboard_shortcuts_overlay.dart';
+import '../utils/game_responsive_layout.dart';
 import '../theme/balatro_theme.dart';
 import 'main_menu_screen.dart';
 
@@ -46,6 +49,10 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
   final GlobalKey _meldAreaKey = GlobalKey();
   final ScrollController _handScrollController = ScrollController();
 
+  int? _keyboardFocusedCardIndex;
+  bool _showKeyboardHelp = false;
+  bool _isCardAnimationActive = false;
+
   @override
   void initState() {
     super.initState();
@@ -76,6 +83,7 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
     }
 
     setState(() {
+      _keyboardFocusedCardIndex = cardIndex;
       if (_selectedCardIndices.contains(cardIndex)) {
         _selectedCardIndices.remove(cardIndex);
       } else {
@@ -164,6 +172,139 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
       _gameController.discardCard(_selectedCards.first);
       setState(() => _selectedCardIndices.clear());
     }
+  }
+
+  void _sortHand() {
+    final currentUserPlayer = _gameController.getCurrentUserPlayer();
+    if (currentUserPlayer == null) {
+      return;
+    }
+    currentUserPlayer.sortHandByRank();
+    setState(() {
+      _selectedCardIndices.clear();
+      _keyboardFocusedCardIndex = _clampKeyboardFocus(
+        _keyboardFocusedCardIndex,
+        currentUserPlayer.currentHand.length,
+      );
+    });
+  }
+
+  int? _clampKeyboardFocus(int? index, int handLength) {
+    if (handLength <= 0 || index == null) {
+      return null;
+    }
+    if (index >= handLength) {
+      return handLength - 1;
+    }
+    return index;
+  }
+
+  void _onFocusPreviousCard() {
+    final currentUserPlayer = _gameController.getCurrentUserPlayer();
+    if (currentUserPlayer == null) {
+      return;
+    }
+    setState(() {
+      _keyboardFocusedCardIndex = focusPreviousCardIndex(
+        currentIndex: _keyboardFocusedCardIndex,
+        handLength: currentUserPlayer.currentHand.length,
+      );
+    });
+  }
+
+  void _onFocusNextCard() {
+    final currentUserPlayer = _gameController.getCurrentUserPlayer();
+    if (currentUserPlayer == null) {
+      return;
+    }
+    setState(() {
+      _keyboardFocusedCardIndex = focusNextCardIndex(
+        currentIndex: _keyboardFocusedCardIndex,
+        handLength: currentUserPlayer.currentHand.length,
+      );
+    });
+  }
+
+  void _onToggleSelectFocusedCard() {
+    if (_keyboardFocusedCardIndex != null) {
+      _onCardTap(_keyboardFocusedCardIndex!);
+    }
+  }
+
+  void _toggleKeyboardHelp() {
+    setState(() {
+      _showKeyboardHelp = !_showKeyboardHelp;
+    });
+  }
+
+  void _showScoreboard() {
+    final gameState = _gameController.gameState;
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: BalatroTheme.darkPurple,
+        title: const Text(
+          'Scoreboard',
+          style: TextStyle(color: BalatroTheme.neonYellow),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: gameState.players.map((player) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Text(
+                '${player.name}: ${player.score} pts',
+                style: const TextStyle(color: Colors.white),
+              ),
+            );
+          }).toList(),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  GameKeyboardContext _buildKeyboardContext(GameState gameState) {
+    final currentUserPlayer = _gameController.getCurrentUserPlayer();
+    final handLength = currentUserPlayer?.currentHand.length ?? 0;
+    return GameKeyboardContext(
+      turnPhase: gameState.turnPhase,
+      canUnlockDiscard: _gameController.canUnlockDiscard(),
+      selectedCardCount: _selectedCardIndices.length,
+      handLength: handLength,
+      focusedCardIndex: _clampKeyboardFocus(
+        _keyboardFocusedCardIndex,
+        handLength,
+      ),
+      isHumanTurn: _gameController.isMyTurn,
+      isAnimating: _isCardAnimationActive,
+      hasInteractedSinceDraw: true,
+      isHelpVisible: _showKeyboardHelp,
+    );
+  }
+
+  GameKeyboardActions _buildKeyboardActions() {
+    return GameKeyboardActions(
+      onDrawFromDeck: _onDrawFromDeck,
+      onUnlockDiscard: _gameController.canUnlockDiscard()
+          ? _onUnlockDiscard
+          : null,
+      onOpenMeldModal: _showAdvancedMeldSelector,
+      onDiscard: _onDiscard,
+      onClearSelection: () => setState(() => _selectedCardIndices.clear()),
+      onSortHand: _sortHand,
+      onToggleSelectFocused: _onToggleSelectFocusedCard,
+      onFocusPrevious: _onFocusPreviousCard,
+      onFocusNext: _onFocusNextCard,
+      onShowScoreboard: _showScoreboard,
+      onToggleHelp: _toggleKeyboardHelp,
+    );
   }
 
   void _showAdvancedMeldSelector() {
@@ -413,165 +554,202 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
           return _buildGameEndScreen(gameState);
         }
 
-        return Container(
-          decoration: const BoxDecoration(
-            gradient: BalatroTheme.primaryGradient,
-          ),
-          child: Scaffold(
-            backgroundColor: Colors.transparent,
-            appBar: GameAppBar(
-              gameState: gameState,
-              isMultiplayer: true,
-              connectionStream: _gameController.connectionStream,
-              isOnline: _gameController.isOnline,
-              sessionInfo: GameSessionInfo(
-                gameId: _gameController.gameId,
-                playerId: _gameController.userId,
-              ),
-              onLeaveGame: _cleanupAndExit,
-            ),
-            body: CardAnimationHost(
-              eventBus: gameEventBus,
-              localHumanPlayer: () => humanPlayer,
-              deckKey: _deckKey,
-              discardKey: _discardKey,
-              handStackKey: _handStackKey,
-              meldAreaKey: _meldAreaKey,
-              handScrollController: _handScrollController,
-              child: GameBoardLayout(
-                gameState: gameState,
-                viewingPlayerMelds: _viewingPlayerMelds,
-                onPlayerTap: (player) {
-                  setState(() {
-                    _viewingPlayerMelds = player.id == _gameController.userId
-                        ? null
-                        : player;
-                  });
-                },
-                deckKey: _deckKey,
-                discardKey: _discardKey,
-                meldAreaKey: _meldAreaKey,
-                headerExpanded: _headerExpanded,
-                onHeaderToggle: () {
-                  setState(() {
-                    _headerExpanded = !_headerExpanded;
-                  });
-                },
-                currentUserId: _gameController.userId,
-                useDesktopRecentActions: true,
-                recentActionsExpanded: _actionsExpanded,
-                onRecentActionsToggle: () {
-                  setState(() {
-                    _actionsExpanded = !_actionsExpanded;
-                  });
-                },
-                headerExtras: [
-                  Icon(
-                    _gameController.isOnline ? Icons.wifi : Icons.wifi_off,
-                    color: _gameController.isOnline ? Colors.green : Colors.red,
-                    size: 16,
+        final showDesktopKeyboardHints = !GameResponsiveLayout.isMobile(
+          context,
+        );
+
+        return GameKeyboardShortcuts(
+          getContext: () => _buildKeyboardContext(gameState),
+          actions: _buildKeyboardActions(),
+          child: Stack(
+            children: [
+              Container(
+                decoration: const BoxDecoration(
+                  gradient: BalatroTheme.primaryGradient,
+                ),
+                child: Scaffold(
+                  backgroundColor: Colors.transparent,
+                  appBar: GameAppBar(
+                    gameState: gameState,
+                    isMultiplayer: true,
+                    connectionStream: _gameController.connectionStream,
+                    isOnline: _gameController.isOnline,
+                    sessionInfo: GameSessionInfo(
+                      gameId: _gameController.gameId,
+                      playerId: _gameController.userId,
+                    ),
+                    onLeaveGame: _cleanupAndExit,
                   ),
-                  const SizedBox(width: 4),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 6,
-                      vertical: 2,
-                    ),
-                    decoration: BoxDecoration(
-                      color: _gameController.isMyTurn
-                          ? Colors.green.withValues(alpha: 0.3)
-                          : Colors.orange.withValues(alpha: 0.3),
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: Text(
-                      _gameController.isMyTurn
-                          ? 'YOU'
-                          : gameState.currentPlayer.name,
-                      style: TextStyle(
-                        color: _gameController.isMyTurn
-                            ? Colors.green
-                            : Colors.orange,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 10,
+                  body: CardAnimationHost(
+                    eventBus: gameEventBus,
+                    localHumanPlayer: () => humanPlayer,
+                    deckKey: _deckKey,
+                    discardKey: _discardKey,
+                    handStackKey: _handStackKey,
+                    meldAreaKey: _meldAreaKey,
+                    handScrollController: _handScrollController,
+                    onAnimationStateChanged: (isAnimating) {
+                      if (_isCardAnimationActive != isAnimating) {
+                        setState(() {
+                          _isCardAnimationActive = isAnimating;
+                        });
+                      }
+                    },
+                    child: GameBoardLayout(
+                      gameState: gameState,
+                      viewingPlayerMelds: _viewingPlayerMelds,
+                      onPlayerTap: (player) {
+                        setState(() {
+                          _viewingPlayerMelds =
+                              player.id == _gameController.userId
+                              ? null
+                              : player;
+                        });
+                      },
+                      deckKey: _deckKey,
+                      discardKey: _discardKey,
+                      meldAreaKey: _meldAreaKey,
+                      headerExpanded: _headerExpanded,
+                      onHeaderToggle: () {
+                        setState(() {
+                          _headerExpanded = !_headerExpanded;
+                        });
+                      },
+                      currentUserId: _gameController.userId,
+                      useDesktopRecentActions: true,
+                      recentActionsExpanded: _actionsExpanded,
+                      onRecentActionsToggle: () {
+                        setState(() {
+                          _actionsExpanded = !_actionsExpanded;
+                        });
+                      },
+                      headerExtras: [
+                        if (showDesktopKeyboardHints) ...[
+                          KeyboardShortcutsHelpChip(onTap: _toggleKeyboardHelp),
+                          const SizedBox(width: 4),
+                        ],
+                        Icon(
+                          _gameController.isOnline
+                              ? Icons.wifi
+                              : Icons.wifi_off,
+                          color: _gameController.isOnline
+                              ? Colors.green
+                              : Colors.red,
+                          size: 16,
+                        ),
+                        const SizedBox(width: 4),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: _gameController.isMyTurn
+                                ? Colors.green.withValues(alpha: 0.3)
+                                : Colors.orange.withValues(alpha: 0.3),
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Text(
+                            _gameController.isMyTurn
+                                ? 'YOU'
+                                : gameState.currentPlayer.name,
+                            style: TextStyle(
+                              color: _gameController.isMyTurn
+                                  ? Colors.green
+                                  : Colors.orange,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 10,
+                            ),
+                          ),
+                        ),
+                        if (_turnTimerEnabled) ...[
+                          const SizedBox(width: 4),
+                          TurnTimer(
+                            key: ValueKey(gameState.currentPlayer.id),
+                            turnDurationSeconds: _turnDurationSeconds,
+                            isActive: _gameController.isMyTurn,
+                            onTimeUp: _handleTurnTimeout,
+                            onTick: (remaining) {
+                              if (remaining == 30 && _gameController.isMyTurn) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('⏰ 30 seconds remaining!'),
+                                    backgroundColor: Colors.orange,
+                                    duration: Duration(seconds: 2),
+                                  ),
+                                );
+                              }
+                            },
+                          ),
+                        ],
+                      ],
+                      aboveMelds: gameState.finalTurnPhaseActive
+                          ? FinalTurnBanner(
+                              gameState: gameState,
+                              localPlayerId: _gameController.userId,
+                            )
+                          : null,
+                      meldsSection: MeldsSection(
+                        gameState: gameState,
+                        humanPlayer: humanPlayer,
+                        viewingPlayerMelds: _viewingPlayerMelds,
+                        onViewPlayerMelds: (player) {
+                          setState(() {
+                            _viewingPlayerMelds = player;
+                          });
+                        },
+                        onAddCardToMeld: _onAddCardToMeld,
+                        onSelectAllCardsForMeld: _selectAllCardsForMeld,
+                        canAddCardToMeld: _canAddCardToMeld,
+                        getCompatibleCardsInfo: _getCompatibleCardsInfo,
+                        currentUserId: _gameController.userId,
+                      ),
+                      actionButtons: GameActionButtons(
+                        gameState: gameState,
+                        humanPlayer: humanPlayer,
+                        selectedCardIndices: _selectedCardIndices,
+                        showKeyboardHints: showDesktopKeyboardHints,
+                        onDrawFromDeck: _onDrawFromDeck,
+                        onUnlockDiscard:
+                            (gameState.turnPhase == TurnPhase.draw &&
+                                _gameController.canUnlockDiscard())
+                            ? _onUnlockDiscard
+                            : null,
+                        onShowAdvancedMeldSelector: _showAdvancedMeldSelector,
+                        onDiscard: _selectedCards.length == 1
+                            ? _onDiscard
+                            : null,
+                        onClearSelection: () =>
+                            setState(() => _selectedCardIndices.clear()),
+                        currentUserId: _gameController.userId,
+                      ),
+                      handDisplay: GameHandDisplay(
+                        player: humanPlayer,
+                        selectedCardIndices: _selectedCardIndices,
+                        keyboardFocusedCardIndex: _clampKeyboardFocus(
+                          _keyboardFocusedCardIndex,
+                          humanPlayer.currentHand.length,
+                        ),
+                        onCardTap: _onCardTap,
+                        onCardDoubleTap: _onCardDoubleTap,
+                        isCardPlayable: _isCardPlayable,
+                        viewingPlayerMelds: _viewingPlayerMelds,
+                        onReturnToHand: () =>
+                            setState(() => _viewingPlayerMelds = null),
+                        isCurrentPlayerTurn:
+                            _gameController.gameState.currentPlayer.id ==
+                            _gameController.userId,
+                        showHighlights: true,
+                        handStackKey: _handStackKey,
+                        handScrollController: _handScrollController,
                       ),
                     ),
                   ),
-                  if (_turnTimerEnabled) ...[
-                    const SizedBox(width: 4),
-                    TurnTimer(
-                      key: ValueKey(gameState.currentPlayer.id),
-                      turnDurationSeconds: _turnDurationSeconds,
-                      isActive: _gameController.isMyTurn,
-                      onTimeUp: _handleTurnTimeout,
-                      onTick: (remaining) {
-                        if (remaining == 30 && _gameController.isMyTurn) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('⏰ 30 seconds remaining!'),
-                              backgroundColor: Colors.orange,
-                              duration: Duration(seconds: 2),
-                            ),
-                          );
-                        }
-                      },
-                    ),
-                  ],
-                ],
-                aboveMelds: gameState.finalTurnPhaseActive
-                    ? FinalTurnBanner(
-                        gameState: gameState,
-                        localPlayerId: _gameController.userId,
-                      )
-                    : null,
-                meldsSection: MeldsSection(
-                  gameState: gameState,
-                  humanPlayer: humanPlayer,
-                  viewingPlayerMelds: _viewingPlayerMelds,
-                  onViewPlayerMelds: (player) {
-                    setState(() {
-                      _viewingPlayerMelds = player;
-                    });
-                  },
-                  onAddCardToMeld: _onAddCardToMeld,
-                  onSelectAllCardsForMeld: _selectAllCardsForMeld,
-                  canAddCardToMeld: _canAddCardToMeld,
-                  getCompatibleCardsInfo: _getCompatibleCardsInfo,
-                  currentUserId: _gameController.userId,
-                ),
-                actionButtons: GameActionButtons(
-                  gameState: gameState,
-                  humanPlayer: humanPlayer,
-                  selectedCardIndices: _selectedCardIndices,
-                  onDrawFromDeck: _onDrawFromDeck,
-                  onUnlockDiscard:
-                      (gameState.turnPhase == TurnPhase.draw &&
-                          _gameController.canUnlockDiscard())
-                      ? _onUnlockDiscard
-                      : null,
-                  onShowAdvancedMeldSelector: _showAdvancedMeldSelector,
-                  onDiscard: _selectedCards.length == 1 ? _onDiscard : null,
-                  onClearSelection: () =>
-                      setState(() => _selectedCardIndices.clear()),
-                  currentUserId: _gameController.userId,
-                ),
-                handDisplay: GameHandDisplay(
-                  player: humanPlayer,
-                  selectedCardIndices: _selectedCardIndices,
-                  onCardTap: _onCardTap,
-                  onCardDoubleTap: _onCardDoubleTap,
-                  isCardPlayable: _isCardPlayable,
-                  viewingPlayerMelds: _viewingPlayerMelds,
-                  onReturnToHand: () =>
-                      setState(() => _viewingPlayerMelds = null),
-                  isCurrentPlayerTurn:
-                      _gameController.gameState.currentPlayer.id ==
-                      _gameController.userId,
-                  showHighlights: true,
-                  handStackKey: _handStackKey,
-                  handScrollController: _handScrollController,
                 ),
               ),
-            ),
+              if (_showKeyboardHelp && showDesktopKeyboardHints)
+                KeyboardShortcutsOverlay(onDismiss: _toggleKeyboardHelp),
+            ],
           ),
         );
       },

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -182,21 +182,11 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
     currentUserPlayer.sortHandByRank();
     setState(() {
       _selectedCardIndices.clear();
-      _keyboardFocusedCardIndex = _clampKeyboardFocus(
-        _keyboardFocusedCardIndex,
-        currentUserPlayer.currentHand.length,
+      _keyboardFocusedCardIndex = clampKeyboardFocus(
+        index: _keyboardFocusedCardIndex,
+        handLength: currentUserPlayer.currentHand.length,
       );
     });
-  }
-
-  int? _clampKeyboardFocus(int? index, int handLength) {
-    if (handLength <= 0 || index == null) {
-      return null;
-    }
-    if (index >= handLength) {
-      return handLength - 1;
-    }
-    return index;
   }
 
   void _onFocusPreviousCard() {
@@ -278,9 +268,9 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
       canUnlockDiscard: _gameController.canUnlockDiscard(),
       selectedCardCount: _selectedCardIndices.length,
       handLength: handLength,
-      focusedCardIndex: _clampKeyboardFocus(
-        _keyboardFocusedCardIndex,
-        handLength,
+      focusedCardIndex: clampKeyboardFocus(
+        index: _keyboardFocusedCardIndex,
+        handLength: handLength,
       ),
       isHumanTurn: _gameController.isMyTurn,
       isAnimating: _isCardAnimationActive,
@@ -726,9 +716,9 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
                       handDisplay: GameHandDisplay(
                         player: humanPlayer,
                         selectedCardIndices: _selectedCardIndices,
-                        keyboardFocusedCardIndex: _clampKeyboardFocus(
-                          _keyboardFocusedCardIndex,
-                          humanPlayer.currentHand.length,
+                        keyboardFocusedCardIndex: clampKeyboardFocus(
+                          index: _keyboardFocusedCardIndex,
+                          handLength: humanPlayer.currentHand.length,
                         ),
                         onCardTap: _onCardTap,
                         onCardDoubleTap: _onCardDoubleTap,

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import '../models/game_state.dart';
 import '../models/player.dart';
+import '../constants/keyboard_shortcuts.dart';
 import '../utils/game_responsive_layout.dart';
 import 'card_animation_host.dart';
 
@@ -187,6 +188,7 @@ class GameActionButtons extends StatelessWidget {
   final VoidCallback? onDiscard;
   final VoidCallback onClearSelection;
   final String? currentUserId; // For multiplayer turn detection
+  final bool showKeyboardHints;
 
   const GameActionButtons({
     super.key,
@@ -199,6 +201,7 @@ class GameActionButtons extends StatelessWidget {
     required this.onDiscard,
     required this.onClearSelection,
     this.currentUserId, // Optional - for multiplayer
+    this.showKeyboardHints = false,
   });
 
   bool get _hasSelectedCard => selectedCardIndices.length == 1;
@@ -363,6 +366,7 @@ class GameActionButtons extends StatelessWidget {
         _buildCompactButton(
           onPressed: isAnimating ? null : onDrawFromDeck,
           text: 'Draw from deck',
+          shortcutHint: showKeyboardHints ? KeyboardShortcuts.drawKey : null,
           isPhone: isPhone,
         ),
       );
@@ -371,6 +375,9 @@ class GameActionButtons extends StatelessWidget {
           _buildCompactButton(
             onPressed: isAnimating ? null : onUnlockDiscard,
             text: 'Take Discard',
+            shortcutHint: showKeyboardHints
+                ? KeyboardShortcuts.takeDiscardKey
+                : null,
             isPhone: isPhone,
           ),
         );
@@ -382,6 +389,9 @@ class GameActionButtons extends StatelessWidget {
         _buildCompactButton(
           onPressed: isAnimating ? null : onShowAdvancedMeldSelector,
           text: 'Play Cards',
+          shortcutHint: showKeyboardHints
+              ? KeyboardShortcuts.playCardsKey
+              : null,
           isPhone: isPhone,
           backgroundColor: const Color(
             0xFF16c79a,
@@ -392,6 +402,7 @@ class GameActionButtons extends StatelessWidget {
         _buildCompactButton(
           onPressed: isAnimating ? null : (_hasSelectedCard ? onDiscard : null),
           text: _discardButtonText,
+          shortcutHint: showKeyboardHints ? KeyboardShortcuts.discardKey : null,
           isPhone: isPhone,
           backgroundColor:
               _discardButtonColor ??
@@ -403,6 +414,7 @@ class GameActionButtons extends StatelessWidget {
           _buildCompactButton(
             onPressed: isAnimating ? null : onClearSelection,
             text: 'Clear',
+            shortcutHint: showKeyboardHints ? KeyboardShortcuts.clearKey : null,
             isPhone: isPhone,
             backgroundColor: Colors.grey,
           ),
@@ -435,9 +447,14 @@ class GameActionButtons extends StatelessWidget {
     required VoidCallback? onPressed,
     required String text,
     required bool isPhone,
+    String? shortcutHint,
     Color? backgroundColor,
   }) {
-    return ElevatedButton(
+    final label = shortcutHint == null
+        ? text
+        : '$text${KeyboardShortcuts.tooltipSuffix(shortcutHint)}';
+
+    final button = ElevatedButton(
       onPressed: onPressed,
       style: ElevatedButton.styleFrom(
         backgroundColor: backgroundColor,
@@ -461,5 +478,11 @@ class GameActionButtons extends StatelessWidget {
         overflow: TextOverflow.ellipsis,
       ),
     );
+
+    if (shortcutHint == null) {
+      return button;
+    }
+
+    return Tooltip(message: label, child: button);
   }
 }

--- a/lib/widgets/game_hand_display.dart
+++ b/lib/widgets/game_hand_display.dart
@@ -12,6 +12,7 @@ import 'playing_card_widget.dart';
 class GameHandDisplay extends StatelessWidget {
   final Player player;
   final List<int> selectedCardIndices;
+  final int? keyboardFocusedCardIndex;
   final Function(int)? onCardTap;
   final Function(int)? onCardDoubleTap;
   final bool Function(PlayingCard)? isCardPlayable;
@@ -26,6 +27,7 @@ class GameHandDisplay extends StatelessWidget {
     super.key,
     required this.player,
     required this.selectedCardIndices,
+    this.keyboardFocusedCardIndex,
     this.onCardTap,
     this.onCardDoubleTap,
     this.isCardPlayable,
@@ -126,6 +128,8 @@ class GameHandDisplay extends StatelessWidget {
                                 width: sizes.handWidth,
                                 height: sizes.handHeight,
                                 isSelected: selectedCardIndices.contains(index),
+                                isKeyboardFocused:
+                                    keyboardFocusedCardIndex == index,
                                 isPlayable: isCardPlayable?.call(card) ?? false,
                                 isNewlyDrawn:
                                     showHighlights &&

--- a/lib/widgets/game_keyboard_shortcuts.dart
+++ b/lib/widgets/game_keyboard_shortcuts.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import '../constants/keyboard_shortcuts.dart';
 import '../models/game_state.dart';
 
 /// Callbacks invoked by keyboard shortcuts.
@@ -58,7 +59,7 @@ class GameKeyboardContext {
 
 /// Returns true when the key is H or ? (shift+/).
 bool isHelpToggleKey(KeyDownEvent event) {
-  if (event.logicalKey == LogicalKeyboardKey.keyH) {
+  if (event.logicalKey == KeyboardShortcuts.help) {
     return true;
   }
   return event.character == '?';
@@ -81,7 +82,7 @@ KeyEventResult handleGameKeyboardEvent({
     return KeyEventResult.handled;
   }
 
-  if (context.isHelpVisible && key == LogicalKeyboardKey.escape) {
+  if (context.isHelpVisible && key == KeyboardShortcuts.escape) {
     actions.onToggleHelp();
     return KeyEventResult.handled;
   }
@@ -95,7 +96,7 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // W = Draw from deck
-  if (key == LogicalKeyboardKey.keyW) {
+  if (key == KeyboardShortcuts.draw) {
     if (context.turnPhase == TurnPhase.draw) {
       actions.onDrawFromDeck();
       return KeyEventResult.handled;
@@ -103,7 +104,7 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // Q = Take discard pile
-  if (key == LogicalKeyboardKey.keyQ) {
+  if (key == KeyboardShortcuts.takeDiscard) {
     if (context.turnPhase == TurnPhase.draw &&
         context.canUnlockDiscard &&
         actions.onUnlockDiscard != null) {
@@ -113,7 +114,7 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // E = Open Play Cards modal
-  if (key == LogicalKeyboardKey.keyE) {
+  if (key == KeyboardShortcuts.playCards) {
     if (context.turnPhase == TurnPhase.meld) {
       actions.onOpenMeldModal();
       return KeyEventResult.handled;
@@ -121,7 +122,7 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // Space / Enter = Discard
-  if (key == LogicalKeyboardKey.space || key == LogicalKeyboardKey.enter) {
+  if (key == KeyboardShortcuts.discard || key == KeyboardShortcuts.discardAlt) {
     if (context.turnPhase == TurnPhase.meld &&
         context.selectedCardCount == 1 &&
         context.hasInteractedSinceDraw) {
@@ -131,7 +132,7 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // A = Focus previous card
-  if (key == LogicalKeyboardKey.keyA) {
+  if (key == KeyboardShortcuts.prevCard) {
     if (context.handLength > 0) {
       actions.onFocusPrevious();
       return KeyEventResult.handled;
@@ -139,7 +140,7 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // D = Focus next card
-  if (key == LogicalKeyboardKey.keyD) {
+  if (key == KeyboardShortcuts.nextCard) {
     if (context.handLength > 0) {
       actions.onFocusNext();
       return KeyEventResult.handled;
@@ -147,7 +148,7 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // F = Toggle select on focused card
-  if (key == LogicalKeyboardKey.keyF) {
+  if (key == KeyboardShortcuts.toggleSelect) {
     if (context.handLength > 0 && context.focusedCardIndex != null) {
       actions.onToggleSelectFocused();
       return KeyEventResult.handled;
@@ -155,13 +156,13 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // S = Sort hand
-  if (key == LogicalKeyboardKey.keyS) {
+  if (key == KeyboardShortcuts.sort) {
     actions.onSortHand();
     return KeyEventResult.handled;
   }
 
   // C / Esc = Clear selection
-  if (key == LogicalKeyboardKey.keyC || key == LogicalKeyboardKey.escape) {
+  if (key == KeyboardShortcuts.clear || key == KeyboardShortcuts.escape) {
     if (context.selectedCardCount > 0) {
       actions.onClearSelection();
       return KeyEventResult.handled;
@@ -169,7 +170,7 @@ KeyEventResult handleGameKeyboardEvent({
   }
 
   // R = Scoreboard
-  if (key == LogicalKeyboardKey.keyR) {
+  if (key == KeyboardShortcuts.scoreboard) {
     actions.onShowScoreboard();
     return KeyEventResult.handled;
   }
@@ -218,16 +219,33 @@ class _GameKeyboardShortcutsState extends State<GameKeyboardShortcuts> {
 
   @override
   Widget build(BuildContext context) {
+    // ExcludeFocus keeps action-bar ElevatedButtons from stealing primary focus
+    // so WASD shortcuts keep working after mouse clicks. Dialogs open on the
+    // navigator overlay and are unaffected.
     return Focus(
       focusNode: _focusNode,
       autofocus: true,
       onKeyEvent: _onKeyEvent,
-      child: widget.child,
+      child: ExcludeFocus(child: widget.child),
     );
   }
 }
 
+/// Clamps a keyboard focus index into [0, handLength - 1], or null when empty.
+int? clampKeyboardFocus({required int? index, required int handLength}) {
+  if (handLength <= 0 || index == null) {
+    return null;
+  }
+  if (index >= handLength) {
+    return handLength - 1;
+  }
+  return index;
+}
+
 /// Moves keyboard focus to the previous card index (wraps at 0).
+///
+/// Out-of-range non-null indices (below 0 or beyond the hand) wrap to the
+/// last card so focus always lands on a valid index.
 int? focusPreviousCardIndex({
   required int? currentIndex,
   required int handLength,
@@ -238,13 +256,16 @@ int? focusPreviousCardIndex({
   if (currentIndex == null) {
     return handLength - 1;
   }
-  if (currentIndex <= 0) {
+  if (currentIndex <= 0 || currentIndex >= handLength) {
     return handLength - 1;
   }
   return currentIndex - 1;
 }
 
 /// Moves keyboard focus to the next card index (wraps at end).
+///
+/// Out-of-range non-null indices (below 0 or at/beyond the end) wrap to the
+/// first card so focus always lands on a valid index.
 int? focusNextCardIndex({required int? currentIndex, required int handLength}) {
   if (handLength <= 0) {
     return null;
@@ -252,7 +273,7 @@ int? focusNextCardIndex({required int? currentIndex, required int handLength}) {
   if (currentIndex == null) {
     return 0;
   }
-  if (currentIndex >= handLength - 1) {
+  if (currentIndex < 0 || currentIndex >= handLength - 1) {
     return 0;
   }
   return currentIndex + 1;

--- a/lib/widgets/game_keyboard_shortcuts.dart
+++ b/lib/widgets/game_keyboard_shortcuts.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../models/game_state.dart';
+
+/// Callbacks invoked by keyboard shortcuts.
+class GameKeyboardActions {
+  final VoidCallback onDrawFromDeck;
+  final VoidCallback? onUnlockDiscard;
+  final VoidCallback onOpenMeldModal;
+  final VoidCallback onDiscard;
+  final VoidCallback onClearSelection;
+  final VoidCallback onSortHand;
+  final VoidCallback onToggleSelectFocused;
+  final VoidCallback onFocusPrevious;
+  final VoidCallback onFocusNext;
+  final VoidCallback onShowScoreboard;
+  final VoidCallback onToggleHelp;
+
+  const GameKeyboardActions({
+    required this.onDrawFromDeck,
+    required this.onUnlockDiscard,
+    required this.onOpenMeldModal,
+    required this.onDiscard,
+    required this.onClearSelection,
+    required this.onSortHand,
+    required this.onToggleSelectFocused,
+    required this.onFocusPrevious,
+    required this.onFocusNext,
+    required this.onShowScoreboard,
+    required this.onToggleHelp,
+  });
+}
+
+/// Read-only state needed to decide which shortcuts apply.
+class GameKeyboardContext {
+  final TurnPhase turnPhase;
+  final bool canUnlockDiscard;
+  final int selectedCardCount;
+  final int handLength;
+  final int? focusedCardIndex;
+  final bool isHumanTurn;
+  final bool isAnimating;
+  final bool hasInteractedSinceDraw;
+  final bool isHelpVisible;
+
+  const GameKeyboardContext({
+    required this.turnPhase,
+    required this.canUnlockDiscard,
+    required this.selectedCardCount,
+    required this.handLength,
+    required this.focusedCardIndex,
+    required this.isHumanTurn,
+    required this.isAnimating,
+    required this.hasInteractedSinceDraw,
+    this.isHelpVisible = false,
+  });
+}
+
+/// Returns true when the key is H or ? (shift+/).
+bool isHelpToggleKey(KeyDownEvent event) {
+  if (event.logicalKey == LogicalKeyboardKey.keyH) {
+    return true;
+  }
+  return event.character == '?';
+}
+
+/// Pure keyboard handler for unit testing.
+KeyEventResult handleGameKeyboardEvent({
+  required KeyEvent event,
+  required GameKeyboardContext context,
+  required GameKeyboardActions actions,
+}) {
+  if (event is! KeyDownEvent) {
+    return KeyEventResult.ignored;
+  }
+
+  final key = event.logicalKey;
+
+  if (isHelpToggleKey(event)) {
+    actions.onToggleHelp();
+    return KeyEventResult.handled;
+  }
+
+  if (context.isHelpVisible && key == LogicalKeyboardKey.escape) {
+    actions.onToggleHelp();
+    return KeyEventResult.handled;
+  }
+
+  if (context.isAnimating) {
+    return KeyEventResult.ignored;
+  }
+
+  if (!context.isHumanTurn) {
+    return KeyEventResult.ignored;
+  }
+
+  // W = Draw from deck
+  if (key == LogicalKeyboardKey.keyW) {
+    if (context.turnPhase == TurnPhase.draw) {
+      actions.onDrawFromDeck();
+      return KeyEventResult.handled;
+    }
+  }
+
+  // Q = Take discard pile
+  if (key == LogicalKeyboardKey.keyQ) {
+    if (context.turnPhase == TurnPhase.draw &&
+        context.canUnlockDiscard &&
+        actions.onUnlockDiscard != null) {
+      actions.onUnlockDiscard!();
+      return KeyEventResult.handled;
+    }
+  }
+
+  // E = Open Play Cards modal
+  if (key == LogicalKeyboardKey.keyE) {
+    if (context.turnPhase == TurnPhase.meld) {
+      actions.onOpenMeldModal();
+      return KeyEventResult.handled;
+    }
+  }
+
+  // Space / Enter = Discard
+  if (key == LogicalKeyboardKey.space || key == LogicalKeyboardKey.enter) {
+    if (context.turnPhase == TurnPhase.meld &&
+        context.selectedCardCount == 1 &&
+        context.hasInteractedSinceDraw) {
+      actions.onDiscard();
+      return KeyEventResult.handled;
+    }
+  }
+
+  // A = Focus previous card
+  if (key == LogicalKeyboardKey.keyA) {
+    if (context.handLength > 0) {
+      actions.onFocusPrevious();
+      return KeyEventResult.handled;
+    }
+  }
+
+  // D = Focus next card
+  if (key == LogicalKeyboardKey.keyD) {
+    if (context.handLength > 0) {
+      actions.onFocusNext();
+      return KeyEventResult.handled;
+    }
+  }
+
+  // F = Toggle select on focused card
+  if (key == LogicalKeyboardKey.keyF) {
+    if (context.handLength > 0 && context.focusedCardIndex != null) {
+      actions.onToggleSelectFocused();
+      return KeyEventResult.handled;
+    }
+  }
+
+  // S = Sort hand
+  if (key == LogicalKeyboardKey.keyS) {
+    actions.onSortHand();
+    return KeyEventResult.handled;
+  }
+
+  // C / Esc = Clear selection
+  if (key == LogicalKeyboardKey.keyC || key == LogicalKeyboardKey.escape) {
+    if (context.selectedCardCount > 0) {
+      actions.onClearSelection();
+      return KeyEventResult.handled;
+    }
+  }
+
+  // R = Scoreboard
+  if (key == LogicalKeyboardKey.keyR) {
+    actions.onShowScoreboard();
+    return KeyEventResult.handled;
+  }
+
+  return KeyEventResult.ignored;
+}
+
+/// Wraps [child] with keyboard focus and routes key events to [handleGameKeyboardEvent].
+class GameKeyboardShortcuts extends StatefulWidget {
+  final Widget child;
+  final GameKeyboardContext Function() getContext;
+  final GameKeyboardActions actions;
+  final bool enabled;
+
+  const GameKeyboardShortcuts({
+    super.key,
+    required this.child,
+    required this.getContext,
+    required this.actions,
+    this.enabled = true,
+  });
+
+  @override
+  State<GameKeyboardShortcuts> createState() => _GameKeyboardShortcutsState();
+}
+
+class _GameKeyboardShortcutsState extends State<GameKeyboardShortcuts> {
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
+    if (!widget.enabled) {
+      return KeyEventResult.ignored;
+    }
+    return handleGameKeyboardEvent(
+      event: event,
+      context: widget.getContext(),
+      actions: widget.actions,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      autofocus: true,
+      onKeyEvent: _onKeyEvent,
+      child: widget.child,
+    );
+  }
+}
+
+/// Moves keyboard focus to the previous card index (wraps at 0).
+int? focusPreviousCardIndex({
+  required int? currentIndex,
+  required int handLength,
+}) {
+  if (handLength <= 0) {
+    return null;
+  }
+  if (currentIndex == null) {
+    return handLength - 1;
+  }
+  if (currentIndex <= 0) {
+    return handLength - 1;
+  }
+  return currentIndex - 1;
+}
+
+/// Moves keyboard focus to the next card index (wraps at end).
+int? focusNextCardIndex({required int? currentIndex, required int handLength}) {
+  if (handLength <= 0) {
+    return null;
+  }
+  if (currentIndex == null) {
+    return 0;
+  }
+  if (currentIndex >= handLength - 1) {
+    return 0;
+  }
+  return currentIndex + 1;
+}

--- a/lib/widgets/keyboard_shortcuts_overlay.dart
+++ b/lib/widgets/keyboard_shortcuts_overlay.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import '../constants/keyboard_shortcuts.dart';
+import '../theme/balatro_theme.dart';
+
+/// Compact WASD keyboard shortcuts help panel for desktop players.
+class KeyboardShortcutsOverlay extends StatelessWidget {
+  final VoidCallback onDismiss;
+
+  const KeyboardShortcutsOverlay({super.key, required this.onDismiss});
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      right: 12,
+      bottom: 12,
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          width: 320,
+          constraints: const BoxConstraints(maxHeight: 420),
+          decoration: BoxDecoration(
+            color: BalatroTheme.darkPurple.withValues(alpha: 0.95),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: BalatroTheme.glowColor, width: 2),
+            boxShadow: [
+              BoxShadow(
+                color: BalatroTheme.neonBlue.withValues(alpha: 0.3),
+                blurRadius: 12,
+                spreadRadius: 2,
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 10, 8, 4),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.keyboard,
+                      color: BalatroTheme.neonBlue,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    const Expanded(
+                      child: Text(
+                        'Keyboard Shortcuts',
+                        style: TextStyle(
+                          color: BalatroTheme.neonBlue,
+                          fontSize: 15,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close, color: Colors.white70),
+                      iconSize: 18,
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(
+                        minWidth: 32,
+                        minHeight: 32,
+                      ),
+                      onPressed: onDismiss,
+                      tooltip: 'Close (H or Esc)',
+                    ),
+                  ],
+                ),
+              ),
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Text(
+                  'Left hand on WASD — right hand on mouse',
+                  style: TextStyle(color: Colors.white60, fontSize: 11),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: _WasdDiagram(),
+              ),
+              const SizedBox(height: 8),
+              Flexible(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildSection('Draw Phase', KeyboardShortcuts.drawPhase),
+                      _buildSection('Meld Phase', KeyboardShortcuts.meldPhase),
+                      _buildSection('Hand', KeyboardShortcuts.navigation),
+                      _buildSection('Other', KeyboardShortcuts.utility),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection(String title, List<KeyboardShortcutEntry> entries) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: BalatroTheme.neonYellow,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          ...entries.map(_buildRow),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRow(KeyboardShortcutEntry entry) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.4),
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(color: BalatroTheme.cardBorder),
+            ),
+            child: Text(
+              entry.keyLabel,
+              style: const TextStyle(
+                color: BalatroTheme.neonGreen,
+                fontSize: 11,
+                fontWeight: FontWeight.bold,
+                fontFamily: 'monospace',
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              entry.action,
+              style: const TextStyle(color: Colors.white70, fontSize: 11),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WasdDiagram extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: KeyboardShortcuts.wasdLayout.map((row) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 2),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: row.map((keyLabel) {
+              final label =
+                  KeyboardShortcuts.wasdLayoutLabels[keyLabel] ?? keyLabel;
+              final isWide = keyLabel == 'Space';
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 3),
+                child: Column(
+                  children: [
+                    Container(
+                      width: isWide ? 72 : 36,
+                      height: 32,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: BalatroTheme.cardBackground,
+                        borderRadius: BorderRadius.circular(6),
+                        border: Border.all(color: BalatroTheme.neonBlue),
+                      ),
+                      child: Text(
+                        keyLabel,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 11,
+                          fontWeight: FontWeight.bold,
+                          fontFamily: 'monospace',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    SizedBox(
+                      width: isWide ? 72 : 36,
+                      child: Text(
+                        label,
+                        textAlign: TextAlign.center,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Colors.white54,
+                          fontSize: 8,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }).toList(),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+/// Small header chip that opens the keyboard shortcuts overlay.
+class KeyboardShortcutsHelpChip extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const KeyboardShortcutsHelpChip({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: BalatroTheme.neonBlue.withValues(alpha: 0.2),
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(
+            color: BalatroTheme.neonBlue.withValues(alpha: 0.6),
+          ),
+        ),
+        child: const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.keyboard, color: BalatroTheme.neonBlue, size: 14),
+            SizedBox(width: 4),
+            Text(
+              'H',
+              style: TextStyle(
+                color: BalatroTheme.neonBlue,
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/playing_card_widget.dart
+++ b/lib/widgets/playing_card_widget.dart
@@ -6,6 +6,7 @@ import '../theme/balatro_theme.dart';
 class PlayingCardWidget extends StatelessWidget {
   final PlayingCard card;
   final bool isSelected;
+  final bool isKeyboardFocused;
   final bool isPlayable;
   final bool isNewlyDrawn;
   final VoidCallback? onTap;
@@ -19,6 +20,7 @@ class PlayingCardWidget extends StatelessWidget {
     super.key,
     required this.card,
     this.isSelected = false,
+    this.isKeyboardFocused = false,
     this.isPlayable = false,
     this.isNewlyDrawn = false,
     this.onTap,
@@ -63,6 +65,8 @@ class PlayingCardWidget extends StatelessWidget {
               border: Border.all(
                 color: isSelected
                     ? BalatroTheme.glowColor
+                    : isKeyboardFocused
+                    ? BalatroTheme.neonBlue
                     : isNewlyDrawn
                     ? BalatroTheme.neonYellow
                     : isPlayable
@@ -70,6 +74,8 @@ class PlayingCardWidget extends StatelessWidget {
                     : BalatroTheme.cardBorder,
                 width: isSelected
                     ? 3
+                    : isKeyboardFocused
+                    ? 2
                     : isNewlyDrawn
                     ? 2
                     : 1,

--- a/test/widgets/game_keyboard_shortcuts_test.dart
+++ b/test/widgets/game_keyboard_shortcuts_test.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/widgets/game_keyboard_shortcuts.dart';
+
+void main() {
+  group('focusPreviousCardIndex', () {
+    test('returns last card when current is null', () {
+      expect(focusPreviousCardIndex(currentIndex: null, handLength: 5), 4);
+    });
+
+    test('wraps from first card to last', () {
+      expect(focusPreviousCardIndex(currentIndex: 0, handLength: 5), 4);
+    });
+
+    test('moves to previous card', () {
+      expect(focusPreviousCardIndex(currentIndex: 3, handLength: 5), 2);
+    });
+  });
+
+  group('focusNextCardIndex', () {
+    test('returns first card when current is null', () {
+      expect(focusNextCardIndex(currentIndex: null, handLength: 5), 0);
+    });
+
+    test('wraps from last card to first', () {
+      expect(focusNextCardIndex(currentIndex: 4, handLength: 5), 0);
+    });
+
+    test('moves to next card', () {
+      expect(focusNextCardIndex(currentIndex: 2, handLength: 5), 3);
+    });
+  });
+
+  group('handleGameKeyboardEvent', () {
+    late int drawCount;
+    late int unlockCount;
+    late int meldCount;
+    late int discardCount;
+    late int clearCount;
+    late int sortCount;
+    late int toggleSelectCount;
+    late int focusPreviousCount;
+    late int focusNextCount;
+    late int scoreboardCount;
+    late int helpCount;
+
+    GameKeyboardActions buildActions() {
+      return GameKeyboardActions(
+        onDrawFromDeck: () => drawCount++,
+        onUnlockDiscard: () => unlockCount++,
+        onOpenMeldModal: () => meldCount++,
+        onDiscard: () => discardCount++,
+        onClearSelection: () => clearCount++,
+        onSortHand: () => sortCount++,
+        onToggleSelectFocused: () => toggleSelectCount++,
+        onFocusPrevious: () => focusPreviousCount++,
+        onFocusNext: () => focusNextCount++,
+        onShowScoreboard: () => scoreboardCount++,
+        onToggleHelp: () => helpCount++,
+      );
+    }
+
+    GameKeyboardContext buildContext({
+      TurnPhase turnPhase = TurnPhase.draw,
+      bool canUnlockDiscard = true,
+      int selectedCardCount = 0,
+      int handLength = 5,
+      int? focusedCardIndex,
+      bool isHumanTurn = true,
+      bool isAnimating = false,
+      bool hasInteractedSinceDraw = true,
+      bool isHelpVisible = false,
+    }) {
+      return GameKeyboardContext(
+        turnPhase: turnPhase,
+        canUnlockDiscard: canUnlockDiscard,
+        selectedCardCount: selectedCardCount,
+        handLength: handLength,
+        focusedCardIndex: focusedCardIndex,
+        isHumanTurn: isHumanTurn,
+        isAnimating: isAnimating,
+        hasInteractedSinceDraw: hasInteractedSinceDraw,
+        isHelpVisible: isHelpVisible,
+      );
+    }
+
+    KeyDownEvent keyEvent(LogicalKeyboardKey key, {String? character}) {
+      return KeyDownEvent(
+        physicalKey: PhysicalKeyboardKey(0),
+        logicalKey: key,
+        character: character,
+        timeStamp: Duration.zero,
+      );
+    }
+
+    setUp(() {
+      drawCount = 0;
+      unlockCount = 0;
+      meldCount = 0;
+      discardCount = 0;
+      clearCount = 0;
+      sortCount = 0;
+      toggleSelectCount = 0;
+      focusPreviousCount = 0;
+      focusNextCount = 0;
+      scoreboardCount = 0;
+      helpCount = 0;
+    });
+
+    test('W draws during draw phase', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyW),
+        context: buildContext(),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(drawCount, 1);
+    });
+
+    test('Q unlocks discard when available', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyQ),
+        context: buildContext(),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(unlockCount, 1);
+    });
+
+    test('E opens meld modal during meld phase', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyE),
+        context: buildContext(turnPhase: TurnPhase.meld),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(meldCount, 1);
+    });
+
+    test('Space discards with one selected card and interaction guard', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.space),
+        context: buildContext(turnPhase: TurnPhase.meld, selectedCardCount: 1),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(discardCount, 1);
+    });
+
+    test('Space ignores discard without interaction guard', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.space),
+        context: buildContext(
+          turnPhase: TurnPhase.meld,
+          selectedCardCount: 1,
+          hasInteractedSinceDraw: false,
+        ),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.ignored);
+      expect(discardCount, 0);
+    });
+
+    test('A and D navigate hand', () {
+      handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyA),
+        context: buildContext(),
+        actions: buildActions(),
+      );
+      handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyD),
+        context: buildContext(),
+        actions: buildActions(),
+      );
+
+      expect(focusPreviousCount, 1);
+      expect(focusNextCount, 1);
+    });
+
+    test('F toggles selection on focused card', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyF),
+        context: buildContext(focusedCardIndex: 2),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(toggleSelectCount, 1);
+    });
+
+    test('C clears selection', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyC),
+        context: buildContext(selectedCardCount: 2),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(clearCount, 1);
+    });
+
+    test('H toggles help overlay', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyH),
+        context: buildContext(isHumanTurn: false),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(helpCount, 1);
+    });
+
+    test('ignores shortcuts during bot turn except help', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyW),
+        context: buildContext(isHumanTurn: false),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.ignored);
+      expect(drawCount, 0);
+    });
+
+    test('ignores shortcuts during animation', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyW),
+        context: buildContext(isAnimating: true),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.ignored);
+      expect(drawCount, 0);
+    });
+
+    test('Esc dismisses help overlay when visible', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.escape),
+        context: buildContext(isHelpVisible: true),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(helpCount, 1);
+      expect(clearCount, 0);
+    });
+  });
+
+  group('GameKeyboardShortcuts widget', () {
+    testWidgets('invokes draw callback on W key press', (tester) async {
+      var drawCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GameKeyboardShortcuts(
+            getContext: () => const GameKeyboardContext(
+              turnPhase: TurnPhase.draw,
+              canUnlockDiscard: false,
+              selectedCardCount: 0,
+              handLength: 3,
+              focusedCardIndex: null,
+              isHumanTurn: true,
+              isAnimating: false,
+              hasInteractedSinceDraw: true,
+            ),
+            actions: GameKeyboardActions(
+              onDrawFromDeck: () => drawCount++,
+              onUnlockDiscard: null,
+              onOpenMeldModal: () {},
+              onDiscard: () {},
+              onClearSelection: () {},
+              onSortHand: () {},
+              onToggleSelectFocused: () {},
+              onFocusPrevious: () {},
+              onFocusNext: () {},
+              onShowScoreboard: () {},
+              onToggleHelp: () {},
+            ),
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyW);
+      expect(drawCount, 1);
+    });
+  });
+}

--- a/test/widgets/game_keyboard_shortcuts_test.dart
+++ b/test/widgets/game_keyboard_shortcuts_test.dart
@@ -17,6 +17,14 @@ void main() {
     test('moves to previous card', () {
       expect(focusPreviousCardIndex(currentIndex: 3, handLength: 5), 2);
     });
+
+    test('wraps out-of-range high index to last card', () {
+      expect(focusPreviousCardIndex(currentIndex: 10, handLength: 5), 4);
+    });
+
+    test('wraps negative index to last card', () {
+      expect(focusPreviousCardIndex(currentIndex: -1, handLength: 5), 4);
+    });
   });
 
   group('focusNextCardIndex', () {
@@ -30,6 +38,32 @@ void main() {
 
     test('moves to next card', () {
       expect(focusNextCardIndex(currentIndex: 2, handLength: 5), 3);
+    });
+
+    test('wraps out-of-range high index to first card', () {
+      expect(focusNextCardIndex(currentIndex: 10, handLength: 5), 0);
+    });
+
+    test('wraps negative index to first card', () {
+      expect(focusNextCardIndex(currentIndex: -3, handLength: 5), 0);
+    });
+  });
+
+  group('clampKeyboardFocus', () {
+    test('returns null for empty hand', () {
+      expect(clampKeyboardFocus(index: 2, handLength: 0), isNull);
+    });
+
+    test('returns null for null index', () {
+      expect(clampKeyboardFocus(index: null, handLength: 5), isNull);
+    });
+
+    test('clamps above upper bound', () {
+      expect(clampKeyboardFocus(index: 9, handLength: 5), 4);
+    });
+
+    test('preserves in-range index', () {
+      expect(clampKeyboardFocus(index: 2, handLength: 5), 2);
     });
   });
 
@@ -204,6 +238,28 @@ void main() {
 
       expect(result, KeyEventResult.handled);
       expect(clearCount, 1);
+    });
+
+    test('S sorts hand', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyS),
+        context: buildContext(),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(sortCount, 1);
+    });
+
+    test('R opens scoreboard', () {
+      final result = handleGameKeyboardEvent(
+        event: keyEvent(LogicalKeyboardKey.keyR),
+        context: buildContext(),
+        actions: buildActions(),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(scoreboardCount, 1);
     });
 
     test('H toggles help overlay', () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds desktop/web keyboard shortcuts designed for one-hand-on-keyboard, one-hand-on-mouse play. Shortcuts are shared between solo and multiplayer via a new `GameKeyboardShortcuts` widget.

## WASD layout

| Key | Action |
|-----|--------|
| **W** | Draw from deck |
| **Q** | Take discard pile |
| **E** | Open Play Cards modal |
| **Space** / **Enter** | Discard / Go to Foot / Go Out |
| **A** / **D** | Focus previous / next card in hand |
| **F** | Toggle select on focused card |
| **S** | Sort hand by rank |
| **C** / **Esc** | Clear selection |
| **R** | Open scoreboard |
| **H** / **?** | Toggle shortcuts help overlay |

## Changes

- New shared handler: `lib/widgets/game_keyboard_shortcuts.dart`
- Shortcut constants + help UI: `lib/constants/keyboard_shortcuts.dart`, `lib/widgets/keyboard_shortcuts_overlay.dart`
- Solo + multiplayer screens wired with keyboard focus ring on hand cards
- Desktop button tooltips and How to Play section
- 19 unit/widget tests

## Test plan

- [x] `flutter test test/widgets/game_keyboard_shortcuts_test.dart`
- [x] `./format_and_test.sh` (format, analyze, full suite)
- [ ] Manual: solo game on web — W draw, D+F select, Space discard, H help overlay

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28ad75b4-b9fe-4013-9173-67f5e4752b30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28ad75b4-b9fe-4013-9173-67f5e4752b30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop keyboard shortcuts for draw, unlock-and-take discard, meld, discard, sort, navigation, selection, scoreboards, and help.
  * Added hand keyboard-focus visuals and keyboard-driven focus/selection behavior.
  * Added an on-screen keyboard shortcuts overlay (with a help chip) and keyboard hint tooltips on action buttons.
  * Extended the “How to Play” dialog with a “Keyboard Shortcuts (Desktop)” section.
* **Tests**
  * Added automated coverage for shortcut dispatching, focus navigation, clamping behavior, help dismissal, and key-triggered actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->