### PR TITLE
Fix Continue restoring bot personalities (Clara icon wrong)

### DIFF
--- a/lib/config/bot_configurations.dart
+++ b/lib/config/bot_configurations.dart
@@ -1,4 +1,6 @@
 import '../ai/bot_personality.dart';
+import '../models/player.dart';
+import 'solo_game_settings.dart';
 
 /// Bot configuration with display name and personality mapping.
 class BotConfig {
@@ -20,6 +22,11 @@ const List<BotConfig> kBotConfigurations = [
   BotConfig('Sue', BotPersonality.adaptive),
 ];
 
+/// Name → personality lookup for known solo bots.
+final Map<String, BotPersonality> kBotPersonalityByName = {
+  for (final config in kBotConfigurations) config.name: config.personality,
+};
+
 /// Human-readable labels for bot personalities.
 String botPersonalityLabel(BotPersonality personality) {
   switch (personality) {
@@ -32,4 +39,57 @@ String botPersonalityLabel(BotPersonality personality) {
     case BotPersonality.adaptive:
       return 'Adaptive';
   }
+}
+
+/// Resolve bot personalities for save/restore.
+///
+/// Preference order:
+/// 1. [preferred] map (live runtime / explicit save)
+/// 2. [settings] personalities matched to bot order
+/// 3. Known name mapping from [kBotConfigurations]
+/// 4. [BotPersonality.adaptive] fallback
+Map<String, BotPersonality> resolveBotPersonalities({
+  required List<Player> players,
+  SoloGameSettings? settings,
+  Map<String, BotPersonality>? preferred,
+}) {
+  final bots = players.where((p) => p.type == PlayerType.bot).toList();
+  final fromSettings = settings?.normalizedPersonalities ?? const [];
+  final result = <String, BotPersonality>{};
+
+  for (var i = 0; i < bots.length; i++) {
+    final bot = bots[i];
+    final preferredPersonality = preferred?[bot.id];
+    if (preferredPersonality != null) {
+      result[bot.id] = preferredPersonality;
+      continue;
+    }
+    if (i < fromSettings.length) {
+      result[bot.id] = fromSettings[i];
+      continue;
+    }
+    result[bot.id] = kBotPersonalityByName[bot.name] ?? BotPersonality.adaptive;
+  }
+
+  return result;
+}
+
+/// Serialize personalities as `BotPersonality.<name>` strings for save formats.
+Map<String, String> serializeBotPersonalities(
+  Map<String, BotPersonality> personalities,
+) {
+  return {
+    for (final entry in personalities.entries)
+      entry.key: entry.value.toString(),
+  };
+}
+
+/// Parse `BotPersonality.<name>` or bare enum name strings from saves.
+BotPersonality parseBotPersonalityString(String value) {
+  for (final personality in BotPersonality.values) {
+    if (personality.toString() == value || personality.name == value) {
+      return personality;
+    }
+  }
+  return BotPersonality.adaptive;
 }

--- a/lib/config/bot_configurations.dart
+++ b/lib/config/bot_configurations.dart
@@ -1,5 +1,6 @@
 import '../ai/bot_personality.dart';
 import '../models/player.dart';
+import '../utils/debug_logger.dart';
 import 'solo_game_settings.dart';
 
 /// Bot configuration with display name and personality mapping.
@@ -91,5 +92,8 @@ BotPersonality parseBotPersonalityString(String value) {
       return personality;
     }
   }
+  DebugLogger.warning(
+    'Unknown bot personality "$value", falling back to adaptive',
+  );
   return BotPersonality.adaptive;
 }

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -40,6 +40,10 @@ class GameController implements GameInterface {
   @override
   final int? gameSeed;
 
+  /// Personalities restored from local autosave (playerId → enum toString).
+  /// Applied by GameScreen when continuing a saved solo game.
+  Map<String, String> restoredBotPersonalities = {};
+
   factory GameController({
     required List<Player> players,
     int? seed,

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -131,39 +131,40 @@ class _GameScreenState extends ConsumerState<GameScreen> {
   /// Helper method to assign bot personalities consistently
   void _assignBotPersonalities() {
     final controller = _gameController;
-    if (controller == null) return;
-
-    final botPlayers = controller.gameState.players
-        .where((p) => p.type == PlayerType.bot)
-        .toList();
-
-    // Create personality mapping from predefined bot configurations
-    final personalityMap = <String, BotPersonality>{};
-    for (final config in kBotConfigurations) {
-      personalityMap[config.name] = config.personality;
+    if (controller == null) {
+      return;
     }
 
-    // Assign personalities based on bot names, with fallback to random
-    for (final bot in botPlayers) {
-      final predefinedPersonality = personalityMap[bot.name];
-      if (predefinedPersonality != null) {
-        _botAI.assignPersonality(bot.id, predefinedPersonality);
-      } else {
-        // Fallback to random assignment for unknown bot names
-        final personalities = BotPersonality.values;
-        final randomPersonality =
-            personalities[(bot.id.hashCode % personalities.length)];
-        _botAI.assignPersonality(bot.id, randomPersonality);
-      }
+    final resolved = resolveBotPersonalities(
+      players: controller.gameState.players,
+      settings: controller.gameState.soloSettings,
+    );
+    for (final entry in resolved.entries) {
+      _botAI.assignPersonality(entry.key, entry.value);
     }
 
     // Log personality assignments in debug mode
     if (kDebugMode) {
+      final botPlayers = controller.gameState.players.where(
+        (p) => p.type == PlayerType.bot,
+      );
       for (final bot in botPlayers) {
         final personality = _botAI.personalityManager.getPersonality(bot.id);
         print('Bot ${bot.name} (${bot.id}) assigned personality: $personality');
       }
     }
+  }
+
+  /// Restore personalities when opening a continued autosave.
+  void _restorePersonalitiesForContinuedGame(GameController controller) {
+    final saved = controller.restoredBotPersonalities;
+    if (saved.isNotEmpty) {
+      _botTurnManager.restoreBotPersonalities(saved);
+      return;
+    }
+
+    // Legacy saves: derive from solo settings / known bot names
+    _assignBotPersonalities();
   }
 
   /// Initialize all manager instances after game controller setup
@@ -296,6 +297,10 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           .read(gameControllerProvider.notifier)
           .setController(widget.gameController!, eventBus);
       _initializeManagers();
+
+      // Continue must restore personalities — autosave previously left them
+      // unassigned, so icons/AI defaulted to Adaptive (e.g. Clara showed Sue's icon).
+      _restorePersonalitiesForContinuedGame(widget.gameController!);
 
       _isInitialized = true;
 

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -150,7 +150,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       );
       for (final bot in botPlayers) {
         final personality = _botAI.personalityManager.getPersonality(bot.id);
-        print('Bot ${bot.name} (${bot.id}) assigned personality: $personality');
+        DebugLogger.debug(
+          'Bot ${bot.name} (${bot.id}) assigned personality: $personality',
+        );
       }
     }
   }
@@ -903,8 +905,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
             .read(gameControllerProvider.notifier)
             .setController(savedController, eventBus);
 
-        // Assign consistent bot personalities based on player IDs
-        _assignBotPersonalities();
+        _initializeManagers();
+        _restorePersonalitiesForContinuedGame(savedController);
 
         // Sort the human player's hand
         final humanPlayer = ref.read(humanPlayerProvider);

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -79,7 +79,9 @@ class BotTurnManager {
       );
       for (final bot in botPlayers) {
         final personality = botAI.personalityManager.getPersonality(bot.id);
-        print('Bot ${bot.name} (${bot.id}) assigned personality: $personality');
+        DebugLogger.debug(
+          'Bot ${bot.name} (${bot.id}) assigned personality: $personality',
+        );
       }
     }
   }
@@ -98,6 +100,11 @@ class BotTurnManager {
       return;
     }
 
+    final resolvedFallback = resolveBotPersonalities(
+      players: gameController.gameState.players,
+      settings: gameController.gameState.soloSettings,
+    );
+
     for (final bot in botPlayers) {
       final savedPersonalityName = savedPersonalities[bot.id];
       if (savedPersonalityName != null) {
@@ -105,21 +112,17 @@ class BotTurnManager {
         botAI.assignPersonality(bot.id, personality);
 
         if (kDebugMode) {
-          print(
+          DebugLogger.debug(
             'Bot ${bot.name} (${bot.id}) restored personality: $personality',
           );
         }
       } else {
-        // Missing entry for this bot — fall back to settings/name resolution
-        final resolved = resolveBotPersonalities(
-          players: [bot],
-          settings: gameController.gameState.soloSettings,
-        );
-        final personality = resolved[bot.id] ?? BotPersonality.adaptive;
+        // Missing entry for this bot — fall back to full-roster resolution
+        final personality = resolvedFallback[bot.id] ?? BotPersonality.adaptive;
         botAI.assignPersonality(bot.id, personality);
 
         if (kDebugMode) {
-          print(
+          DebugLogger.debug(
             'Bot ${bot.name} (${bot.id}) assigned personality: $personality (no saved entry)',
           );
         }

--- a/lib/screens/managers/bot_turn_manager.dart
+++ b/lib/screens/managers/bot_turn_manager.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'package:flutter/foundation.dart';
 import '../../models/player.dart';
 import '../../models/card.dart';
@@ -64,32 +63,20 @@ class BotTurnManager {
 
   /// Helper method to assign bot personalities consistently
   void assignBotPersonalities() {
-    final botPlayers = gameController.gameState.players
-        .where((p) => p.type == PlayerType.bot)
-        .toList();
+    final resolved = resolveBotPersonalities(
+      players: gameController.gameState.players,
+      settings: gameController.gameState.soloSettings,
+    );
 
-    // Create personality mapping from predefined bot configurations
-    final personalityMap = <String, BotPersonality>{};
-    for (final config in kBotConfigurations) {
-      personalityMap[config.name] = config.personality;
-    }
-
-    // Assign personalities based on bot names, with fallback to random
-    for (final bot in botPlayers) {
-      final predefinedPersonality = personalityMap[bot.name];
-      if (predefinedPersonality != null) {
-        botAI.assignPersonality(bot.id, predefinedPersonality);
-      } else {
-        // Fallback to random assignment for unknown bot names
-        final personalities = BotPersonality.values;
-        final randomPersonality =
-            personalities[(bot.id.hashCode % personalities.length)];
-        botAI.assignPersonality(bot.id, randomPersonality);
-      }
+    for (final entry in resolved.entries) {
+      botAI.assignPersonality(entry.key, entry.value);
     }
 
     // Log personality assignments in debug mode
     if (kDebugMode) {
+      final botPlayers = gameController.gameState.players.where(
+        (p) => p.type == PlayerType.bot,
+      );
       for (final bot in botPlayers) {
         final personality = botAI.personalityManager.getPersonality(bot.id);
         print('Bot ${bot.name} (${bot.id}) assigned personality: $personality');
@@ -106,14 +93,15 @@ class BotTurnManager {
         .where((p) => p.type == PlayerType.bot)
         .toList();
 
+    if (savedPersonalities.isEmpty) {
+      assignBotPersonalities();
+      return;
+    }
+
     for (final bot in botPlayers) {
       final savedPersonalityName = savedPersonalities[bot.id];
       if (savedPersonalityName != null) {
-        // Parse saved personality name back to enum
-        final personality = BotPersonality.values.firstWhere(
-          (p) => p.toString() == savedPersonalityName,
-          orElse: () => BotPersonality.adaptive, // Fallback to adaptive
-        );
+        final personality = parseBotPersonalityString(savedPersonalityName);
         botAI.assignPersonality(bot.id, personality);
 
         if (kDebugMode) {
@@ -122,14 +110,17 @@ class BotTurnManager {
           );
         }
       } else {
-        // If no saved personality for this bot, assign a random one
-        final randomPersonality = BotPersonality
-            .values[Random().nextInt(BotPersonality.values.length)];
-        botAI.assignPersonality(bot.id, randomPersonality);
+        // Missing entry for this bot — fall back to settings/name resolution
+        final resolved = resolveBotPersonalities(
+          players: [bot],
+          settings: gameController.gameState.soloSettings,
+        );
+        final personality = resolved[bot.id] ?? BotPersonality.adaptive;
+        botAI.assignPersonality(bot.id, personality);
 
         if (kDebugMode) {
           print(
-            'Bot ${bot.name} (${bot.id}) assigned new personality: $randomPersonality (no saved data)',
+            'Bot ${bot.name} (${bot.id}) assigned personality: $personality (no saved entry)',
           );
         }
       }

--- a/lib/screens/managers/persistence_manager.dart
+++ b/lib/screens/managers/persistence_manager.dart
@@ -4,6 +4,7 @@ import '../../models/player.dart';
 import '../../models/game_state.dart';
 import '../../game/game_controller.dart';
 import '../../ai/enhanced_bot_ai.dart';
+import '../../ai/bot_personality.dart';
 import '../../services/game_save_service.dart';
 import '../../utils/debug_logger.dart';
 import '../../theme/balatro_theme.dart';
@@ -30,9 +31,18 @@ class PersistenceManager {
   /// Save current game state to local storage
   Future<void> saveGameState() async {
     try {
+      final botPersonalities = <String, BotPersonality>{};
+      for (final player in gameController.gameState.players) {
+        if (player.type == PlayerType.bot) {
+          botPersonalities[player.id] = botAI.personalityManager.getPersonality(
+            player.id,
+          );
+        }
+      }
       await GameSaveService.saveGame(
         gameController.gameState,
         gameController.gameSeed,
+        botPersonalities: botPersonalities,
       );
     } catch (e) {
       DebugLogger.error('Failed to save game state: $e');

--- a/lib/screens/managers/persistence_manager.dart
+++ b/lib/screens/managers/persistence_manager.dart
@@ -5,6 +5,7 @@ import '../../models/game_state.dart';
 import '../../game/game_controller.dart';
 import '../../ai/enhanced_bot_ai.dart';
 import '../../ai/bot_personality.dart';
+import '../../config/bot_configurations.dart';
 import '../../services/game_save_service.dart';
 import '../../utils/debug_logger.dart';
 import '../../theme/balatro_theme.dart';
@@ -28,21 +29,25 @@ class PersistenceManager {
     required this.onGameLoaded,
   });
 
+  Map<String, BotPersonality> _liveBotPersonalities() {
+    final botPersonalities = <String, BotPersonality>{};
+    for (final player in gameController.gameState.players) {
+      if (player.type == PlayerType.bot) {
+        botPersonalities[player.id] = botAI.personalityManager.getPersonality(
+          player.id,
+        );
+      }
+    }
+    return botPersonalities;
+  }
+
   /// Save current game state to local storage
   Future<void> saveGameState() async {
     try {
-      final botPersonalities = <String, BotPersonality>{};
-      for (final player in gameController.gameState.players) {
-        if (player.type == PlayerType.bot) {
-          botPersonalities[player.id] = botAI.personalityManager.getPersonality(
-            player.id,
-          );
-        }
-      }
       await GameSaveService.saveGame(
         gameController.gameState,
         gameController.gameSeed,
-        botPersonalities: botPersonalities,
+        botPersonalities: _liveBotPersonalities(),
       );
     } catch (e) {
       DebugLogger.error('Failed to save game state: $e');
@@ -51,16 +56,9 @@ class PersistenceManager {
 
   /// Export current game state with bot personalities
   String exportGameState() {
-    // Collect current bot personalities
-    final botPersonalities = <String, String>{};
-    for (final player in gameController.gameState.players) {
-      if (player.type == PlayerType.bot) {
-        final personality = botAI.personalityManager.getPersonality(player.id);
-        botPersonalities[player.id] = personality.toString();
-      }
-    }
-
-    return gameController.exportGameState(botPersonalities);
+    return gameController.exportGameState(
+      serializeBotPersonalities(_liveBotPersonalities()),
+    );
   }
 
   /// Copy exported game state to clipboard

--- a/lib/services/game_save_service.dart
+++ b/lib/services/game_save_service.dart
@@ -6,6 +6,8 @@ import '../models/player.dart';
 import '../models/card.dart';
 import '../models/meld.dart';
 import '../game/game_controller.dart';
+import '../ai/bot_personality.dart';
+import '../config/bot_configurations.dart';
 import '../config/solo_game_settings.dart';
 
 class GameSaveService {
@@ -13,10 +15,18 @@ class GameSaveService {
   static final _log = Logger('GameSaveService');
 
   /// Save the current game state to local storage
-  static Future<void> saveGame(GameState gameState, int? gameSeed) async {
+  static Future<void> saveGame(
+    GameState gameState,
+    int? gameSeed, {
+    Map<String, BotPersonality>? botPersonalities,
+  }) async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final gameData = _serializeGameState(gameState, gameSeed);
+      final gameData = _serializeGameState(
+        gameState,
+        gameSeed,
+        botPersonalities: botPersonalities,
+      );
       final jsonString = jsonEncode(gameData);
 
       await prefs.setString(_saveKey, jsonString);
@@ -71,8 +81,14 @@ class GameSaveService {
   /// Serialize game state to a JSON-compatible map
   static Map<String, dynamic> _serializeGameState(
     GameState gameState,
-    int? gameSeed,
-  ) {
+    int? gameSeed, {
+    Map<String, BotPersonality>? botPersonalities,
+  }) {
+    final resolved = resolveBotPersonalities(
+      players: gameState.players,
+      settings: gameState.soloSettings,
+      preferred: botPersonalities,
+    );
     return {
       'gameSeed': gameSeed,
       'timestamp': DateTime.now().toIso8601String(),
@@ -97,6 +113,7 @@ class GameSaveService {
       'hasDrawnFromDeck': gameState.hasDrawnFromDeck,
       'hasMelded': gameState.hasMelded,
       'soloSettings': gameState.soloSettings.toJson(),
+      'botPersonalities': serializeBotPersonalities(resolved),
       'finalTurnPhaseActive': gameState.finalTurnPhaseActive,
       'playerWhoWentOutIndex': gameState.playerWhoWentOutIndex,
       'playersAwaitingFinalTurn': gameState.playersAwaitingFinalTurn.toList(),
@@ -167,6 +184,25 @@ class GameSaveService {
       // Clear newly drawn cards since they're not serialized properly
       // This prevents incorrect highlighting after game restore
       gameController.clearAllNewlyDrawnCards();
+
+      // Restore bot personalities from save, or derive for legacy saves
+      final savedPersonalities =
+          (savedData['botPersonalities'] as Map?)?.map(
+            (key, value) => MapEntry(key.toString(), value.toString()),
+          ) ??
+          <String, String>{};
+
+      if (savedPersonalities.isNotEmpty) {
+        gameController.restoredBotPersonalities = savedPersonalities;
+      } else {
+        final derived = resolveBotPersonalities(
+          players: players,
+          settings: soloSettings,
+        );
+        gameController.restoredBotPersonalities = serializeBotPersonalities(
+          derived,
+        );
+      }
 
       return gameController;
     } catch (e) {

--- a/test/services/game_save_personality_restore_test.dart
+++ b/test/services/game_save_personality_restore_test.dart
@@ -30,15 +30,41 @@ void main() {
       Player(id: '3', name: 'Clara', type: PlayerType.bot),
     ];
 
+    GameController buildSueClaraController() {
+      final controller = GameController(
+        players: sueClaraPlayers(),
+        seed: 708121,
+        soloSettings: sueClaraSettings(),
+      );
+      controller.initializeGame();
+      return controller;
+    }
+
+    ({BotTurnManager manager, EnhancedBotAI botAI}) buildTurnManager(
+      GameController controller,
+    ) {
+      final botAI = EnhancedBotAI();
+      final manager = BotTurnManager(
+        gameController: controller,
+        botAI: botAI,
+        onStateChanged: () {},
+        logHumanAction: (_) {},
+        logBotDecision:
+            ({
+              required String botId,
+              required String decision,
+              required String reasoning,
+              Map<String, dynamic>? context,
+              gameStateSnapshot,
+            }) {},
+      );
+      return (manager: manager, botAI: botAI);
+    }
+
     test(
       'autosave includes bot personalities from solo settings order',
       () async {
-        final controller = GameController(
-          players: sueClaraPlayers(),
-          seed: 708121,
-          soloSettings: sueClaraSettings(),
-        );
-        controller.initializeGame();
+        final controller = buildSueClaraController();
 
         await GameSaveService.saveGame(controller.gameState, 708121);
 
@@ -53,12 +79,7 @@ void main() {
     test(
       'Continue restore assigns Sue adaptive and Clara conservative',
       () async {
-        final controller = GameController(
-          players: sueClaraPlayers(),
-          seed: 708121,
-          soloSettings: sueClaraSettings(),
-        );
-        controller.initializeGame();
+        final controller = buildSueClaraController();
         await GameSaveService.saveGame(controller.gameState, 708121);
 
         final restored = await GameController.loadSavedGame();
@@ -72,22 +93,8 @@ void main() {
           equals('BotPersonality.conservative'),
         );
 
-        final botAI = EnhancedBotAI();
-        final turnManager = BotTurnManager(
-          gameController: restored,
-          botAI: botAI,
-          onStateChanged: () {},
-          logHumanAction: (_) {},
-          logBotDecision:
-              ({
-                required String botId,
-                required String decision,
-                required String reasoning,
-                Map<String, dynamic>? context,
-                gameStateSnapshot,
-              }) {},
-        );
-        turnManager.restoreBotPersonalities(restored.restoredBotPersonalities);
+        final (:manager, :botAI) = buildTurnManager(restored);
+        manager.restoreBotPersonalities(restored.restoredBotPersonalities);
 
         expect(
           botAI.personalityManager.getPersonality('2'),
@@ -143,52 +150,14 @@ void main() {
 
     test(
       'partial personality map restores saved entries and fills missing bots',
-      () async {
-        final controller = GameController(
-          players: sueClaraPlayers(),
-          seed: 708121,
-          soloSettings: sueClaraSettings(),
-        );
-        controller.initializeGame();
-        await GameSaveService.saveGame(controller.gameState, 708121);
-
-        final restored = await GameController.loadSavedGame();
-        expect(restored, isNotNull);
-
-        final botAI = EnhancedBotAI();
-        final turnManager = BotTurnManager(
-          gameController: restored!,
-          botAI: botAI,
-          onStateChanged: () {},
-          logHumanAction: (_) {},
-          logBotDecision:
-              ({
-                required String botId,
-                required String decision,
-                required String reasoning,
-                Map<String, dynamic>? context,
-                gameStateSnapshot,
-              }) {},
-        );
+      () {
+        final controller = buildSueClaraController();
+        final (:manager, :botAI) = buildTurnManager(controller);
 
         // Legacy/partial Continue payload: Sue saved, Clara missing.
         // Clara must resolve from full roster (settings/name), not Adaptive default.
-        turnManager.restoreBotPersonalities({'2': 'BotPersonality.adaptive'});
+        manager.restoreBotPersonalities({'2': 'BotPersonality.adaptive'});
 
-        expect(
-          botAI.personalityManager.getPersonality('2'),
-          equals(BotPersonality.adaptive),
-        );
-        expect(
-          botAI.personalityManager.getPersonality('3'),
-          equals(BotPersonality.conservative),
-        );
-
-        // Malformed saved value falls back to Adaptive while valid entries stick.
-        turnManager.restoreBotPersonalities({
-          '2': 'BotPersonality.notARealPersonality',
-          '3': 'BotPersonality.conservative',
-        });
         expect(
           botAI.personalityManager.getPersonality('2'),
           equals(BotPersonality.adaptive),
@@ -199,5 +168,24 @@ void main() {
         );
       },
     );
+
+    test('malformed saved personality falls back to adaptive', () {
+      final controller = buildSueClaraController();
+      final (:manager, :botAI) = buildTurnManager(controller);
+
+      manager.restoreBotPersonalities({
+        '2': 'BotPersonality.notARealPersonality',
+        '3': 'BotPersonality.conservative',
+      });
+
+      expect(
+        botAI.personalityManager.getPersonality('2'),
+        equals(BotPersonality.adaptive),
+      );
+      expect(
+        botAI.personalityManager.getPersonality('3'),
+        equals(BotPersonality.conservative),
+      );
+    });
   });
 }

--- a/test/services/game_save_personality_restore_test.dart
+++ b/test/services/game_save_personality_restore_test.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:hand_foot_game_flutter/ai/bot_personality.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/config/bot_configurations.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/screens/managers/bot_turn_manager.dart';
+import 'package:hand_foot_game_flutter/services/game_save_service.dart';
+
+void main() {
+  group('Continue game personality restore', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    SoloGameSettings sueClaraSettings() => SoloGameSettings(
+      botCount: 2,
+      botPersonalities: [BotPersonality.adaptive, BotPersonality.conservative],
+      enableGoingOutBonus: true,
+      enableFinalTurnAfterGoingOut: true,
+    );
+
+    List<Player> sueClaraPlayers() => [
+      Player(id: '1', name: 'You', type: PlayerType.human),
+      Player(id: '2', name: 'Sue', type: PlayerType.bot),
+      Player(id: '3', name: 'Clara', type: PlayerType.bot),
+    ];
+
+    test(
+      'autosave includes bot personalities from solo settings order',
+      () async {
+        final controller = GameController(
+          players: sueClaraPlayers(),
+          seed: 708121,
+          soloSettings: sueClaraSettings(),
+        );
+        controller.initializeGame();
+
+        await GameSaveService.saveGame(controller.gameState, 708121);
+
+        final saved = await GameSaveService.loadGame();
+        expect(saved, isNotNull);
+        final bp = Map<String, String>.from(saved!['botPersonalities'] as Map);
+        expect(bp['2'], equals('BotPersonality.adaptive'));
+        expect(bp['3'], equals('BotPersonality.conservative'));
+      },
+    );
+
+    test(
+      'Continue restore assigns Sue adaptive and Clara conservative',
+      () async {
+        final controller = GameController(
+          players: sueClaraPlayers(),
+          seed: 708121,
+          soloSettings: sueClaraSettings(),
+        );
+        controller.initializeGame();
+        await GameSaveService.saveGame(controller.gameState, 708121);
+
+        final restored = await GameController.loadSavedGame();
+        expect(restored, isNotNull);
+        expect(
+          restored!.restoredBotPersonalities['2'],
+          equals('BotPersonality.adaptive'),
+        );
+        expect(
+          restored.restoredBotPersonalities['3'],
+          equals('BotPersonality.conservative'),
+        );
+
+        final botAI = EnhancedBotAI();
+        final turnManager = BotTurnManager(
+          gameController: restored,
+          botAI: botAI,
+          onStateChanged: () {},
+          logHumanAction: (_) {},
+          logBotDecision:
+              ({
+                required String botId,
+                required String decision,
+                required String reasoning,
+                Map<String, dynamic>? context,
+                gameStateSnapshot,
+              }) {},
+        );
+        turnManager.restoreBotPersonalities(restored.restoredBotPersonalities);
+
+        expect(
+          botAI.personalityManager.getPersonality('2'),
+          equals(BotPersonality.adaptive),
+        );
+        expect(
+          botAI.personalityManager.getPersonality('3'),
+          equals(BotPersonality.conservative),
+        );
+      },
+    );
+
+    test(
+      'legacy saves without botPersonalities derive from settings/names',
+      () async {
+        final settings = sueClaraSettings();
+        final players = sueClaraPlayers();
+        final controller = GameController(
+          players: players,
+          seed: 708121,
+          soloSettings: settings,
+        );
+        controller.initializeGame();
+        await GameSaveService.saveGame(controller.gameState, 708121);
+
+        final saved = await GameSaveService.loadGame();
+        expect(saved, isNotNull);
+        saved!.remove('botPersonalities');
+
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString('hand_foot_game_save', jsonEncode(saved));
+
+        final restored = GameSaveService.restoreGameController(saved);
+        expect(restored, isNotNull);
+        // Derived from soloSettings after missing map removed from payload
+        expect(
+          restored!.restoredBotPersonalities['2'],
+          equals('BotPersonality.adaptive'),
+        );
+        expect(
+          restored.restoredBotPersonalities['3'],
+          equals('BotPersonality.conservative'),
+        );
+
+        final derived = resolveBotPersonalities(
+          players: players,
+          settings: settings,
+        );
+        expect(derived['3'], equals(BotPersonality.conservative));
+        expect(kBotPersonalityByName['Clara'], BotPersonality.conservative);
+      },
+    );
+
+    test(
+      'unassigned personalities defaulted to adaptive (regression of bug)',
+      () {
+        final botAI = EnhancedBotAI();
+        // Before fix: Continue never assigned personalities → Clara looked Adaptive
+        expect(
+          botAI.personalityManager.getPersonality('3'),
+          equals(BotPersonality.adaptive),
+        );
+
+        botAI.assignPersonality('3', BotPersonality.conservative);
+        expect(
+          botAI.personalityManager.getPersonality('3'),
+          equals(BotPersonality.conservative),
+        );
+      },
+    );
+  });
+}

--- a/test/services/game_save_personality_restore_test.dart
+++ b/test/services/game_save_personality_restore_test.dart
@@ -142,16 +142,57 @@ void main() {
     );
 
     test(
-      'unassigned personalities defaulted to adaptive (regression of bug)',
-      () {
+      'partial personality map restores saved entries and fills missing bots',
+      () async {
+        final controller = GameController(
+          players: sueClaraPlayers(),
+          seed: 708121,
+          soloSettings: sueClaraSettings(),
+        );
+        controller.initializeGame();
+        await GameSaveService.saveGame(controller.gameState, 708121);
+
+        final restored = await GameController.loadSavedGame();
+        expect(restored, isNotNull);
+
         final botAI = EnhancedBotAI();
-        // Before fix: Continue never assigned personalities → Clara looked Adaptive
-        expect(
-          botAI.personalityManager.getPersonality('3'),
-          equals(BotPersonality.adaptive),
+        final turnManager = BotTurnManager(
+          gameController: restored!,
+          botAI: botAI,
+          onStateChanged: () {},
+          logHumanAction: (_) {},
+          logBotDecision:
+              ({
+                required String botId,
+                required String decision,
+                required String reasoning,
+                Map<String, dynamic>? context,
+                gameStateSnapshot,
+              }) {},
         );
 
-        botAI.assignPersonality('3', BotPersonality.conservative);
+        // Legacy/partial Continue payload: Sue saved, Clara missing.
+        // Clara must resolve from full roster (settings/name), not Adaptive default.
+        turnManager.restoreBotPersonalities({'2': 'BotPersonality.adaptive'});
+
+        expect(
+          botAI.personalityManager.getPersonality('2'),
+          equals(BotPersonality.adaptive),
+        );
+        expect(
+          botAI.personalityManager.getPersonality('3'),
+          equals(BotPersonality.conservative),
+        );
+
+        // Malformed saved value falls back to Adaptive while valid entries stick.
+        turnManager.restoreBotPersonalities({
+          '2': 'BotPersonality.notARealPersonality',
+          '3': 'BotPersonality.conservative',
+        });
+        expect(
+          botAI.personalityManager.getPersonality('2'),
+          equals(BotPersonality.adaptive),
+        );
         expect(
           botAI.personalityManager.getPersonality('3'),
           equals(BotPersonality.conservative),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continue from a saved solo game left bot personalities unassigned, so every bot defaulted to **Adaptive**. That made Clara show Sue’s sync-style icon (and play Adaptive AI after resume).

Firestore confirmed session `session_17837967067906790` (seed `708121`) actually ran as **Sue = adaptive**, **Clara = conservative**.

### Changes
- Restore personalities when opening a continued autosave (`GameScreen` Continue path)
- Persist `botPersonalities` in local autosave
- Derive from solo settings / known bot names for legacy saves without the field
- Shared `resolveBotPersonalities` helper + regression tests for Sue/Clara Continue

## Test plan

- [x] `dart format .` (changed files)
- [ ] `flutter analyze` (zero issues)
- [ ] `flutter test` (or `./format_and_test.sh`)
- [x] Targeted tests: `test/services/game_save_personality_restore_test.dart`
- [ ] Manual: start Sue+Clara game, leave, Continue → Clara should show shield (Conservative)

## Checklist

- [x] No secrets, `.env` files, or credential JSON committed
- [x] Behavior changes include or update tests when practical
- [x] Docs updated if this changes contributor or player-facing workflows (N/A)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d52a759-c422-4be1-a8f5-3bef5f11104e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d52a759-c422-4be1-a8f5-3bef5f11104e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot personalities are now saved in game exports and persisted in auto-saves, then restored when continuing solo games.
  * Restoration prefers saved values, otherwise resolves from solo settings (by bot order/name) and finally uses an adaptive default.
* **Bug Fixes**
  * Prevented bot personalities from reverting to inconsistent/random selections after restore, including for partial or malformed saved entries.
* **Tests**
  * Added/expanded coverage for current saves, legacy saves without personality data, partial restores, and unrecognized personality fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->