### PR TITLE
Fix playable hand card highlight clipping on edge cards

### DIFF
--- a/lib/constants/ui_constants.dart
+++ b/lib/constants/ui_constants.dart
@@ -40,7 +40,7 @@ class UIConstants {
 
   /// Horizontal inset for the hand scroller so playable/newly-drawn glow
   /// shadows are not clipped on the leftmost/rightmost cards.
-  static const double handGlowPadding = 24.0;
+  static const double handGlowPadding = 12.0;
 
   // Border radius
   static const double defaultBorderRadius = 8.0;

--- a/lib/constants/ui_constants.dart
+++ b/lib/constants/ui_constants.dart
@@ -40,7 +40,8 @@ class UIConstants {
 
   /// Horizontal inset for the hand scroller so playable/newly-drawn glow
   /// shadows are not clipped on the leftmost/rightmost cards.
-  static const double handGlowPadding = 12.0;
+  /// Must cover playableOuterGlowBlur + playableOuterGlowSpread (12 + 2).
+  static const double handGlowPadding = 14.0;
 
   // Border radius
   static const double defaultBorderRadius = 8.0;

--- a/lib/constants/ui_constants.dart
+++ b/lib/constants/ui_constants.dart
@@ -38,6 +38,10 @@ class UIConstants {
   static const double mediumSpacing = 8.0;
   static const double largeSpacing = 16.0;
 
+  /// Horizontal inset for the hand scroller so playable/newly-drawn glow
+  /// shadows are not clipped on the leftmost/rightmost cards.
+  static const double handGlowPadding = 24.0;
+
   // Border radius
   static const double defaultBorderRadius = 8.0;
   static const double smallBorderRadius = 4.0;

--- a/lib/game/enhanced_multiplayer_controller.dart
+++ b/lib/game/enhanced_multiplayer_controller.dart
@@ -929,6 +929,11 @@ class EnhancedMultiplayerController implements MultiplayerGameInterface {
   }
 
   @override
+  Set<int> getPlayableCardIndices(Player player) {
+    return _gameController.getPlayableCardIndices(player);
+  }
+
+  @override
   Future<void> saveGame() async {
     // Multiplayer games are automatically saved via network sync
     // No local persistence needed

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -526,6 +526,11 @@ class GameController implements GameInterface {
     return _meldManager.getPlayableCards(_gameState.currentPlayer);
   }
 
+  @override
+  Set<int> getPlayableCardIndices(Player player) {
+    return _meldManager.getPlayableCardIndices(player);
+  }
+
   // ============= Game Status and Queries =============
 
   @override

--- a/lib/game/game_interface.dart
+++ b/lib/game/game_interface.dart
@@ -34,6 +34,7 @@ abstract class GameInterface {
   bool canPlayerGoOut();
   List<List<PlayingCard>> findPossibleMelds(Player player);
   List<PlayingCard> getPlayableCards();
+  Set<int> getPlayableCardIndices(Player player);
 
   // Game management
   void initializeGame();

--- a/lib/game/managers/meld_manager.dart
+++ b/lib/game/managers/meld_manager.dart
@@ -275,7 +275,7 @@ class MeldManager {
 
     final hand = player.currentHand;
     final possibleMelds = findPossibleMelds(player);
-    var possibleMeldsNeedWild = false;
+    var shouldHighlightWilds = false;
 
     for (final meld in possibleMelds) {
       final remaining = List<PlayingCard>.from(meld);
@@ -289,14 +289,31 @@ class MeldManager {
         }
       }
       if (meld.any((card) => card.isWild)) {
-        possibleMeldsNeedWild = true;
+        shouldHighlightWilds = true;
       }
+    }
+
+    // findPossibleMelds prefers clean melds when a rank has 3+ naturals, so it
+    // omits dirty alternatives. Wilds remain legal with those ranks (and with
+    // pair+wild candidates already flagged above).
+    if (!shouldHighlightWilds && hand.any((card) => card.isWild)) {
+      final naturalCounts = <CardRank, int>{};
+      for (final card in hand) {
+        if (!card.isWild && card.rank != CardRank.three) {
+          naturalCounts.update(
+            card.rank,
+            (count) => count + 1,
+            ifAbsent: () => 1,
+          );
+        }
+      }
+      shouldHighlightWilds = naturalCounts.values.any((count) => count >= 3);
     }
 
     // findPossibleMelds reuses wildCards.take(...) without consuming, so only
     // the first wild is typically present in meld lists. Light up every wild
     // that could complete a dirty new meld.
-    if (possibleMeldsNeedWild) {
+    if (shouldHighlightWilds) {
       for (int i = 0; i < hand.length; i++) {
         if (hand[i].isWild) {
           playableIndices.add(i);

--- a/lib/game/managers/meld_manager.dart
+++ b/lib/game/managers/meld_manager.dart
@@ -262,6 +262,60 @@ class MeldManager {
     return playableCards.toSet().toList();
   }
 
+  /// Hand indices that should show playable (green) highlight in the UI.
+  ///
+  /// Prefer this over [getPlayableCards] for rendering: identity/`==` on
+  /// [PlayingCard] is suit+rank, so duplicate multi-deck cards cannot be
+  /// keyed reliably by object equality alone.
+  Set<int> getPlayableCardIndices(Player player) {
+    final playableIndices = <int>{};
+    if (_gameState.turnPhase != TurnPhase.meld) {
+      return playableIndices;
+    }
+
+    final hand = player.currentHand;
+    final possibleMelds = findPossibleMelds(player);
+    var possibleMeldsNeedWild = false;
+
+    for (final meld in possibleMelds) {
+      final remaining = List<PlayingCard>.from(meld);
+      for (int i = 0; i < hand.length; i++) {
+        final matchIndex = remaining.indexWhere(
+          (card) => identical(card, hand[i]),
+        );
+        if (matchIndex >= 0) {
+          playableIndices.add(i);
+          remaining.removeAt(matchIndex);
+        }
+      }
+      if (meld.any((card) => card.isWild)) {
+        possibleMeldsNeedWild = true;
+      }
+    }
+
+    // findPossibleMelds reuses wildCards.take(...) without consuming, so only
+    // the first wild is typically present in meld lists. Light up every wild
+    // that could complete a dirty new meld.
+    if (possibleMeldsNeedWild) {
+      for (int i = 0; i < hand.length; i++) {
+        if (hand[i].isWild) {
+          playableIndices.add(i);
+        }
+      }
+    }
+
+    for (int i = 0; i < hand.length; i++) {
+      for (final meld in player.melds) {
+        if (meld.canAddCard(hand[i])) {
+          playableIndices.add(i);
+          break;
+        }
+      }
+    }
+
+    return playableIndices;
+  }
+
   /// Helper to create a new meld or add to existing meld.
   void _createOrAddToMeld(
     Player player,

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -829,39 +829,23 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         .toList();
   }
 
-  bool _isCardPlayable(PlayingCard card) {
+  Set<int> _playableCardIndices(Player humanPlayer) {
     final currentPlayer = ref.read(currentPlayerProvider);
     if (currentPlayer?.type != PlayerType.human) {
-      return false;
+      return {};
     }
 
     final gameState = ref.read(currentGameStateProvider);
     if (gameState?.turnPhase != TurnPhase.meld) {
-      return false;
+      return {};
     }
-
-    final humanPlayer = ref.read(humanPlayerProvider);
-    if (humanPlayer == null) return false;
 
     final controller = _gameController;
-    if (controller == null) return false;
-
-    // Check if this card can be added to any existing meld
-    for (int i = 0; i < humanPlayer.melds.length; i++) {
-      if (humanPlayer.melds[i].canAddCard(card)) {
-        return true;
-      }
+    if (controller == null) {
+      return {};
     }
 
-    // Check if this card can form a new meld
-    final possibleMelds = controller.findPossibleMelds(humanPlayer);
-    for (final meld in possibleMelds) {
-      if (meld.contains(card)) {
-        return true;
-      }
-    }
-
-    return false;
+    return controller.getPlayableCardIndices(humanPlayer);
   }
 
   bool _isGameStuck() {
@@ -1862,7 +1846,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
                             gameState.phase != GamePhase.gameEnd
                         ? _onCardDoubleTap
                         : null,
-                    isCardPlayable: _isCardPlayable,
+                    playableCardIndices: _playableCardIndices(humanPlayer),
                     viewingPlayerMelds: _viewingPlayerMelds,
                     onReturnToHand: () {
                       setState(() {

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -126,24 +126,16 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
     });
   }
 
-  bool _isCardPlayable(PlayingCard card) {
+  Set<int> _playableCardIndices(Player humanPlayer) {
     if (_gameController.gameState.currentPlayer.id != _gameController.userId) {
-      return false;
+      return {};
     }
 
     if (_gameController.gameState.turnPhase != TurnPhase.meld) {
-      return false;
+      return {};
     }
 
-    final currentUserPlayer = _gameController.getCurrentUserPlayer();
-    if (currentUserPlayer == null) return false;
-
-    for (int i = 0; i < currentUserPlayer.melds.length; i++) {
-      if (currentUserPlayer.melds[i].canAddCard(card)) {
-        return true;
-      }
-    }
-    return false;
+    return _gameController.getPlayableCardIndices(humanPlayer);
   }
 
   List<PlayingCard> get _selectedCards {
@@ -722,7 +714,7 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
                         ),
                         onCardTap: _onCardTap,
                         onCardDoubleTap: _onCardDoubleTap,
-                        isCardPlayable: _isCardPlayable,
+                        playableCardIndices: _playableCardIndices(humanPlayer),
                         viewingPlayerMelds: _viewingPlayerMelds,
                         onReturnToHand: () =>
                             setState(() => _viewingPlayerMelds = null),

--- a/lib/widgets/game_hand_display.dart
+++ b/lib/widgets/game_hand_display.dart
@@ -16,6 +16,8 @@ class GameHandDisplay extends StatelessWidget {
   final Function(int)? onCardTap;
   final Function(int)? onCardDoubleTap;
   final bool Function(PlayingCard)? isCardPlayable;
+  /// Preferred playable lookup by hand index (avoids equality edge cases).
+  final Set<int>? playableCardIndices;
   final Player? viewingPlayerMelds;
   final VoidCallback? onReturnToHand;
   final bool isCurrentPlayerTurn;
@@ -31,6 +33,7 @@ class GameHandDisplay extends StatelessWidget {
     this.onCardTap,
     this.onCardDoubleTap,
     this.isCardPlayable,
+    this.playableCardIndices,
     this.viewingPlayerMelds,
     this.onReturnToHand,
     this.isCurrentPlayerTurn = true,
@@ -91,7 +94,11 @@ class GameHandDisplay extends StatelessWidget {
                 child: SingleChildScrollView(
                   controller: handScrollController,
                   scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  // Keep glow shadows visible on edge cards (pairs of 4s/5s etc.)
+                  clipBehavior: Clip.none,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: UIConstants.handGlowPadding,
+                  ),
                   child: SizedBox(
                     width: sizes.handStackWidth(player.currentHand.length),
                     height: stackHeight,
@@ -106,6 +113,9 @@ class GameHandDisplay extends StatelessWidget {
                               context,
                               index,
                             );
+                        final isPlayable = playableCardIndices != null
+                            ? playableCardIndices!.contains(index)
+                            : (isCardPlayable?.call(card) ?? false);
 
                         return Positioned(
                           left: sizes.handCardLeft(index),
@@ -130,7 +140,7 @@ class GameHandDisplay extends StatelessWidget {
                                 isSelected: selectedCardIndices.contains(index),
                                 isKeyboardFocused:
                                     keyboardFocusedCardIndex == index,
-                                isPlayable: isCardPlayable?.call(card) ?? false,
+                                isPlayable: isPlayable,
                                 isNewlyDrawn:
                                     showHighlights &&
                                     index < player.currentHand.length &&

--- a/lib/widgets/game_hand_display.dart
+++ b/lib/widgets/game_hand_display.dart
@@ -49,116 +49,137 @@ class GameHandDisplay extends StatelessWidget {
     final stackHeight =
         sizes.handHeight + sizes.selectionLift + UIConstants.smallSpacing;
 
-    return Opacity(
-      opacity: isCurrentPlayerTurn ? 1.0 : 0.7,
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(8, 4, 8, 6),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-              child: GestureDetector(
-                onTap: onReturnToHand,
-                child: Text(
-                  () {
-                    if (viewingPlayerMelds != null &&
-                        viewingPlayerMelds != player) {
-                      return 'Viewing ${viewingPlayerMelds!.name} — tap to return';
-                    }
-                    return 'Your Hand (${player.currentHand.length})';
-                  }(),
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: FontWeight.bold,
-                    color:
-                        viewingPlayerMelds != null &&
-                            viewingPlayerMelds != player
-                        ? BalatroTheme.neonYellow
-                        : Colors.white,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+    final content = Container(
+      padding: const EdgeInsets.fromLTRB(8, 4, 8, 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+            child: GestureDetector(
+              onTap: onReturnToHand,
+              child: Text(
+                () {
+                  if (viewingPlayerMelds != null &&
+                      viewingPlayerMelds != player) {
+                    return 'Viewing ${viewingPlayerMelds!.name} — tap to return';
+                  }
+                  return 'Your Hand (${player.currentHand.length})';
+                }(),
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.bold,
+                  color:
+                      viewingPlayerMelds != null && viewingPlayerMelds != player
+                      ? BalatroTheme.neonYellow
+                      : Colors.white,
                 ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
             ),
-            SizedBox(
-              height: stackHeight,
-              child: ScrollConfiguration(
-                behavior: ScrollConfiguration.of(context).copyWith(
-                  dragDevices: {
-                    PointerDeviceKind.touch,
-                    PointerDeviceKind.mouse,
-                  },
+          ),
+          SizedBox(
+            height: stackHeight,
+            child: ScrollConfiguration(
+              behavior: ScrollConfiguration.of(context).copyWith(
+                dragDevices: {PointerDeviceKind.touch, PointerDeviceKind.mouse},
+              ),
+              child: SingleChildScrollView(
+                controller: handScrollController,
+                scrollDirection: Axis.horizontal,
+                // Keep glow shadows visible on edge cards (pairs of 4s/5s etc.)
+                clipBehavior: Clip.none,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: UIConstants.handGlowPadding,
                 ),
-                child: SingleChildScrollView(
-                  controller: handScrollController,
-                  scrollDirection: Axis.horizontal,
-                  // Keep glow shadows visible on edge cards (pairs of 4s/5s etc.)
-                  clipBehavior: Clip.none,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: UIConstants.handGlowPadding,
-                  ),
-                  child: SizedBox(
-                    width: sizes.handStackWidth(player.currentHand.length),
-                    height: stackHeight,
-                    child: Stack(
-                      key: handStackKey,
-                      clipBehavior: Clip.none,
-                      children: player.currentHand.asMap().entries.map((entry) {
-                        final index = entry.key;
-                        final card = entry.value;
-                        final hideDuringAnimation =
-                            CardAnimationScope.shouldHideHandCard(
-                              context,
-                              index,
-                            );
-                        final isPlayable = playableCardIndices != null
-                            ? playableCardIndices!.contains(index)
-                            : (isCardPlayable?.call(card) ?? false);
+                child: SizedBox(
+                  width: sizes.handStackWidth(player.currentHand.length),
+                  height: stackHeight,
+                  child: Stack(
+                    key: handStackKey,
+                    clipBehavior: Clip.none,
+                    children: player.currentHand.asMap().entries.map((entry) {
+                      final index = entry.key;
+                      final card = entry.value;
+                      final hideDuringAnimation =
+                          CardAnimationScope.shouldHideHandCard(context, index);
+                      final isPlayable = playableCardIndices != null
+                          ? playableCardIndices!.contains(index)
+                          : (isCardPlayable?.call(card) ?? false);
 
-                        return Positioned(
-                          left: sizes.handCardLeft(index),
-                          bottom: 0,
-                          child: GestureDetector(
-                            onTap: onCardTap != null && !hideDuringAnimation
-                                ? () => onCardTap!(index)
-                                : null,
-                            onDoubleTap:
-                                onCardDoubleTap != null && !hideDuringAnimation
-                                ? () => onCardDoubleTap!(index)
-                                : null,
-                            child: Opacity(
-                              opacity: hideDuringAnimation ? 0 : 1,
-                              child: PlayingCardWidget(
-                                key: ValueKey(
-                                  'hand-${card.rank}-${card.suit}-$index-${viewingPlayerMelds?.id ?? "you"}',
+                      return Positioned(
+                        left: sizes.handCardLeft(index),
+                        bottom: 0,
+                        child: GestureDetector(
+                          onTap: onCardTap != null && !hideDuringAnimation
+                              ? () => onCardTap!(index)
+                              : null,
+                          onDoubleTap:
+                              onCardDoubleTap != null && !hideDuringAnimation
+                              ? () => onCardDoubleTap!(index)
+                              : null,
+                          // Avoid wrapping visible cards in Opacity:
+                          // Opacity creates a compositing layer that clips
+                          // BoxShadow outside the card bounds — burying
+                          // playable/newly-drawn glows under the fan and
+                          // making pairs (e.g. Jacks) look unhighlighted.
+                          child: hideDuringAnimation
+                              ? Opacity(
+                                  opacity: 0,
+                                  child: _buildHandCard(
+                                    card: card,
+                                    index: index,
+                                    sizes: sizes,
+                                    isPlayable: isPlayable,
+                                  ),
+                                )
+                              : _buildHandCard(
+                                  card: card,
+                                  index: index,
+                                  sizes: sizes,
+                                  isPlayable: isPlayable,
                                 ),
-                                card: card,
-                                width: sizes.handWidth,
-                                height: sizes.handHeight,
-                                isSelected: selectedCardIndices.contains(index),
-                                isKeyboardFocused:
-                                    keyboardFocusedCardIndex == index,
-                                isPlayable: isPlayable,
-                                isNewlyDrawn:
-                                    showHighlights &&
-                                    index < player.currentHand.length &&
-                                    player.isCardIndexNewlyDrawn(index),
-                              ),
-                            ),
-                          ),
-                        );
-                      }).toList(),
-                    ),
+                        ),
+                      );
+                    }).toList(),
                   ),
                 ),
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
+    );
+
+    // Only use Opacity when dimming — Opacity(1) still clips child shadows.
+    if (!isCurrentPlayerTurn) {
+      return Opacity(opacity: 0.7, child: content);
+    }
+    return content;
+  }
+
+  Widget _buildHandCard({
+    required PlayingCard card,
+    required int index,
+    required GameCardSizes sizes,
+    required bool isPlayable,
+  }) {
+    return PlayingCardWidget(
+      key: ValueKey(
+        'hand-${card.rank}-${card.suit}-$index-${viewingPlayerMelds?.id ?? "you"}',
+      ),
+      card: card,
+      width: sizes.handWidth,
+      height: sizes.handHeight,
+      isSelected: selectedCardIndices.contains(index),
+      isKeyboardFocused: keyboardFocusedCardIndex == index,
+      isPlayable: isPlayable,
+      isNewlyDrawn:
+          showHighlights &&
+          index < player.currentHand.length &&
+          player.isCardIndexNewlyDrawn(index),
     );
   }
 }

--- a/lib/widgets/game_hand_display.dart
+++ b/lib/widgets/game_hand_display.dart
@@ -16,6 +16,7 @@ class GameHandDisplay extends StatelessWidget {
   final Function(int)? onCardTap;
   final Function(int)? onCardDoubleTap;
   final bool Function(PlayingCard)? isCardPlayable;
+
   /// Preferred playable lookup by hand index (avoids equality edge cases).
   final Set<int>? playableCardIndices;
   final Player? viewingPlayerMelds;

--- a/lib/widgets/playing_card_widget.dart
+++ b/lib/widgets/playing_card_widget.dart
@@ -16,6 +16,15 @@ class PlayingCardWidget extends StatelessWidget {
 
   static const double cardMargin = 2.0;
 
+  /// Shared playable-treatment values (subtle green highlight).
+  static const double playableBorderWidth = 1.0;
+  static const double playableInnerGlowBlur = 6.0;
+  static const double playableInnerGlowSpread = 1.0;
+  static const double playableInnerGlowAlpha = 0.5;
+  static const double playableOuterGlowBlur = 12.0;
+  static const double playableOuterGlowSpread = 2.0;
+  static const double playableOuterGlowAlpha = 0.2;
+
   const PlayingCardWidget({
     super.key,
     required this.card,
@@ -78,6 +87,8 @@ class PlayingCardWidget extends StatelessWidget {
                     ? 2
                     : isNewlyDrawn
                     ? 2
+                    : isPlayable
+                    ? playableBorderWidth
                     : 1,
               ),
               borderRadius: BorderRadius.circular(12),
@@ -116,14 +127,18 @@ class PlayingCardWidget extends StatelessWidget {
                 ] else if (isPlayable) ...[
                   // Playable cards get green glow (original subtle look)
                   BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.5),
-                    blurRadius: 6,
-                    spreadRadius: 1,
+                    color: BalatroTheme.neonGreen.withValues(
+                      alpha: playableInnerGlowAlpha,
+                    ),
+                    blurRadius: playableInnerGlowBlur,
+                    spreadRadius: playableInnerGlowSpread,
                   ),
                   BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.2),
-                    blurRadius: 12,
-                    spreadRadius: 2,
+                    color: BalatroTheme.neonGreen.withValues(
+                      alpha: playableOuterGlowAlpha,
+                    ),
+                    blurRadius: playableOuterGlowBlur,
+                    spreadRadius: playableOuterGlowSpread,
                   ),
                 ] else if (card.isWild) ...[
                   // Wild cards always have subtle rainbow glow

--- a/lib/widgets/playing_card_widget.dart
+++ b/lib/widgets/playing_card_widget.dart
@@ -78,6 +78,8 @@ class PlayingCardWidget extends StatelessWidget {
                     ? 2
                     : isNewlyDrawn
                     ? 2
+                    : isPlayable
+                    ? 2
                     : 1,
               ),
               borderRadius: BorderRadius.circular(12),
@@ -114,16 +116,23 @@ class PlayingCardWidget extends StatelessWidget {
                     spreadRadius: 3,
                   ),
                 ] else if (isPlayable) ...[
-                  // Playable cards get green glow
+                  // Playable cards get a strong green glow (must stay visible
+                  // on edge cards where scroll clipping used to hide softer
+                  // shadows).
                   BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.5),
-                    blurRadius: 6,
+                    color: BalatroTheme.neonGreen.withValues(alpha: 0.75),
+                    blurRadius: 8,
                     spreadRadius: 1,
                   ),
                   BoxShadow(
+                    color: BalatroTheme.neonGreen.withValues(alpha: 0.45),
+                    blurRadius: 16,
+                    spreadRadius: 3,
+                  ),
+                  BoxShadow(
                     color: BalatroTheme.neonGreen.withValues(alpha: 0.2),
-                    blurRadius: 12,
-                    spreadRadius: 2,
+                    blurRadius: 22,
+                    spreadRadius: 5,
                   ),
                 ] else if (card.isWild) ...[
                   // Wild cards always have subtle rainbow glow

--- a/lib/widgets/playing_card_widget.dart
+++ b/lib/widgets/playing_card_widget.dart
@@ -78,8 +78,6 @@ class PlayingCardWidget extends StatelessWidget {
                     ? 2
                     : isNewlyDrawn
                     ? 2
-                    : isPlayable
-                    ? 2
                     : 1,
               ),
               borderRadius: BorderRadius.circular(12),
@@ -116,31 +114,16 @@ class PlayingCardWidget extends StatelessWidget {
                     spreadRadius: 3,
                   ),
                 ] else if (isPlayable) ...[
-                  // Depth shadow so playable cards don't look flatter than
-                  // neighboring unplayable cards in the overlapping fan.
-                  const BoxShadow(
-                    color: Colors.black,
-                    offset: Offset(2, 3),
-                    blurRadius: 8,
+                  // Playable cards get green glow (original subtle look)
+                  BoxShadow(
+                    color: BalatroTheme.neonGreen.withValues(alpha: 0.5),
+                    blurRadius: 6,
                     spreadRadius: 1,
                   ),
-                  // Upward glow: sibling cards overlap to the right and clip
-                  // side/bottom shadows; glow above the fan stays visible.
                   BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.85),
-                    blurRadius: 10,
-                    spreadRadius: 1,
-                    offset: const Offset(0, -4),
-                  ),
-                  BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.55),
-                    blurRadius: 14,
+                    color: BalatroTheme.neonGreen.withValues(alpha: 0.2),
+                    blurRadius: 12,
                     spreadRadius: 2,
-                  ),
-                  BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.25),
-                    blurRadius: 20,
-                    spreadRadius: 4,
                   ),
                 ] else if (card.isWild) ...[
                   // Wild cards always have subtle rainbow glow
@@ -168,61 +151,24 @@ class PlayingCardWidget extends StatelessWidget {
                     spreadRadius: 1,
                   ),
                 ] else ...[
-                  // Strong Balatro styling for hand cards
+                  // Depth only — large cyan/pink outer glows used to be mostly
+                  // invisible (clipped by Opacity) and look noisy once fixed.
                   const BoxShadow(
                     color: Colors.black,
                     offset: Offset(2, 3),
-                    blurRadius: 8,
-                    spreadRadius: 1,
+                    blurRadius: 6,
+                    spreadRadius: 0,
                   ),
                   BoxShadow(
-                    color: BalatroTheme.cardBorder.withValues(alpha: 0.7),
-                    blurRadius: 10,
-                    spreadRadius: 2,
-                  ),
-                  BoxShadow(
-                    color: BalatroTheme.glowColor.withValues(alpha: 0.3),
-                    blurRadius: 14,
-                    spreadRadius: 3,
-                  ),
-                  BoxShadow(
-                    color: BalatroTheme.neonPink.withValues(alpha: 0.2),
-                    blurRadius: 18,
-                    spreadRadius: 2,
+                    color: BalatroTheme.cardBorder.withValues(alpha: 0.45),
+                    blurRadius: 4,
+                    spreadRadius: 0,
                   ),
                 ],
               ],
             ),
             child: Stack(
-              clipBehavior: Clip.none,
               children: [
-                // In-face cue: survives fan overlap and Opacity clipping of
-                // outer shadows (visible on the peeking left strip).
-                if (isPlayable && !isSelected && !isNewlyDrawn)
-                  Positioned(
-                    left: 0,
-                    top: 0,
-                    bottom: 0,
-                    width: 4,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: BalatroTheme.neonGreen.withValues(alpha: 0.95),
-                        borderRadius: const BorderRadius.only(
-                          topLeft: Radius.circular(12),
-                          bottomLeft: Radius.circular(12),
-                        ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: BalatroTheme.neonGreen.withValues(
-                              alpha: 0.7,
-                            ),
-                            blurRadius: 6,
-                            spreadRadius: 0.5,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
                 // Holographic shimmer effect
                 if (card.isWild)
                   Container(

--- a/lib/widgets/playing_card_widget.dart
+++ b/lib/widgets/playing_card_widget.dart
@@ -116,23 +116,31 @@ class PlayingCardWidget extends StatelessWidget {
                     spreadRadius: 3,
                   ),
                 ] else if (isPlayable) ...[
-                  // Playable cards get a strong green glow (must stay visible
-                  // on edge cards where scroll clipping used to hide softer
-                  // shadows).
-                  BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.75),
+                  // Depth shadow so playable cards don't look flatter than
+                  // neighboring unplayable cards in the overlapping fan.
+                  const BoxShadow(
+                    color: Colors.black,
+                    offset: Offset(2, 3),
                     blurRadius: 8,
                     spreadRadius: 1,
                   ),
+                  // Upward glow: sibling cards overlap to the right and clip
+                  // side/bottom shadows; glow above the fan stays visible.
                   BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.45),
-                    blurRadius: 16,
-                    spreadRadius: 3,
+                    color: BalatroTheme.neonGreen.withValues(alpha: 0.85),
+                    blurRadius: 10,
+                    spreadRadius: 1,
+                    offset: const Offset(0, -4),
                   ),
                   BoxShadow(
-                    color: BalatroTheme.neonGreen.withValues(alpha: 0.2),
-                    blurRadius: 22,
-                    spreadRadius: 5,
+                    color: BalatroTheme.neonGreen.withValues(alpha: 0.55),
+                    blurRadius: 14,
+                    spreadRadius: 2,
+                  ),
+                  BoxShadow(
+                    color: BalatroTheme.neonGreen.withValues(alpha: 0.25),
+                    blurRadius: 20,
+                    spreadRadius: 4,
                   ),
                 ] else if (card.isWild) ...[
                   // Wild cards always have subtle rainbow glow
@@ -186,7 +194,35 @@ class PlayingCardWidget extends StatelessWidget {
               ],
             ),
             child: Stack(
+              clipBehavior: Clip.none,
               children: [
+                // In-face cue: survives fan overlap and Opacity clipping of
+                // outer shadows (visible on the peeking left strip).
+                if (isPlayable && !isSelected && !isNewlyDrawn)
+                  Positioned(
+                    left: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: 4,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: BalatroTheme.neonGreen.withValues(alpha: 0.95),
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(12),
+                          bottomLeft: Radius.circular(12),
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: BalatroTheme.neonGreen.withValues(
+                              alpha: 0.7,
+                            ),
+                            blurRadius: 6,
+                            spreadRadius: 0.5,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
                 // Holographic shimmer effect
                 if (card.isWild)
                   Container(

--- a/test/game/managers/import_session_highlight_test.dart
+++ b/test/game/managers/import_session_highlight_test.dart
@@ -15,18 +15,7 @@ void main() {
       final gc = result!.controller;
       final human = gc.gameState.players.first;
 
-      print(
-        'phase=${gc.gameState.turnPhase} req=${gc.gameState.playDownRequirement} pd=${human.hasPlayedDown}',
-      );
-      for (var i = 0; i < human.currentHand.length; i++) {
-        final c = human.currentHand[i];
-        print('[$i] ${c.displayName}');
-      }
-
       final melds = gc.findPossibleMelds(human);
-      for (final m in melds) {
-        print('meld: ${m.map((c) => c.displayName).join(', ')}');
-      }
 
       final jackIndices = <int>[];
       for (var i = 0; i < human.currentHand.length; i++) {
@@ -55,5 +44,6 @@ void main() {
       expect(indices.contains(6), isTrue);
       expect(indices.contains(7), isTrue);
     },
+    tags: ['regression'],
   );
 }

--- a/test/game/managers/import_session_highlight_test.dart
+++ b/test/game/managers/import_session_highlight_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+
+void main() {
+  // Exact export from session_17840009637893789 (user paste).
+  const export =
+      'eyJ2IjozLCJzIjo3OTE1OTEsImciOnsicCI6MSwidCI6MSwiciI6MiwiYyI6MCwiZiI6dHJ1ZSwiZCI6dHJ1ZSwibSI6ZmFsc2UsInEiOjkwfSwicGxheWVycyI6W3siaWQiOiIxIiwibiI6IllvdSIsInQiOjAsInNjIjoyODQwLCJwZCI6ZmFsc2UsImZ0IjpmYWxzZSwibWVsZHMiOltdLCJoIjpbIjQsMCIsIjQsMyIsIjUsMCIsIjUsMyIsIjUsMyIsIjUsMiIsIjcsMCIsIjcsMSIsIjEwLDAiLCIxMCwxIiwiMTEsMSIsIjExLDMiLCIxMSwwIiwiMTIsMSIsIjEyLDIiLCIxMiwwIiwiMCwxIiwiMSwyIiwiMSwzIiwiMSwwIl0sImYiOlsiOSwyIiwiOCwxIiwiMCwxIiwiMTAsMCIsIjEsMiIsIjEyLDIiLCI4LDAiLCIzLDEiLCI2LDAiLCIzLDIiLCIxMiwwIl0sInJzaCI6W3siciI6MSwiY3AiOjU0MCwiY2IiOjMsImRiIjoyLCJwcCI6MCwiZ2IiOjEwMCwidHMiOjI3NDB9XX0seyJpZCI6IjIiLCJuIjoiU3VlIiwidCI6MSwic2MiOjE2MzAsInBkIjpmYWxzZSwiZnQiOmZhbHNlLCJtZWxkcyI6W10sImgiOlsiNCwwIiwiNSwyIiwiNSwzIiwiNSwwIiwiNSwxIiwiNiwyIiwiNywxIiwiNywxIiwiNywzIiwiOCwyIiwiOSwzIiwiOSwyIiwiOSwyIiwiMTAsMyIsIjExLDEiLCIxMSwwIiwiMTIsMyIsIjAsMCJdLCJmIjpbIjEsMCIsIjEwLDIiLCIxMSwyIiwiMTMsIiwiNywzIiwiMTMsIiwiOSwyIiwiNywwIiwiNCwzIiwiMSwyIiwiMTEsMSJdLCJyc2giOlt7InIiOjEsImNwIjo1NTAsImNiIjoxLCJkYiI6MiwicHAiOjIwLCJnYiI6MCwidHMiOjE2MzB9XX0seyJpZCI6IjMiLCJuIjoiQ2xhcmEiLCJ0IjoxLCJzYyI6MTgwNSwicGQiOnRydWUsImZ0IjpmYWxzZSwibWVsZHMiOlt7InQiOjEsImMiOlsiNCwzIiwiNCwyIiwiMSwzIl19LHsidCI6MCwiYyI6WyIwLDEiLCIwLDMiLCIwLDAiXX0seyJ0IjoxLCJjIjpbIjEyLDIiLCIxMiwyIiwiMSwxIl19LHsidCI6MSwiYyI6WyI2LDEiLCI2LDIiLCIxLDEiLCI2LDMiXX1dLCJoIjpbIjgsMSIsIjksMyIsIjksMyIsIjExLDMiLCIxMSwyIl0sImYiOlsiMTMsIiwiNCwyIiwiMTMsIiwiNywwIiwiMSwzIiwiMiwyIiwiMTIsMyIsIjEsMSIsIjUsMSIsIjAsMyIsIjQsMSJdLCJyc2giOlt7InIiOjEsImNwIjo1NDAsImNiIjoyLCJkYiI6MSwicHAiOjM1LCJnYiI6MCwidHMiOjE4MDV9XX1dLCJkZWNrIjp7InN6IjoxMDUsInMiOjc5MTU5MSwidG9wIjoiMCwzIn0sImRwIjpbIjEsMyIsIjIsMiIsIjIsMyIsIjUsMiIsIjMsMCIsIjcsMSIsIjIsMCIsIjgsMyIsIjMsMiIsIjMsMiIsIjIsMyIsIjUsMSIsIjIsMSIsIjYsMyIsIjIsMSIsIjMsMyIsIjYsMCIsIjMsMyIsIjMsMSIsIjksMSIsIjQsMSIsIjcsMCJdLCJyYSI6W3sibSI6IuKPre+4jyBjaG9zZSBub3QgdG8gbWVsZCIsInAiOiJTdWUiLCJ0IjoxNzg0MDAyNjg0ODUyfSx7Im0iOiLwn5eR77iPIGRpc2NhcmRlZCAzIOKZpiIsInAiOiJTdWUiLCJ0IjoxNzg0MDAyNjg3ODYyfSx7Im0iOiLwn460IGRyZXcgMiBjYXJkcyBmcm9tIGRlY2siLCJwIjoiQ2xhcmEiLCJ0IjoxNzg0MDAyNjkxMzc2fSx7Im0iOiJwbGF5ZWQgZG93biB3aXRoIDkwIHBvaW50czogbmV3IGZpdmU6IDUg4pmgLCA1IOKZoywgMiDimaA7IG5ldyBhY2U6IEEg4pmmLCBBIOKZoCwgQSDimaUiLCJwIjoiQ2xhcmEiLCJ0IjoxNzg0MDAyNjkzNjg1fSx7Im0iOiLwn5OLIGNyZWF0ZWQgbmV3IG1lbGQ6IEsg4pmjLCBLIOKZoywgMiDimaYiLCJwIjoiQ2xhcmEiLCJ0IjoxNzg0MDAyNjk0NDk0fSx7Im0iOiLwn5OLIGNyZWF0ZWQgbmV3IG1lbGQ6IDcg4pmmLCA3IOKZoywgMiDimaYiLCJwIjoiQ2xhcmEiLCJ0IjoxNzg0MDAyNjk1Mjk2fSx7Im0iOiLij63vuI8gY2hvc2Ugbm90IHRvIG1lbGQiLCJwIjoiQ2xhcmEiLCJ0IjoxNzg0MDAyNjk2MTAzfSx7Im0iOiLwn5eR77iPIGRpc2NhcmRlZCA0IOKZoCIsInAiOiJDbGFyYSIsInQiOjE3ODQwMDI2OTkxMTN9LHsibSI6IvCfjq8gZHJldzogNyDimaUsIFEg4pmgIiwicCI6IllvdSIsInQiOjE3ODQwMDI3MDk5NzV9LHsibSI6IvCfl5HvuI8gZGlzY2FyZGVkIDcg4pmlIiwicCI6IllvdSIsInQiOjE3ODQwMDI3MTg0NzR9LHsibSI6IvCfjrQgZHJldyAyIGNhcmRzIGZyb20gZGVjayIsInAiOiJTdWUiLCJ0IjoxNzg0MDAyNzE4OTc4fSx7Im0iOiJmb3JjZWQgZGlzY2FyZCBvZiBGb3Vy4pmgIiwicCI6IlN1ZSIsInQiOjE3ODQwMDI3MjEyODh9LHsibSI6IvCfjrQgZHJldyAyIGNhcmRzIGZyb20gZGVjayIsInAiOiJDbGFyYSIsInQiOjE3ODQwMDI3MjE3OTh9LHsibSI6IuKPre+4jyBjaG9zZSBub3QgdG8gbWVsZCIsInAiOiJDbGFyYSIsInQiOjE3ODQwMDI3MjQxMDl9LHsibSI6IvCfl5HvuI8gZGlzY2FyZGVkIDQg4pmmIiwicCI6IkNsYXJhIiwidCI6MTc4NDAwMjcyNzExM30seyJtIjoi8J+OryBkcmV3OiA2IOKZoywgSyDimaUiLCJwIjoiWW91IiwidCI6MTc4NDAwMjc0NDg3Nn0seyJtIjoi8J+Xke+4jyBkaXNjYXJkZWQgMTAg4pmmIiwicCI6IllvdSIsInQiOjE3ODQwMDI3NjE1MDh9LHsibSI6IvCfjrQgZHJldyAyIGNhcmRzIGZyb20gZGVjayIsInAiOiJTdWUiLCJ0IjoxNzg0MDAyNzYyMDE3fSx7Im0iOiJmb3JjZWQgZGlzY2FyZCBvZiBGaXZl4pmmIiwicCI6IlN1ZSIsInQiOjE3ODQwMDI3NjQzMjd9LHsibSI6IvCfjrQgZHJldyAyIGNhcmRzIGZyb20gZGVjayIsInAiOiJDbGFyYSIsInQiOjE3ODQwMDI3NjQ4MzF9LHsibSI6IuKelSBhZGRlZCA3IOKZoCB0byBleGlzdGluZyBtZWxkIiwicCI6IkNsYXJhIiwidCI6MTc4NDAwMjc2NzE0Mn0seyJtIjoi4o+t77iPIGNob3NlIG5vdCB0byBtZWxkIiwicCI6IkNsYXJhIiwidCI6MTc4NDAwMjc2Nzk0NH0seyJtIjoi8J+Xke+4jyBkaXNjYXJkZWQgOCDimaUiLCJwIjoiQ2xhcmEiLCJ0IjoxNzg0MDAyNzcwOTU1fSx7Im0iOiLwn46vIGRyZXc6IEEg4pmmLCBRIOKZpSIsInAiOiJZb3UiLCJ0IjoxNzg0MDAyNzg4MjYwfV0sImJwIjp7IjIiOiJCb3RQZXJzb25hbGl0eS5hZGFwdGl2ZSIsIjMiOiJCb3RQZXJzb25hbGl0eS5jb25zZXJ2YXRpdmUifX0=';
+
+  test(
+    'imported session: Jacks/5s/8s playable with wilds via contains and indices',
+    () {
+      final result = GameController.fromExportJson(export);
+      expect(result, isNotNull);
+      final gc = result!.controller;
+      final human = gc.gameState.players.first;
+
+      print(
+        'phase=${gc.gameState.turnPhase} req=${gc.gameState.playDownRequirement} pd=${human.hasPlayedDown}',
+      );
+      for (var i = 0; i < human.currentHand.length; i++) {
+        final c = human.currentHand[i];
+        print('[$i] ${c.displayName}');
+      }
+
+      final melds = gc.findPossibleMelds(human);
+      for (final m in melds) {
+        print('meld: ${m.map((c) => c.displayName).join(', ')}');
+      }
+
+      final jackIndices = <int>[];
+      for (var i = 0; i < human.currentHand.length; i++) {
+        if (human.currentHand[i].rank == CardRank.jack) {
+          jackIndices.add(i);
+        }
+      }
+      expect(jackIndices, hasLength(2));
+
+      for (final i in jackIndices) {
+        final card = human.currentHand[i];
+        final viaContains = melds.any((m) => m.contains(card));
+        expect(
+          viaContains,
+          isTrue,
+          reason: 'Jack at $i must be in findPossibleMelds (old UI check)',
+        );
+      }
+
+      final indices = gc.getPlayableCardIndices(human);
+      for (final i in jackIndices) {
+        expect(indices.contains(i), isTrue, reason: 'Jack index $i playable');
+      }
+      // First two cards are 5s; indices 6-7 are 8s in this export.
+      expect(indices.contains(0), isTrue);
+      expect(indices.contains(6), isTrue);
+      expect(indices.contains(7), isTrue);
+    },
+  );
+}

--- a/test/game/managers/playable_card_indices_test.dart
+++ b/test/game/managers/playable_card_indices_test.dart
@@ -80,10 +80,9 @@ void main() {
     });
   });
 
-  test('handGlowPadding is large enough for playable glow blur', () {
-    // Guards the UX regression where ~12–16px soft shadows were clipped
-    // by the hand scroller's tiny horizontal inset.
-    const playableGlowBlur = 16.0;
+  test('handGlowPadding covers default playable glow blur', () {
+    // Original playable glow blurRadius max is 12.
+    const playableGlowBlur = 12.0;
     expect(UIConstants.handGlowPadding, greaterThanOrEqualTo(playableGlowBlur));
   });
 }

--- a/test/game/managers/playable_card_indices_test.dart
+++ b/test/game/managers/playable_card_indices_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+void main() {
+  group('getPlayableCardIndices', () {
+    late GameController controller;
+    late Player human;
+
+    setUp(() {
+      controller = GameController(
+        players: [
+          Player(id: '1', name: 'You', type: PlayerType.human),
+          Player(id: '2', name: 'Sue', type: PlayerType.bot),
+          Player(id: '3', name: 'Clara', type: PlayerType.bot),
+        ],
+        seed: 791591,
+      );
+      controller.initializeGame(dealCards: false);
+      human = controller.gameState.players.first;
+      controller.gameState.turnPhase = TurnPhase.meld;
+    });
+
+    test('marks leftmost pair of fives with wilds when hand is rank-sorted', () {
+      // Recreates the reported hand shape: low pair sits at indices 0–1
+      // after sort; 8s and wilds further right. Both pairs must light up.
+      human.hand
+        ..clear()
+        ..addAll([
+          PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          PlayingCard(suit: Suit.spades, rank: CardRank.five),
+          PlayingCard(suit: Suit.hearts, rank: CardRank.six),
+          PlayingCard(suit: Suit.spades, rank: CardRank.six),
+          PlayingCard(suit: Suit.spades, rank: CardRank.six),
+          PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+          PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+          PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
+          PlayingCard(suit: Suit.diamonds, rank: CardRank.ten),
+          PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+          PlayingCard(suit: Suit.diamonds, rank: CardRank.jack),
+          PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+          PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+          PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+          PlayingCard(suit: Suit.spades, rank: CardRank.two),
+          PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+        ]);
+
+      final indices = controller.getPlayableCardIndices(human);
+
+      expect(indices.contains(0), isTrue, reason: 'leftmost 5♥ must be playable');
+      expect(indices.contains(1), isTrue, reason: '5♠ must be playable');
+      expect(indices.contains(6), isTrue, reason: '8♥ must be playable');
+      expect(indices.contains(7), isTrue, reason: '8♦ must be playable');
+      // All wilds usable for dirty melds (not only the first take())
+      expect(indices.contains(14), isTrue);
+      expect(indices.contains(15), isTrue);
+      expect(indices.contains(16), isTrue);
+    });
+
+    test('returns empty set outside meld phase', () {
+      human.hand.addAll([
+        PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+        PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+      ]);
+      controller.gameState.turnPhase = TurnPhase.draw;
+
+      expect(controller.getPlayableCardIndices(human), isEmpty);
+    });
+  });
+
+  test('handGlowPadding is large enough for playable glow blur', () {
+    // Guards the UX regression where ~12–16px soft shadows were clipped
+    // by the hand scroller's tiny horizontal inset.
+    const handGlowPadding = 24.0;
+    const playableGlowBlur = 16.0;
+    expect(handGlowPadding, greaterThanOrEqualTo(playableGlowBlur));
+  });
+}

--- a/test/game/managers/playable_card_indices_test.dart
+++ b/test/game/managers/playable_card_indices_test.dart
@@ -4,6 +4,9 @@ import 'package:hand_foot_game_flutter/game/game_controller.dart';
 import 'package:hand_foot_game_flutter/models/card.dart';
 import 'package:hand_foot_game_flutter/models/game_state.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/widgets/playing_card_widget.dart';
+
+import '../../helpers/game_controller_test_helpers.dart';
 
 void main() {
   group('getPlayableCardIndices', () {
@@ -11,17 +14,9 @@ void main() {
     late Player human;
 
     setUp(() {
-      controller = GameController(
-        players: [
-          Player(id: '1', name: 'You', type: PlayerType.human),
-          Player(id: '2', name: 'Sue', type: PlayerType.bot),
-          Player(id: '3', name: 'Clara', type: PlayerType.bot),
-        ],
-        seed: 791591,
-      );
-      controller.initializeGame(dealCards: false);
-      human = controller.gameState.players.first;
-      controller.gameState.turnPhase = TurnPhase.meld;
+      final setup = createMeldPhaseTestController();
+      controller = setup.controller;
+      human = setup.human;
     });
 
     test(
@@ -66,6 +61,39 @@ void main() {
         expect(indices.contains(15), isTrue);
         expect(indices.contains(16), isTrue);
       },
+      tags: ['meld'],
+    );
+
+    test(
+      'marks wilds playable when findPossibleMelds only returns clean 3+',
+      () {
+        // Three kings → clean-only candidate; wild still legal for a dirty meld.
+        human.hand
+          ..clear()
+          ..addAll([
+            PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+            PlayingCard(suit: Suit.spades, rank: CardRank.king),
+            PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+            PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+            PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+            PlayingCard(suit: Suit.spades, rank: CardRank.two),
+          ]);
+
+        final melds = controller.findPossibleMelds(human);
+        expect(melds.any((m) => m.any((c) => c.isWild)), isFalse);
+
+        final indices = controller.getPlayableCardIndices(human);
+        expect(indices.contains(0), isTrue);
+        expect(indices.contains(1), isTrue);
+        expect(indices.contains(2), isTrue);
+        expect(
+          indices.contains(4),
+          isTrue,
+          reason: 'wild usable for dirty king meld',
+        );
+        expect(indices.contains(5), isTrue, reason: 'all wilds highlighted');
+      },
+      tags: ['meld'],
     );
 
     test('returns empty set outside meld phase', () {
@@ -77,12 +105,13 @@ void main() {
       controller.gameState.turnPhase = TurnPhase.draw;
 
       expect(controller.getPlayableCardIndices(human), isEmpty);
-    });
+    }, tags: ['meld']);
   });
 
   test('handGlowPadding covers default playable glow blur', () {
-    // Original playable glow blurRadius max is 12.
-    const playableGlowBlur = 12.0;
-    expect(UIConstants.handGlowPadding, greaterThanOrEqualTo(playableGlowBlur));
+    expect(
+      UIConstants.handGlowPadding,
+      greaterThanOrEqualTo(PlayingCardWidget.playableOuterGlowBlur),
+    );
   });
 }

--- a/test/game/managers/playable_card_indices_test.dart
+++ b/test/game/managers/playable_card_indices_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/constants/ui_constants.dart';
 import 'package:hand_foot_game_flutter/game/game_controller.dart';
 import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
 import 'package:hand_foot_game_flutter/models/player.dart';
 
 void main() {
@@ -22,42 +24,49 @@ void main() {
       controller.gameState.turnPhase = TurnPhase.meld;
     });
 
-    test('marks leftmost pair of fives with wilds when hand is rank-sorted', () {
-      // Recreates the reported hand shape: low pair sits at indices 0–1
-      // after sort; 8s and wilds further right. Both pairs must light up.
-      human.hand
-        ..clear()
-        ..addAll([
-          PlayingCard(suit: Suit.hearts, rank: CardRank.five),
-          PlayingCard(suit: Suit.spades, rank: CardRank.five),
-          PlayingCard(suit: Suit.hearts, rank: CardRank.six),
-          PlayingCard(suit: Suit.spades, rank: CardRank.six),
-          PlayingCard(suit: Suit.spades, rank: CardRank.six),
-          PlayingCard(suit: Suit.spades, rank: CardRank.seven),
-          PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
-          PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
-          PlayingCard(suit: Suit.diamonds, rank: CardRank.ten),
-          PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
-          PlayingCard(suit: Suit.diamonds, rank: CardRank.jack),
-          PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
-          PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
-          PlayingCard(suit: Suit.clubs, rank: CardRank.king),
-          PlayingCard(suit: Suit.clubs, rank: CardRank.two),
-          PlayingCard(suit: Suit.spades, rank: CardRank.two),
-          PlayingCard(suit: Suit.hearts, rank: CardRank.two),
-        ]);
+    test(
+      'marks leftmost pair of fives with wilds when hand is rank-sorted',
+      () {
+        // Recreates the reported hand shape: low pair sits at indices 0–1
+        // after sort; 8s and wilds further right. Both pairs must light up.
+        human.hand
+          ..clear()
+          ..addAll([
+            PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+            PlayingCard(suit: Suit.spades, rank: CardRank.five),
+            PlayingCard(suit: Suit.hearts, rank: CardRank.six),
+            PlayingCard(suit: Suit.spades, rank: CardRank.six),
+            PlayingCard(suit: Suit.spades, rank: CardRank.six),
+            PlayingCard(suit: Suit.spades, rank: CardRank.seven),
+            PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+            PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
+            PlayingCard(suit: Suit.diamonds, rank: CardRank.ten),
+            PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+            PlayingCard(suit: Suit.diamonds, rank: CardRank.jack),
+            PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+            PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+            PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+            PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+            PlayingCard(suit: Suit.spades, rank: CardRank.two),
+            PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+          ]);
 
-      final indices = controller.getPlayableCardIndices(human);
+        final indices = controller.getPlayableCardIndices(human);
 
-      expect(indices.contains(0), isTrue, reason: 'leftmost 5♥ must be playable');
-      expect(indices.contains(1), isTrue, reason: '5♠ must be playable');
-      expect(indices.contains(6), isTrue, reason: '8♥ must be playable');
-      expect(indices.contains(7), isTrue, reason: '8♦ must be playable');
-      // All wilds usable for dirty melds (not only the first take())
-      expect(indices.contains(14), isTrue);
-      expect(indices.contains(15), isTrue);
-      expect(indices.contains(16), isTrue);
-    });
+        expect(
+          indices.contains(0),
+          isTrue,
+          reason: 'leftmost 5♥ must be playable',
+        );
+        expect(indices.contains(1), isTrue, reason: '5♠ must be playable');
+        expect(indices.contains(6), isTrue, reason: '8♥ must be playable');
+        expect(indices.contains(7), isTrue, reason: '8♦ must be playable');
+        // All wilds usable for dirty melds (not only the first take())
+        expect(indices.contains(14), isTrue);
+        expect(indices.contains(15), isTrue);
+        expect(indices.contains(16), isTrue);
+      },
+    );
 
     test('returns empty set outside meld phase', () {
       human.hand.addAll([
@@ -74,8 +83,7 @@ void main() {
   test('handGlowPadding is large enough for playable glow blur', () {
     // Guards the UX regression where ~12–16px soft shadows were clipped
     // by the hand scroller's tiny horizontal inset.
-    const handGlowPadding = 24.0;
     const playableGlowBlur = 16.0;
-    expect(handGlowPadding, greaterThanOrEqualTo(playableGlowBlur));
+    expect(UIConstants.handGlowPadding, greaterThanOrEqualTo(playableGlowBlur));
   });
 }

--- a/test/game/managers/playable_card_indices_test.dart
+++ b/test/game/managers/playable_card_indices_test.dart
@@ -48,18 +48,15 @@ void main() {
 
         final indices = controller.getPlayableCardIndices(human);
 
+        // 5s/8s/Jacks/Kings (dirty with wilds), clean 6s, all wilds.
+        // Not playable: lone 7, 10, and Q.
         expect(
-          indices.contains(0),
-          isTrue,
-          reason: 'leftmost 5♥ must be playable',
+          indices,
+          equals({0, 1, 2, 3, 4, 6, 7, 9, 10, 12, 13, 14, 15, 16}),
         );
-        expect(indices.contains(1), isTrue, reason: '5♠ must be playable');
-        expect(indices.contains(6), isTrue, reason: '8♥ must be playable');
-        expect(indices.contains(7), isTrue, reason: '8♦ must be playable');
-        // All wilds usable for dirty melds (not only the first take())
-        expect(indices.contains(14), isTrue);
-        expect(indices.contains(15), isTrue);
-        expect(indices.contains(16), isTrue);
+        expect(indices.contains(5), isFalse, reason: 'lone 7 not playable');
+        expect(indices.contains(8), isFalse, reason: 'lone 10 not playable');
+        expect(indices.contains(11), isFalse, reason: 'lone Q not playable');
       },
       tags: ['meld'],
     );
@@ -83,15 +80,8 @@ void main() {
         expect(melds.any((m) => m.any((c) => c.isWild)), isFalse);
 
         final indices = controller.getPlayableCardIndices(human);
-        expect(indices.contains(0), isTrue);
-        expect(indices.contains(1), isTrue);
-        expect(indices.contains(2), isTrue);
-        expect(
-          indices.contains(4),
-          isTrue,
-          reason: 'wild usable for dirty king meld',
-        );
-        expect(indices.contains(5), isTrue, reason: 'all wilds highlighted');
+        expect(indices, equals({0, 1, 2, 4, 5}));
+        expect(indices.contains(3), isFalse, reason: 'lone ace not playable');
       },
       tags: ['meld'],
     );
@@ -109,9 +99,12 @@ void main() {
   });
 
   test('handGlowPadding covers default playable glow blur', () {
+    const playableGlowExtent =
+        PlayingCardWidget.playableOuterGlowBlur +
+        PlayingCardWidget.playableOuterGlowSpread;
     expect(
       UIConstants.handGlowPadding,
-      greaterThanOrEqualTo(PlayingCardWidget.playableOuterGlowBlur),
+      greaterThanOrEqualTo(playableGlowExtent),
     );
   });
 }

--- a/test/helpers/game_controller_test_helpers.dart
+++ b/test/helpers/game_controller_test_helpers.dart
@@ -1,0 +1,21 @@
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+/// Shared solo-game setup for playable-highlight regression tests.
+({GameController controller, Player human}) createMeldPhaseTestController({
+  int seed = 791591,
+}) {
+  final controller = GameController(
+    players: [
+      Player(id: '1', name: 'You', type: PlayerType.human),
+      Player(id: '2', name: 'Sue', type: PlayerType.bot),
+      Player(id: '3', name: 'Clara', type: PlayerType.bot),
+    ],
+    seed: seed,
+  );
+  controller.initializeGame(dealCards: false);
+  final human = controller.gameState.players.first;
+  controller.gameState.turnPhase = TurnPhase.meld;
+  return (controller: controller, human: human);
+}

--- a/test/widgets/game_hand_playable_highlight_test.dart
+++ b/test/widgets/game_hand_playable_highlight_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+import 'package:hand_foot_game_flutter/theme/balatro_theme.dart';
+import 'package:hand_foot_game_flutter/widgets/game_hand_display.dart';
+import 'package:hand_foot_game_flutter/widgets/playing_card_widget.dart';
+
+void main() {
+  testWidgets(
+    'fan hand marks dirty-meld pairs including Jacks as playable without Opacity(1)',
+    (tester) async {
+      final controller = GameController(
+        players: [
+          Player(id: '1', name: 'You', type: PlayerType.human),
+          Player(id: '2', name: 'Sue', type: PlayerType.bot),
+          Player(id: '3', name: 'Clara', type: PlayerType.bot),
+        ],
+        seed: 791591,
+      );
+      controller.initializeGame(dealCards: false);
+      final human = controller.gameState.players.first;
+      controller.gameState.turnPhase = TurnPhase.meld;
+
+      human.hand
+        ..clear()
+        ..addAll([
+          PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          PlayingCard(suit: Suit.spades, rank: CardRank.five),
+          PlayingCard(suit: Suit.hearts, rank: CardRank.six),
+          PlayingCard(suit: Suit.spades, rank: CardRank.six),
+          PlayingCard(suit: Suit.clubs, rank: CardRank.six),
+          PlayingCard(suit: Suit.hearts, rank: CardRank.eight),
+          PlayingCard(suit: Suit.diamonds, rank: CardRank.eight),
+          PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+          PlayingCard(suit: Suit.diamonds, rank: CardRank.jack),
+          PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+          PlayingCard(suit: Suit.spades, rank: CardRank.two),
+        ]);
+
+      final playable = controller.getPlayableCardIndices(human);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: BalatroTheme.testTheme,
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 200,
+              child: GameHandDisplay(
+                player: human,
+                selectedCardIndices: const [],
+                playableCardIndices: playable,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final cards = tester
+          .widgetList<PlayingCardWidget>(find.byType(PlayingCardWidget))
+          .toList();
+      expect(cards, hasLength(human.hand.length));
+
+      PlayingCardWidget cardAt(int i) => cards[i];
+
+      expect(cardAt(0).isPlayable, isTrue, reason: '5♥ dirty meld');
+      expect(cardAt(5).isPlayable, isTrue, reason: '8♥ dirty meld');
+      expect(cardAt(7).isPlayable, isTrue, reason: 'J♥ mid-hand dirty meld');
+      expect(cardAt(8).isPlayable, isTrue, reason: 'J♦ dirty meld');
+      expect(cardAt(2).isPlayable, isTrue, reason: 'clean 6s');
+
+      // Visible cards must not sit under Opacity(1) (clips outer glow).
+      final opacityWidgets = tester.widgetList<Opacity>(find.byType(Opacity));
+      for (final opacity in opacityWidgets) {
+        expect(
+          opacity.opacity,
+          isNot(1.0),
+          reason: 'Opacity(1) clips playable BoxShadows — use bare widget',
+        );
+      }
+    },
+  );
+}

--- a/test/widgets/game_hand_playable_highlight_test.dart
+++ b/test/widgets/game_hand_playable_highlight_test.dart
@@ -1,28 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hand_foot_game_flutter/game/game_controller.dart';
 import 'package:hand_foot_game_flutter/models/card.dart';
-import 'package:hand_foot_game_flutter/models/game_state.dart';
-import 'package:hand_foot_game_flutter/models/player.dart';
 import 'package:hand_foot_game_flutter/theme/balatro_theme.dart';
+import 'package:hand_foot_game_flutter/widgets/card_animation_host.dart';
 import 'package:hand_foot_game_flutter/widgets/game_hand_display.dart';
 import 'package:hand_foot_game_flutter/widgets/playing_card_widget.dart';
+
+import '../helpers/game_controller_test_helpers.dart';
 
 void main() {
   testWidgets(
     'fan hand marks dirty-meld pairs including Jacks as playable without Opacity(1)',
     (tester) async {
-      final controller = GameController(
-        players: [
-          Player(id: '1', name: 'You', type: PlayerType.human),
-          Player(id: '2', name: 'Sue', type: PlayerType.bot),
-          Player(id: '3', name: 'Clara', type: PlayerType.bot),
-        ],
-        seed: 791591,
-      );
-      controller.initializeGame(dealCards: false);
-      final human = controller.gameState.players.first;
-      controller.gameState.turnPhase = TurnPhase.meld;
+      final setup = createMeldPhaseTestController();
+      final controller = setup.controller;
+      final human = setup.human;
 
       human.hand
         ..clear()
@@ -46,13 +38,19 @@ void main() {
         MaterialApp(
           theme: BalatroTheme.testTheme,
           home: Scaffold(
-            body: SizedBox(
-              width: 800,
-              height: 200,
-              child: GameHandDisplay(
-                player: human,
-                selectedCardIndices: const [],
-                playableCardIndices: playable,
+            body: CardAnimationScope(
+              isAnimating: true,
+              // Hide one hand card so GameHandDisplay wraps it in Opacity(0),
+              // proving we never use Opacity(1) for visible cards.
+              hiddenHandIndices: const {0},
+              child: SizedBox(
+                width: 800,
+                height: 200,
+                child: GameHandDisplay(
+                  player: human,
+                  selectedCardIndices: const [],
+                  playableCardIndices: playable,
+                ),
               ),
             ),
           ),
@@ -73,15 +71,17 @@ void main() {
       expect(cardAt(8).isPlayable, isTrue, reason: 'J♦ dirty meld');
       expect(cardAt(2).isPlayable, isTrue, reason: 'clean 6s');
 
-      // Visible cards must not sit under Opacity(1) (clips outer glow).
-      final opacityWidgets = tester.widgetList<Opacity>(find.byType(Opacity));
-      for (final opacity in opacityWidgets) {
-        expect(
-          opacity.opacity,
-          isNot(1.0),
-          reason: 'Opacity(1) clips playable BoxShadows — use bare widget',
-        );
-      }
+      final opacityFinder = find.descendant(
+        of: find.byType(GameHandDisplay),
+        matching: find.byType(Opacity),
+      );
+      expect(opacityFinder, findsOneWidget);
+      expect(
+        tester.widget<Opacity>(opacityFinder).opacity,
+        0.0,
+        reason: 'hidden animating card uses Opacity(0), never Opacity(1)',
+      );
     },
+    tags: ['widget'],
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes intermittent missing green playable highlights on leftmost hand cards (e.g. pairs of 5s) while middle ranks still glowed.

Root cause was UX, not meld rules: after rank-sort, low pairs sit at the left edge of the hand scroller, whose tiny inset + default clip hid soft playable glow.

## Changes
- Add `handGlowPadding` and `Clip.none` on the hand `SingleChildScrollView`
- Strengthen playable green border/glow on `PlayingCardWidget`
- Add `getPlayableCardIndices` and wire solo/multiplayer hand UI to index-based highlighting (also lights all wilds usable for dirty melds)
- Regression tests for the reported hand shape + glow padding guard

## Test plan
- [ ] `dart format --set-exit-if-changed .`
- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] Manual: PLAY SOLO, meld phase with a leftmost pair + wild — 5s (or 4s) should show green glow like higher pairs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59c1541a-4b4b-4b41-9d5c-d4527ecaf2cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59c1541a-4b4b-4b41-9d5c-d4527ecaf2cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playable cards are now computed in advance and highlighted during the meld phase, including wild-card highlights and cards that complete both new and existing melds.
  * Enhanced hand/“playable” glow styling to reduce edge clipping and improve visual consistency.
* **Bug Fixes**
  * Corrected playable-card detection for dirty meld combinations, including Jack-related cases.
* **Tests**
  * Added/expanded regression and widget coverage for playable-card detection, imported-game behavior, and in-hand playable highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->