### PR TITLE
Fix bot foot-phase go-out traps and hoarding response

### DIFF
--- a/lib/ai/bot_discard_analyzer.dart
+++ b/lib/ai/bot_discard_analyzer.dart
@@ -17,6 +17,11 @@ class BotDiscardAnalyzer {
 
   BotDiscardAnalyzer();
 
+  /// Whether wild cards must be kept while the bot is in foot without go-out books.
+  static bool mustProtectWildsInFoot(Player bot) {
+    return bot.hasPickedUpFoot && !bot.canGoOutWithBooks;
+  }
+
   /// Choose the best card to discard considering multiple factors.
   ///
   /// Returns the card that minimizes harm to the bot while avoiding
@@ -69,7 +74,7 @@ class BotDiscardAnalyzer {
     }
 
     // 2. NEVER discard wilds in foot while missing required go-out books
-    if (card.isWild && bot.hasPickedUpFoot && !bot.canGoOutWithBooks) {
+    if (card.isWild && mustProtectWildsInFoot(bot)) {
       return -BotConfig.wildProtection;
     }
 

--- a/lib/ai/bot_discard_analyzer.dart
+++ b/lib/ai/bot_discard_analyzer.dart
@@ -68,16 +68,21 @@ class BotDiscardAnalyzer {
       return BotConfig.threesPriority + 5; // Black 3 = -5 points
     }
 
-    // 2. NEVER discard wilds unless desperate (< 3 cards)
+    // 2. NEVER discard wilds in foot while missing required go-out books
+    if (card.isWild && bot.hasPickedUpFoot && !bot.canGoOutWithBooks) {
+      return -BotConfig.wildProtection;
+    }
+
+    // 3. NEVER discard wilds unless desperate (<= 3 cards) once books are met
     if (card.isWild && bot.currentHand.length > 3) {
       return -BotConfig.wildProtection;
     }
 
-    // 3. Base score from inverse point value (low value = good to discard)
+    // 4. Base score from inverse point value (low value = good to discard)
     // Invert: high point cards (aces=20, wilds=50) get negative score
     score += 50 - card.pointValue;
 
-    // 4. DEFENSIVE: Check if opponents need this card
+    // 5. DEFENSIVE: Check if opponents need this card
     if (analyzer != null) {
       final opponentNeedScore = _calculateOpponentNeedScore(
         card,
@@ -88,7 +93,7 @@ class BotDiscardAnalyzer {
       score -= opponentNeedScore; // Reduce score if opponents need it
     }
 
-    // 5. STRATEGIC: Duplicate ranks — humans shed low-rank pairs on large hands
+    // 6. STRATEGIC: Duplicate ranks — humans shed low-rank pairs on large hands
     final sameRankCount = bot.currentHand
         .where((c) => c.rank == card.rank && !c.isWild)
         .length;
@@ -121,14 +126,14 @@ class BotDiscardAnalyzer {
       score += BotConfig.humanLowRankDiscardBonus;
     }
 
-    // 6. MELD FIT: Don't discard cards that fit existing melds
+    // 7. MELD FIT: Don't discard cards that fit existing melds
     for (final meld in bot.melds) {
       if (_cardFitsMeld(card, meld)) {
         score -= 30; // Keep cards that can extend melds
       }
     }
 
-    // 7. BOOK COMPLETION: Heavily penalize discarding cards near completing books
+    // 8. BOOK COMPLETION: Heavily penalize discarding cards near completing books
     for (final meld in bot.melds) {
       if (meld.cards.length >= 5 && _cardFitsMeld(card, meld)) {
         score -= 50; // Strong incentive to keep near-book cards

--- a/lib/ai/bot_end_game_manager.dart
+++ b/lib/ai/bot_end_game_manager.dart
@@ -22,7 +22,7 @@ class BotEndGameManager {
   BotEndGameManager({BotMeldAnalyzer? meldAnalyzer})
     : _meldAnalyzer = meldAnalyzer ?? BotMeldAnalyzer();
 
-  /// True when a meld would leave one card while the bot still cannot go out.
+  /// True when a meld would leave 0–1 cards while the bot still cannot go out.
   static bool leavesUnfinishableSingleCard(
     Player bot, {
     required int cardsRemoved,
@@ -33,7 +33,7 @@ class BotEndGameManager {
     }
 
     final remaining = bot.currentHand.length - cardsRemoved;
-    if (remaining != 1) {
+    if (remaining > 1) {
       return false;
     }
 
@@ -780,6 +780,15 @@ class BotEndGameManager {
       // Sort by point value (most negative first) - red 3s are -300, black 3s are -5
       threes.sort((a, b) => a.pointValue.compareTo(b.pointValue));
       return threes.first;
+    }
+
+    // Never discard wilds in foot while missing required go-out books
+    if (bot.hasPickedUpFoot && !bot.canGoOutWithBooks) {
+      final nonWilds = hand.where((card) => !card.isWild).toList();
+      if (nonWilds.isNotEmpty) {
+        nonWilds.sort((a, b) => a.pointValue.compareTo(b.pointValue));
+        return nonWilds.first;
+      }
     }
 
     // Then discard lowest value cards

--- a/lib/ai/bot_end_game_manager.dart
+++ b/lib/ai/bot_end_game_manager.dart
@@ -8,6 +8,7 @@ import '../utils/debug_logger.dart';
 import 'bot_decision.dart';
 import 'bot_config.dart';
 import 'bot_meld_analyzer.dart';
+import 'bot_discard_analyzer.dart';
 
 /// Manages end game decisions for bot players.
 ///
@@ -783,7 +784,7 @@ class BotEndGameManager {
     }
 
     // Never discard wilds in foot while missing required go-out books
-    if (bot.hasPickedUpFoot && !bot.canGoOutWithBooks) {
+    if (BotDiscardAnalyzer.mustProtectWildsInFoot(bot)) {
       final nonWilds = hand.where((card) => !card.isWild).toList();
       if (nonWilds.isNotEmpty) {
         nonWilds.sort((a, b) => a.pointValue.compareTo(b.pointValue));

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -982,6 +982,20 @@ class EnhancedBotAI {
       return true;
     }
 
+    // Scenario 4b: Opponent hoarding unplayed cards — end round while penalty is high
+    for (final opponent in gameState.players) {
+      if (opponent.id == bot.id) {
+        continue;
+      }
+      if (opponent.calculateAllUnplayedCardsValue() >=
+          BotConfig.aggressiveGoOutOpponentPenaltyThreshold) {
+        DebugLogger.debug(
+          '${bot.name}: HOARDING RUSH - Opponent penalty ${opponent.calculateAllUnplayedCardsValue()} >= ${BotConfig.aggressiveGoOutOpponentPenaltyThreshold}',
+        );
+        return true;
+      }
+    }
+
     // Scenario 5: EMERGENCY 3s MANAGEMENT - Bot has 8+ cards mostly 3s, needs to rush out
     final threeCount = bot.currentHand.where((card) => card.isThree).length;
     if (bot.currentHand.length >= 8 &&
@@ -3136,6 +3150,13 @@ class EnhancedBotAI {
         return _counterHumanAccumulation(bot, context, gameState, human);
       }
 
+      // THREAT 1b: Human hoarding after play-down (large hand+foot penalty pile)
+      if (human.hasPlayedDown &&
+          human.calculateAllUnplayedCardsValue() >=
+              BotConfig.aggressiveGoOutOpponentPenaltyThreshold) {
+        return _counterHumanAccumulation(bot, context, gameState, human);
+      }
+
       // THREAT 2: Human close to going out
       if (human.hasPickedUpFoot &&
           human.currentHand.length <= GameConfig.dangerousOpponentHandSize) {
@@ -3159,6 +3180,31 @@ class EnhancedBotAI {
     Player human,
   ) {
     final personality = _personalityManager.getPersonality(bot.id);
+    final opponentPenalty = human.calculateAllUnplayedCardsValue();
+    final hoardingPressure =
+        opponentPenalty >= BotConfig.aggressiveGoOutOpponentPenaltyThreshold;
+
+    // When opponent penalty pile is huge, rush finish or complete missing books
+    if (hoardingPressure && bot.hasPickedUpFoot) {
+      if (bot.canGoOutWithBooks) {
+        final controller = context.controller as GameController?;
+        if (controller != null) {
+          final finishDecision = _endGameManager.buildFinishRoundDecision(
+            bot,
+            controller,
+            gameState.turnPhase,
+          );
+          if (finishDecision != null) {
+            return finishDecision;
+          }
+        }
+      } else {
+        final bookRush = _rushToCompleteRequiredBooks(bot, context);
+        if (bookRush != null) {
+          return bookRush;
+        }
+      }
+    }
 
     // AGGRESSIVE BOTS: Speed demon counter-strategy
     if (personality == BotPersonality.aggressive) {
@@ -3308,10 +3354,10 @@ class EnhancedBotAI {
               .where((card) => needsClean ? !card.isWild : true)
               .toList();
           if (addableCards.isNotEmpty) {
-            return BotDecision(
-              action: 'addToMeld',
-              data: {'meldIndex': i, 'card': addableCards.first},
-            );
+            final addition = {'meldIndex': i, 'card': addableCards.first};
+            if (BotEndGameManager.isSafeAddToMeld(bot, addition)) {
+              return BotDecision(action: 'addToMeld', data: addition);
+            }
           }
         }
       }
@@ -3324,7 +3370,9 @@ class EnhancedBotAI {
     for (final meld in possibleMelds) {
       final isClean = !meld.any((card) => card.isWild);
       if ((needsClean && isClean) || (needsDirty && !isClean)) {
-        return BotDecision(action: 'createMeld', data: meld);
+        if (BotEndGameManager.isSafeCreateMeld(bot, meld)) {
+          return BotDecision(action: 'createMeld', data: meld);
+        }
       }
     }
 
@@ -3366,10 +3414,10 @@ class EnhancedBotAI {
 
       final possibleMelds = _getCachedPossibleMelds(bot, context);
       if (possibleMelds.isNotEmpty) {
-        return BotDecision(
-          action: 'createMeld',
-          data: _selectBestNewMeld(bot, possibleMelds),
-        );
+        final bestMeld = _selectBestNewMeld(bot, possibleMelds);
+        if (BotEndGameManager.isSafeCreateMeld(bot, bestMeld)) {
+          return BotDecision(action: 'createMeld', data: bestMeld);
+        }
       }
     }
 

--- a/test/ai/bot_finish_round_strategy_test.dart
+++ b/test/ai/bot_finish_round_strategy_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/bot_discard_analyzer.dart';
 import 'package:hand_foot_game_flutter/ai/bot_end_game_manager.dart';
 import 'package:hand_foot_game_flutter/ai/bot_foot_transition_manager.dart';
 import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
@@ -172,9 +173,11 @@ void main() {
         );
         botPlayer.hand.clear();
         botPlayer.foot.clear();
-        botPlayer.foot.add(
+        botPlayer.foot.addAll([
           const PlayingCard(suit: Suit.spades, rank: CardRank.seven),
-        );
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.nine),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.ten),
+        ]);
 
         gameController.gameState.turnPhase = TurnPhase.meld;
         gameController.gameState.hasDrawnFromDeck = true;
@@ -219,6 +222,52 @@ void main() {
         final decision = botAI.makeDecision(botPlayer, gameController);
 
         expect(decision.action, isNot('addToMeld'));
+      },
+      tags: ['clean_book_regression'],
+    );
+
+    test(
+      'rejects meld that empties hand without both book types',
+      () {
+        botPlayer.melds.clear();
+        botPlayer.melds.add(dirtyBook());
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.foot.addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.five),
+        ]);
+
+        expect(botPlayer.canGoOutWithBooks, isFalse);
+        expect(
+          BotEndGameManager.isSafeCreateMeld(botPlayer, botPlayer.currentHand),
+          isFalse,
+        );
+      },
+      tags: ['clean_book_regression'],
+    );
+
+    test(
+      'does not discard wild twos in foot when missing go-out books',
+      () {
+        botPlayer.melds.clear();
+        botPlayer.melds.add(dirtyBook());
+        botPlayer.hand.clear();
+        botPlayer.foot.clear();
+        botPlayer.foot.addAll([
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.two),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        ]);
+
+        final discardAnalyzer = BotDiscardAnalyzer();
+        final discard = discardAnalyzer.chooseCardToDiscard(
+          botPlayer,
+          gameController.gameState,
+        );
+
+        expect(discard.rank, equals(CardRank.five));
+        expect(discard.isWild, isFalse);
       },
       tags: ['clean_book_regression'],
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses bot AI issues observed in session `session_17839752376397639` where Bot 2 (Adaptive) discarded a wild 2 in foot without go-out books and bots failed to finish while the human hoarded a large penalty pile.

## Changes

### Empty-hand trap prevention (`bot_end_game_manager.dart`)
- `leavesUnfinishableSingleCard()` now blocks melds that leave **0 or 1** cards in foot when the bot still lacks both clean and dirty books (previously only blocked exactly 1 card).
- End-game discard fallback avoids discarding wilds in foot while missing required books.

### Wild discard protection (`bot_discard_analyzer.dart`)
- Wild cards are never discarded in foot when `!canGoOutWithBooks`, regardless of hand size (fixes Two♦ discard with hand=2).

### Hoarding counter & safer book rush (`enhanced_bot_ai.dart`)
- Rush go-out when any opponent's unplayed-card penalty ≥ `aggressiveGoOutOpponentPenaltyThreshold` (180).
- Counter post-playdown hoarding (not just pre-playdown 35-card accumulation).
- `_rushToCompleteRequiredBooks()` and foot-phase meld paths respect `isSafeAddToMeld` / `isSafeCreateMeld`.

## Tests

- Rejects meld that empties hand without both book types
- Does not discard wild twos in foot when missing go-out books
- Updated clean-book lane test to use a safe hand size (3 cards)

## Verification

```
flutter test --no-pub test/ai/bot_finish_round_strategy_test.dart test/ai/bot_foot_phase_melding_test.dart test/ai/human_play_pattern_ai_test.dart
```
All 22 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06e112d6-15e3-411b-8dc4-f39b0aebcc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06e112d6-15e3-411b-8dc4-f39b0aebcc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced bot end-game transitions into the foot phase with safer, context-aware meld decisions.
  * Added stronger “rush to go out” behavior based on opponents’ hoarding pressure, including a dedicated counter for human hoarding.
  * Bots now avoid unsafe melds and only choose meld actions when they pass safety checks.
* **Bug Fixes**
  * Fixed late-round discard/leave behavior for foot-phase scenarios, including better protection of wilds when go-out books are missing.
  * Prevented meld choices that would empty the hand when the bot lacks the required book types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->