### PR TITLE
Fix bots dumping max cards on final turn after go-out

### DIFF
--- a/lib/ai/bot_meld_analyzer.dart
+++ b/lib/ai/bot_meld_analyzer.dart
@@ -21,6 +21,7 @@ class BotMeldAnalyzer {
   // Cached results for performance
   List<List<PlayingCard>>? _cachedPossibleMelds;
   String? _cachedPlayerId;
+  String? _cachedHandFingerprint;
 
   BotMeldAnalyzer();
 
@@ -29,14 +30,21 @@ class BotMeldAnalyzer {
     Player bot,
     GameController controller,
   ) {
-    // Use cached result if available for the same player
-    if (_cachedPossibleMelds != null && _cachedPlayerId == bot.id) {
+    final handFingerprint = bot.currentHand
+        .map((c) => '${c.rank.index}:${c.suit?.index ?? -1}')
+        .join(',');
+
+    // Use cached result only when player AND hand contents match
+    if (_cachedPossibleMelds != null &&
+        _cachedPlayerId == bot.id &&
+        _cachedHandFingerprint == handFingerprint) {
       return _cachedPossibleMelds!;
     }
 
     // Calculate and cache new result
     _cachedPossibleMelds = controller.findPossibleMelds(bot);
     _cachedPlayerId = bot.id;
+    _cachedHandFingerprint = handFingerprint;
 
     return _cachedPossibleMelds!;
   }
@@ -45,6 +53,7 @@ class BotMeldAnalyzer {
   void clearCache() {
     _cachedPossibleMelds = null;
     _cachedPlayerId = null;
+    _cachedHandFingerprint = null;
   }
 
   /// Choose the largest meld from a list of possible melds

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -2565,6 +2565,10 @@ class EnhancedBotAI {
   }
 
   /// On final turn after another player went out: meld all scorable cards.
+  ///
+  /// Priority while still on the hand pile is emptying into the foot (so foot
+  /// cards can still be played this turn). Once on foot — or after play-down —
+  /// maximize points via book completion and dumping every legal card.
   BotDecision _makeFinalTurnScoringDecision(
     Player bot,
     BotGameContext context,
@@ -2597,52 +2601,188 @@ class EnhancedBotAI {
           return BotDecision(action: 'noMeld');
         }
 
-        final playAll = _checkCanPlayAllCards(bot, context);
-        if (playAll != null) {
-          return playAll;
+        // Still on hand pile: clear it completely via melds so foot pickup
+        // happens mid-turn (discarding the last hand card ends the turn).
+        if (!bot.hasPickedUpFoot) {
+          final handToFoot = _makeFinalTurnHandToFootDecision(bot, context);
+          if (handToFoot != null) {
+            return handToFoot;
+          }
         }
 
-        // Dump every card that can attach to existing melds (incl. wilds).
-        final cardsToAdd = _findFinalTurnAdditions(bot, controller);
-        if (cardsToAdd.isNotEmpty) {
-          return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
-        }
-
-        final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
-          bot,
-          controller,
-        );
-        final playableMelds = maximalMelds
-            .where((meld) => _meldCardsStillInHand(bot, meld))
-            .toList();
-        if (playableMelds.length >= 2) {
-          return BotDecision(
-            action: 'createMultipleMelds',
-            data: playableMelds,
-          );
-        }
-        if (playableMelds.length == 1) {
-          return BotDecision(action: 'createMeld', data: playableMelds.first);
-        }
-
-        final possibleMelds = _meldAnalyzer
-            .getPossibleMelds(bot, controller)
-            .where((meld) => _meldCardsStillInHand(bot, meld))
-            .toList();
-        if (possibleMelds.isNotEmpty) {
-          return BotDecision(
-            action: 'createMeld',
-            data: _meldAnalyzer.findBestMeld(
-              possibleMelds,
-              bot: bot,
-              preferLarger: true,
-            ),
-          );
-        }
-        return BotDecision(action: 'noMeld');
+        return _makeFinalTurnPointMaxDecision(bot, context, controller);
       case TurnPhase.discard:
         return _makeFinalTurnDiscardDecision(bot);
     }
+  }
+
+  /// Empty the hand pile into the foot on the final turn, using wilds for new
+  /// melds when that clears more cards than sprinkling them onto existing ones.
+  BotDecision? _makeFinalTurnHandToFootDecision(
+    Player bot,
+    BotGameContext context,
+  ) {
+    final controller = context.controller as GameController?;
+    if (controller == null) {
+      return null;
+    }
+
+    final playAll = _checkCanPlayAllCards(bot, context);
+    if (playAll != null) {
+      DebugLogger.botDebug(
+        bot.id,
+        bot.name,
+        'FINAL TURN: emptying hand pile into foot (play-all)',
+      );
+      return playAll;
+    }
+
+    // Complete books first — big score and fewer cards left toward empty.
+    final bookCompleting = _findFinalTurnBookCompletingAdditions(
+      bot,
+      controller,
+    );
+    if (bookCompleting.isNotEmpty) {
+      return BotDecision(action: 'addToMeld', data: bookCompleting.first);
+    }
+
+    // Create melds (incl. 2 naturals + wild) before dumping wilds onto piles —
+    // otherwise 2 Jacks + wild never becomes a meld and the hand stays stuck.
+    final createDecision = _makeFinalTurnCreateMeldDecision(bot, controller);
+    if (createDecision != null) {
+      DebugLogger.botDebug(
+        bot.id,
+        bot.name,
+        'FINAL TURN: creating meld(s) to reach foot',
+      );
+      return createDecision;
+    }
+
+    // Natural (and leftover wild) adds that shrink the hand pile.
+    final cardsToAdd = _findFinalTurnAdditions(bot, controller);
+    if (cardsToAdd.isNotEmpty) {
+      return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+    }
+
+    return null;
+  }
+
+  /// Maximize points: finish books, dump every legal card, create volume melds.
+  BotDecision _makeFinalTurnPointMaxDecision(
+    Player bot,
+    BotGameContext context,
+    GameController controller,
+  ) {
+    final playAll = _checkCanPlayAllCards(bot, context);
+    if (playAll != null) {
+      return playAll;
+    }
+
+    final bookCompleting = _findFinalTurnBookCompletingAdditions(
+      bot,
+      controller,
+    );
+    if (bookCompleting.isNotEmpty) {
+      return BotDecision(action: 'addToMeld', data: bookCompleting.first);
+    }
+
+    final cardsToAdd = _findFinalTurnAdditions(bot, controller);
+    if (cardsToAdd.isNotEmpty) {
+      return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+    }
+
+    final createDecision = _makeFinalTurnCreateMeldDecision(bot, controller);
+    if (createDecision != null) {
+      return createDecision;
+    }
+
+    return BotDecision(action: 'noMeld');
+  }
+
+  BotDecision? _makeFinalTurnCreateMeldDecision(
+    Player bot,
+    GameController controller,
+  ) {
+    final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
+      bot,
+      controller,
+    );
+    final playableMelds = maximalMelds
+        .where((meld) => _meldCardsStillInHand(bot, meld))
+        .toList();
+    if (playableMelds.length >= 2) {
+      return BotDecision(action: 'createMultipleMelds', data: playableMelds);
+    }
+    if (playableMelds.length == 1) {
+      return BotDecision(action: 'createMeld', data: playableMelds.first);
+    }
+
+    final possibleMelds = _meldAnalyzer
+        .getPossibleMelds(bot, controller)
+        .where((meld) => _meldCardsStillInHand(bot, meld))
+        .toList();
+    if (possibleMelds.isEmpty) {
+      return null;
+    }
+
+    // Prefer the meld that removes the most cards / becomes a book.
+    possibleMelds.sort((a, b) {
+      final bookA = a.length >= GameConfig.bookSize ? 1 : 0;
+      final bookB = b.length >= GameConfig.bookSize ? 1 : 0;
+      if (bookA != bookB) {
+        return bookB.compareTo(bookA);
+      }
+      final bySize = b.length.compareTo(a.length);
+      if (bySize != 0) {
+        return bySize;
+      }
+      final pointsA = a.fold<int>(0, (sum, c) => sum + c.pointValue);
+      final pointsB = b.fold<int>(0, (sum, c) => sum + c.pointValue);
+      return pointsB.compareTo(pointsA);
+    });
+
+    return BotDecision(
+      action: 'createMeld',
+      data: _meldAnalyzer.findBestMeld(
+        possibleMelds,
+        bot: bot,
+        preferLarger: true,
+      ),
+    );
+  }
+
+  /// Adds that turn a 6-card meld into a book (clean preferred — 500 vs 300).
+  List<Map<String, dynamic>> _findFinalTurnBookCompletingAdditions(
+    Player bot,
+    GameController controller,
+  ) {
+    final additions = _findFinalTurnAdditions(bot, controller);
+    final completing = additions.where((addition) {
+      final meld = addition['meld'] as Meld;
+      final card = addition['card'] as PlayingCard;
+      if (meld.cards.length != GameConfig.bookSize - 1) {
+        return false;
+      }
+      // Never complete a clean near-book with a wild (spoils the 500 bonus).
+      if (card.isWild && !meld.cards.any((c) => c.isWild)) {
+        return false;
+      }
+      return true;
+    }).toList();
+
+    completing.sort((a, b) {
+      final meldA = a['meld'] as Meld;
+      final meldB = b['meld'] as Meld;
+      final cardA = a['card'] as PlayingCard;
+      final cardB = b['card'] as PlayingCard;
+      final cleanA = !meldA.cards.any((c) => c.isWild) && !cardA.isWild;
+      final cleanB = !meldB.cards.any((c) => c.isWild) && !cardB.isWild;
+      if (cleanA != cleanB) {
+        return cleanA ? -1 : 1;
+      }
+      return cardB.pointValue.compareTo(cardA.pointValue);
+    });
+    return completing;
   }
 
   /// Prefer additions that shrink the penalty pile without wrecking a clean book.
@@ -2665,12 +2805,28 @@ class EnhancedBotAI {
       if (card.isWild && meld.isClean) {
         return false;
       }
+      // Don't spoil an all-natural pile that is close to a clean book.
+      if (card.isWild &&
+          !meld.cards.any((c) => c.isWild) &&
+          meld.cards.length >= 5) {
+        return false;
+      }
       return true;
     }).toList();
 
     ranked.sort((a, b) {
       final cardA = a['card'] as PlayingCard;
       final cardB = b['card'] as PlayingCard;
+      final meldA = a['meld'] as Meld;
+      final meldB = b['meld'] as Meld;
+
+      // Near-book progression beats raw card points.
+      final nearBookA = meldA.cards.length >= GameConfig.bookSize - 1 ? 1 : 0;
+      final nearBookB = meldB.cards.length >= GameConfig.bookSize - 1 ? 1 : 0;
+      if (nearBookA != nearBookB) {
+        return nearBookB.compareTo(nearBookA);
+      }
+
       final byPoints = cardB.pointValue.compareTo(cardA.pointValue);
       if (byPoints != 0) {
         return byPoints;
@@ -2710,6 +2866,12 @@ class EnhancedBotAI {
     if (threes.isNotEmpty) {
       threes.sort((a, b) => a.pointValue.compareTo(b.pointValue));
       return BotDecision(action: 'discard', data: threes.first);
+    }
+
+    // Last card on the hand pile: discard to pick up foot (turn still ends,
+    // but the discarded card is no longer a held penalty).
+    if (!bot.hasPickedUpFoot && hand.length == 1) {
+      return BotDecision(action: 'discard', data: hand.first);
     }
 
     hand.sort((a, b) => b.pointValue.compareTo(a.pointValue));

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -96,6 +96,14 @@ class EnhancedBotAI {
       // Set context for personality-based decisions
       _personalityManager.setCurrentPlayerContext(bot.id);
 
+      // Clear meld cache whenever hand/meld state may have changed between
+      // decision iterations (must run before final-turn early return).
+      if (gameState.turnPhase == TurnPhase.meld || gameState.hasDrawnFromDeck) {
+        _meldAnalyzer.clearCache();
+        _cachedPossibleMelds = null;
+        _lastMeldCacheKey = null;
+      }
+
       // Final turn after another player went out — maximize melded points, no holding.
       if (gameState.finalTurnPhaseActive &&
           gameState.isPlayerAwaitingFinalTurn(bot)) {
@@ -135,11 +143,6 @@ class EnhancedBotAI {
       // Update game analysis
       _gameAnalyzer.updateOpponentAnalysis(gameState, bot);
       _gameAnalyzer.incrementTurnCount(bot.id);
-
-      // Clear meld cache if needed
-      if (gameState.turnPhase == TurnPhase.meld || gameState.hasDrawnFromDeck) {
-        _meldAnalyzer.clearCache();
-      }
 
       // Calculate early game status to prevent emergency panic on normal starting hands
       final handSize = bot.currentHand.length;
@@ -2576,47 +2579,141 @@ class EnhancedBotAI {
         if (bot.currentHand.isEmpty) {
           return BotDecision(action: 'noMeld');
         }
-        if (controller != null) {
-          final playAll = _checkCanPlayAllCards(bot, context);
-          if (playAll != null) {
-            return playAll;
-          }
+        if (controller == null) {
+          return BotDecision(action: 'noMeld');
+        }
 
-          final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
+        // Play-down first when required — otherwise later dumps are illegal.
+        if (!bot.hasPlayedDown) {
+          final playDown = _meldAnalyzer.findBestPlayDownCombination(
             bot,
             controller,
+            gameState.playDownRequirement,
           );
-          if (maximalMelds.length >= 2) {
-            return BotDecision(
-              action: 'createMultipleMelds',
-              data: maximalMelds,
-            );
+          if (playDown.isNotEmpty) {
+            return _executePlayDown(playDown);
           }
+          // Cannot meet play-down requirement — discard and eat the penalty.
+          return BotDecision(action: 'noMeld');
+        }
 
-          final cardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
-            bot,
-            controller,
+        final playAll = _checkCanPlayAllCards(bot, context);
+        if (playAll != null) {
+          return playAll;
+        }
+
+        // Dump every card that can attach to existing melds (incl. wilds).
+        final cardsToAdd = _findFinalTurnAdditions(bot, controller);
+        if (cardsToAdd.isNotEmpty) {
+          return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
+        }
+
+        final maximalMelds = _meldAnalyzer.findMaximalMeldCombination(
+          bot,
+          controller,
+        );
+        final playableMelds = maximalMelds
+            .where((meld) => _meldCardsStillInHand(bot, meld))
+            .toList();
+        if (playableMelds.length >= 2) {
+          return BotDecision(
+            action: 'createMultipleMelds',
+            data: playableMelds,
           );
-          if (cardsToAdd.isNotEmpty) {
-            return BotDecision(action: 'addToMeld', data: cardsToAdd.first);
-          }
+        }
+        if (playableMelds.length == 1) {
+          return BotDecision(action: 'createMeld', data: playableMelds.first);
+        }
 
-          final possibleMelds = _getCachedPossibleMelds(bot, context);
-          if (possibleMelds.isNotEmpty) {
-            return BotDecision(
-              action: 'createMeld',
-              data: _meldAnalyzer.findBestMeld(
-                possibleMelds,
-                bot: bot,
-                preferLarger: true,
-              ),
-            );
-          }
+        final possibleMelds = _meldAnalyzer
+            .getPossibleMelds(bot, controller)
+            .where((meld) => _meldCardsStillInHand(bot, meld))
+            .toList();
+        if (possibleMelds.isNotEmpty) {
+          return BotDecision(
+            action: 'createMeld',
+            data: _meldAnalyzer.findBestMeld(
+              possibleMelds,
+              bot: bot,
+              preferLarger: true,
+            ),
+          );
         }
         return BotDecision(action: 'noMeld');
       case TurnPhase.discard:
-        return _makeDiscardDecision(bot, context);
+        return _makeFinalTurnDiscardDecision(bot);
     }
+  }
+
+  /// Prefer additions that shrink the penalty pile without wrecking a clean book.
+  List<Map<String, dynamic>> _findFinalTurnAdditions(
+    Player bot,
+    GameController controller,
+  ) {
+    final cardsToAdd = _meldAnalyzer.findCardsToAddToExistingMelds(
+      bot,
+      controller,
+    );
+    if (cardsToAdd.isEmpty) {
+      return cardsToAdd;
+    }
+
+    final ranked = cardsToAdd.where((addition) {
+      final card = addition['card'] as PlayingCard;
+      final meld = addition['meld'] as Meld;
+      // Never convert a clean book to dirty — that loses 200 net book points.
+      if (card.isWild && meld.isClean) {
+        return false;
+      }
+      return true;
+    }).toList();
+
+    ranked.sort((a, b) {
+      final cardA = a['card'] as PlayingCard;
+      final cardB = b['card'] as PlayingCard;
+      final byPoints = cardB.pointValue.compareTo(cardA.pointValue);
+      if (byPoints != 0) {
+        return byPoints;
+      }
+      return (b['priority'] as int).compareTo(a['priority'] as int);
+    });
+    return ranked;
+  }
+
+  bool _meldCardsStillInHand(Player bot, List<PlayingCard> meldCards) {
+    final remaining = List<PlayingCard>.from(bot.currentHand);
+    for (final card in meldCards) {
+      final index = remaining.indexWhere(
+        (handCard) =>
+            identical(handCard, card) ||
+            (handCard.rank == card.rank && handCard.suit == card.suit),
+      );
+      if (index < 0) {
+        return false;
+      }
+      remaining.removeAt(index);
+    }
+    return true;
+  }
+
+  /// Dump the most expensive leftover card — round is ending after this discard.
+  BotDecision _makeFinalTurnDiscardDecision(Player bot) {
+    if (bot.currentHand.isEmpty) {
+      if (bot.canGoOut) {
+        return BotDecision(action: 'goOut');
+      }
+      return BotDecision(action: 'error');
+    }
+
+    final hand = List<PlayingCard>.from(bot.currentHand);
+    final threes = hand.where((card) => card.isThree).toList();
+    if (threes.isNotEmpty) {
+      threes.sort((a, b) => a.pointValue.compareTo(b.pointValue));
+      return BotDecision(action: 'discard', data: threes.first);
+    }
+
+    hand.sort((a, b) => b.pointValue.compareTo(a.pointValue));
+    return BotDecision(action: 'discard', data: hand.first);
   }
 
   /// Determine if we should hold cards based on round play-down requirements

--- a/lib/ai/enhanced_bot_ai.dart
+++ b/lib/ai/enhanced_bot_ai.dart
@@ -2710,11 +2710,14 @@ class EnhancedBotAI {
     final playableMelds = maximalMelds
         .where((meld) => _meldCardsStillInHand(bot, meld))
         .toList();
-    if (playableMelds.length >= 2) {
-      return BotDecision(action: 'createMultipleMelds', data: playableMelds);
+    // findMaximalMeldCombination only heuristically avoids overlap — keep only
+    // melds that claim distinct hand indices before multi-meld create.
+    final disjointMelds = _selectDisjointMeldsByHandIndex(bot, playableMelds);
+    if (disjointMelds.length >= 2) {
+      return BotDecision(action: 'createMultipleMelds', data: disjointMelds);
     }
-    if (playableMelds.length == 1) {
-      return BotDecision(action: 'createMeld', data: playableMelds.first);
+    if (disjointMelds.length == 1) {
+      return BotDecision(action: 'createMeld', data: disjointMelds.first);
     }
 
     final possibleMelds = _meldAnalyzer
@@ -2749,6 +2752,61 @@ class EnhancedBotAI {
         preferLarger: true,
       ),
     );
+  }
+
+  /// Greedily keep melds whose cards map to unused hand indices (no shared cards).
+  List<List<PlayingCard>> _selectDisjointMeldsByHandIndex(
+    Player bot,
+    List<List<PlayingCard>> melds,
+  ) {
+    final usedIndices = <int>{};
+    final selected = <List<PlayingCard>>[];
+
+    // Prefer larger melds first so the greedy keep maximizes cards dumped.
+    final ordered = List<List<PlayingCard>>.from(melds)
+      ..sort((a, b) => b.length.compareTo(a.length));
+
+    for (final meld in ordered) {
+      final claimed = <int>[];
+      var ok = true;
+      for (final card in meld) {
+        var found = -1;
+        // Prefer the exact hand instance when candidates include hand references.
+        for (var i = 0; i < bot.currentHand.length; i++) {
+          if (usedIndices.contains(i) || claimed.contains(i)) {
+            continue;
+          }
+          if (identical(bot.currentHand[i], card)) {
+            found = i;
+            break;
+          }
+        }
+        if (found < 0) {
+          for (var i = 0; i < bot.currentHand.length; i++) {
+            if (usedIndices.contains(i) || claimed.contains(i)) {
+              continue;
+            }
+            final handCard = bot.currentHand[i];
+            if (handCard.rank == card.rank && handCard.suit == card.suit) {
+              found = i;
+              break;
+            }
+          }
+        }
+        if (found < 0) {
+          ok = false;
+          break;
+        }
+        claimed.add(found);
+      }
+      if (!ok) {
+        continue;
+      }
+      usedIndices.addAll(claimed);
+      selected.add(claimed.map((i) => bot.currentHand[i]).toList());
+    }
+
+    return selected;
   }
 
   /// Adds that turn a 6-card meld into a book (clean preferred — 500 vs 300).

--- a/test/ai/final_turn_scoring_dump_test.dart
+++ b/test/ai/final_turn_scoring_dump_test.dart
@@ -1,0 +1,296 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hand_foot_game_flutter/ai/enhanced_bot_ai.dart';
+import 'package:hand_foot_game_flutter/config/solo_game_settings.dart';
+import 'package:hand_foot_game_flutter/game/game_controller.dart';
+import 'package:hand_foot_game_flutter/models/card.dart';
+import 'package:hand_foot_game_flutter/models/game_state.dart';
+import 'package:hand_foot_game_flutter/models/meld.dart';
+import 'package:hand_foot_game_flutter/models/player.dart';
+
+/// Simulates meld-phase iterations the way [BotTurnManager] does.
+void _runFinalTurnMeldLoop(
+  EnhancedBotAI botAI,
+  GameController gc,
+  Player bot, {
+  int maxIterations = 25,
+}) {
+  var iterations = 0;
+  while (gc.gameState.turnPhase == TurnPhase.meld &&
+      iterations < maxIterations) {
+    iterations++;
+    final decision = botAI.makeDecision(bot, gc);
+    if (decision.action == 'noMeld') {
+      gc.gameState.turnPhase = TurnPhase.discard;
+      return;
+    }
+
+    final ok = switch (decision.action) {
+      'addToMeld' => () {
+        final data = decision.data as Map<String, dynamic>;
+        final card = data['card'] as PlayingCard;
+        final handCard = bot.findHandCardInstance(card);
+        if (handCard == null) {
+          return false;
+        }
+        return gc.addCardToMeld(data['meldIndex'] as int, handCard);
+      }(),
+      'createMeld' => gc.createMeld(
+        List<PlayingCard>.from(decision.data as List),
+      ),
+      'createMultipleMelds' => () {
+        var success = true;
+        for (final meld in List<List<PlayingCard>>.from(
+          (decision.data as List).map((e) => List<PlayingCard>.from(e as List)),
+        )) {
+          if (!gc.createMeld(meld)) {
+            success = false;
+            break;
+          }
+        }
+        return success;
+      }(),
+      _ => false,
+    };
+
+    expect(
+      ok,
+      isTrue,
+      reason:
+          'Final-turn action ${decision.action} must succeed '
+          '(hand=${bot.currentHand.map((c) => c.compactName).join(",")})',
+    );
+  }
+}
+
+void _setActiveHand(Player bot, List<PlayingCard> cards) {
+  final pile = bot.hasPickedUpFoot ? bot.foot : bot.hand;
+  pile
+    ..clear()
+    ..addAll(cards);
+}
+
+Meld _cleanKingBook() => Meld.createMeld([
+  const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+  const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+  const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+  const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+  const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+  const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+  const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+])!;
+
+Meld _dirtyQueenBook() => Meld.createMeld([
+  const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+  const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+  const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+  const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+  const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+  const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+  const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+])!;
+
+({EnhancedBotAI botAI, GameController gc, Player human, Player bot})
+_setupFinalTurnBot({bool onFoot = true}) {
+  final botAI = EnhancedBotAI(seed: 42);
+  final human = Player(id: 'h', name: 'You', type: PlayerType.human);
+  final bot = Player(id: 'b', name: 'Bot', type: PlayerType.bot);
+  final gc = GameController(
+    players: [human, bot],
+    seed: 42,
+    soloSettings: SoloGameSettings.defaults,
+  );
+  gc.initializeGame();
+  bot.hasPlayedDown = true;
+  bot.hasPickedUpFoot = onFoot;
+  gc.gameState.currentPlayerIndex = 1;
+  gc.gameState.turnPhase = TurnPhase.meld;
+  gc.gameState.hasDrawnFromDeck = true;
+  gc.gameState.finalTurnPhaseActive = true;
+  gc.gameState.playersAwaitingFinalTurn.add(1);
+  gc.gameState.playerWhoWentOutIndex = 0;
+  return (botAI: botAI, gc: gc, human: human, bot: bot);
+}
+
+void main() {
+  group('Final turn dumping when one-more-turn rule is enabled', () {
+    test('dumps addable cards, wilds onto dirty book, and new melds', () {
+      final setup = _setupFinalTurnBot();
+      final bot = setup.bot;
+      bot.melds.addAll([_cleanKingBook(), _dirtyQueenBook()]);
+      _setActiveHand(bot, [
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.three),
+      ]);
+
+      _runFinalTurnMeldLoop(setup.botAI, setup.gc, bot);
+
+      expect(bot.currentHand.length, 2);
+      expect(bot.currentHand.any((c) => c.rank == CardRank.five), isTrue);
+      expect(bot.currentHand.any((c) => c.isThree), isTrue);
+      expect(bot.melds.any((m) => m.rank == CardRank.ace), isTrue);
+      // Wild went on dirty queens, not clean kings
+      expect(bot.melds[0].isClean, isTrue);
+      expect(bot.melds[1].cards.any((c) => c.isWild), isTrue);
+    });
+
+    test('does not retry stale meld cards after hand changes', () {
+      final setup = _setupFinalTurnBot();
+      final bot = setup.bot;
+      bot.melds.addAll([_cleanKingBook(), _dirtyQueenBook()]);
+      _setActiveHand(bot, [
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+      ]);
+
+      // First decision creates the ace meld
+      final first = setup.botAI.makeDecision(bot, setup.gc);
+      expect(first.action, 'createMeld');
+      expect(
+        setup.gc.createMeld(List<PlayingCard>.from(first.data as List)),
+        isTrue,
+      );
+
+      // Second decision must not invent another ace meld from cache
+      final second = setup.botAI.makeDecision(bot, setup.gc);
+      expect(second.action, 'noMeld');
+    });
+
+    test('empties hand pile into foot then melds playable foot cards', () {
+      final setup = _setupFinalTurnBot(onFoot: false);
+      final bot = setup.bot;
+      bot.melds.addAll([_cleanKingBook(), _dirtyQueenBook()]);
+      bot.hand
+        ..clear()
+        ..addAll([
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        ]);
+      bot.foot
+        ..clear()
+        ..addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        ]);
+
+      _runFinalTurnMeldLoop(setup.botAI, setup.gc, bot);
+
+      expect(bot.hasPickedUpFoot, isTrue);
+      expect(bot.currentHand.any((c) => c.rank == CardRank.jack), isFalse);
+      expect(bot.currentHand.length, 1);
+      expect(bot.currentHand.first.rank, CardRank.five);
+    });
+
+    test('discards highest-penalty leftover card on final turn', () {
+      final setup = _setupFinalTurnBot();
+      final bot = setup.bot;
+      bot.melds.addAll([_cleanKingBook(), _dirtyQueenBook()]);
+      setup.gc.gameState.turnPhase = TurnPhase.discard;
+      _setActiveHand(bot, [
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.five),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.three), // red 3
+      ]);
+
+      final decision = setup.botAI.makeDecision(bot, setup.gc);
+      expect(decision.action, 'discard');
+      expect((decision.data as PlayingCard).isThree, isTrue);
+      expect((decision.data as PlayingCard).pointValue, -300);
+    });
+
+    test('plays down when final turn requires meeting play-down', () {
+      final botAI = EnhancedBotAI(seed: 42);
+      final human = Player(id: 'h', name: 'You', type: PlayerType.human);
+      final bot = Player(id: 'b', name: 'Bot', type: PlayerType.bot);
+      final gc = GameController(
+        players: [human, bot],
+        seed: 42,
+        soloSettings: SoloGameSettings.defaults,
+      );
+      gc.initializeGame();
+      bot.hasPlayedDown = false;
+      bot.hasPickedUpFoot = false;
+      gc.gameState.round = 1;
+      gc.gameState.currentPlayerIndex = 1;
+      gc.gameState.turnPhase = TurnPhase.meld;
+      gc.gameState.hasDrawnFromDeck = true;
+      gc.gameState.finalTurnPhaseActive = true;
+      gc.gameState.playersAwaitingFinalTurn.add(1);
+      gc.gameState.playerWhoWentOutIndex = 0;
+
+      bot.hand
+        ..clear()
+        ..addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        ]);
+
+      final decision = botAI.makeDecision(bot, gc);
+      expect(decision.action, isIn(['createMeld', 'createMultipleMelds']));
+    });
+
+    test('skips illegal play-down when requirement cannot be met', () {
+      final botAI = EnhancedBotAI(seed: 42);
+      final human = Player(id: 'h', name: 'You', type: PlayerType.human);
+      final bot = Player(id: 'b', name: 'Bot', type: PlayerType.bot);
+      final gc = GameController(
+        players: [human, bot],
+        seed: 42,
+        soloSettings: SoloGameSettings.defaults,
+      );
+      gc.initializeGame();
+      bot.hasPlayedDown = false;
+      bot.hasPickedUpFoot = false;
+      gc.gameState.round = 4; // 150 pts required
+      gc.gameState.currentPlayerIndex = 1;
+      gc.gameState.turnPhase = TurnPhase.meld;
+      gc.gameState.hasDrawnFromDeck = true;
+      gc.gameState.finalTurnPhaseActive = true;
+      gc.gameState.playersAwaitingFinalTurn.add(1);
+      gc.gameState.playerWhoWentOutIndex = 0;
+
+      bot.hand
+        ..clear()
+        ..addAll([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        ]);
+
+      final decision = botAI.makeDecision(bot, gc);
+      expect(decision.action, 'noMeld');
+    });
+
+    test('makeDecision ignores final-turn dump when rule phase inactive', () {
+      final setup = _setupFinalTurnBot();
+      setup.gc.gameState.finalTurnPhaseActive = false;
+      setup.gc.gameState.playersAwaitingFinalTurn.clear();
+      final bot = setup.bot;
+      bot.melds.addAll([_cleanKingBook(), _dirtyQueenBook()]);
+      _setActiveHand(bot, [
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+      ]);
+
+      // Without final-turn phase, bots may hold for strategy — just ensure no crash
+      final decision = setup.botAI.makeDecision(bot, setup.gc);
+      expect(decision.action, isNotEmpty);
+    });
+  });
+}

--- a/test/ai/final_turn_scoring_dump_test.dart
+++ b/test/ai/final_turn_scoring_dump_test.dart
@@ -406,5 +406,79 @@ void main() {
       final decision = setup.botAI.makeDecision(bot, setup.gc);
       expect(decision.action, isNotEmpty);
     });
+
+    test('multi-meld final turn only returns disjoint hand cards', () {
+      final setup = _setupFinalTurnBot();
+      final bot = setup.bot;
+      bot.melds.addAll([_cleanKingBook(), _dirtyQueenBook()]);
+      _setActiveHand(bot, [
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.jack),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+      ]);
+
+      final decision = setup.botAI.makeDecision(bot, setup.gc);
+      expect(decision.action, isIn(['createMultipleMelds', 'createMeld']));
+      if (decision.action == 'createMultipleMelds') {
+        final melds = List<List<PlayingCard>>.from(
+          (decision.data as List).map((e) => List<PlayingCard>.from(e as List)),
+        );
+        expect(melds.length, greaterThanOrEqualTo(2));
+        final claimed = <PlayingCard>{};
+        for (final meld in melds) {
+          for (final card in meld) {
+            expect(
+              claimed.add(card),
+              isTrue,
+              reason: 'multi-meld must not reuse the same card instance',
+            );
+            expect(identical(bot.findHandCardInstance(card), card), isTrue);
+          }
+        }
+      }
+    });
+
+    test('overlapping maximal candidates fall back to one createMeld', () {
+      final setup = _setupFinalTurnBot();
+      final bot = setup.bot;
+      // Only a clean book — wild cannot be added without spoiling it, so
+      // the create path runs and must not invent two melds sharing the two.
+      bot.melds.add(_cleanKingBook());
+      _setActiveHand(bot, [
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+        const PlayingCard(suit: Suit.spades, rank: CardRank.jack),
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+      ]);
+
+      final decision = setup.botAI.makeDecision(bot, setup.gc);
+      if (decision.action == 'createMultipleMelds') {
+        final melds = List<List<PlayingCard>>.from(
+          (decision.data as List).map((e) => List<PlayingCard>.from(e as List)),
+        );
+        final claimed = <PlayingCard>{};
+        for (final meld in melds) {
+          for (final card in meld) {
+            expect(
+              claimed.add(card),
+              isTrue,
+              reason: 'must not reuse cards across createMultipleMelds',
+            );
+          }
+        }
+        expect(melds.length, 1); // only one wild — at most one valid meld
+      } else {
+        expect(decision.action, 'createMeld');
+        final meld = List<PlayingCard>.from(decision.data as List);
+        expect(meld.length, greaterThanOrEqualTo(3));
+        expect(meld.where((c) => c.isWild).length, lessThanOrEqualTo(1));
+      }
+    });
   });
 }

--- a/test/ai/final_turn_scoring_dump_test.dart
+++ b/test/ai/final_turn_scoring_dump_test.dart
@@ -191,6 +191,120 @@ void main() {
       expect(bot.currentHand.first.rank, CardRank.five);
     });
 
+    test(
+      'uses wild to create a meld that empties hand into foot, then builds books',
+      () {
+        final setup = _setupFinalTurnBot(onFoot: false);
+        final bot = setup.bot;
+
+        // Dirty queens book + 6 clean kings (one short of book)
+        bot.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+          ])!,
+        );
+        bot.melds.add(
+          Meld.createMeld([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          ])!,
+        );
+
+        // Wild must make Jack meld (not dump onto queens) so hand empties.
+        bot.hand
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.jack),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.two),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          ]);
+        bot.foot
+          ..clear()
+          ..addAll([
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.diamonds, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.spades, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.clubs, rank: CardRank.ace),
+            const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+          ]);
+
+        _runFinalTurnMeldLoop(setup.botAI, setup.gc, bot);
+
+        expect(bot.hasPickedUpFoot, isTrue);
+        expect(bot.hasCleanBook, isTrue);
+        expect(
+          bot.melds.any((m) => m.rank == CardRank.jack),
+          isTrue,
+          reason: 'wild should form a jack meld to clear the hand pile',
+        );
+        expect(
+          bot.melds.any((m) => m.rank == CardRank.ace && m.isBook),
+          isTrue,
+          reason: 'after reaching foot, should meld the ace book',
+        );
+        expect(bot.currentHand.length, 1);
+        expect(bot.currentHand.first.rank, CardRank.five);
+      },
+    );
+
+    test('prefers completing a clean book over a lower-impact add', () {
+      final setup = _setupFinalTurnBot();
+      final bot = setup.bot;
+      bot.melds.addAll([
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.king),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.king),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.king),
+        ])!,
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.queen),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.queen),
+        ])!,
+        Meld.createMeld([
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.diamonds, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.hearts, rank: CardRank.jack),
+          const PlayingCard(suit: Suit.spades, rank: CardRank.two),
+          const PlayingCard(suit: Suit.clubs, rank: CardRank.two),
+        ])!,
+      ]);
+
+      _setActiveHand(bot, [
+        const PlayingCard(suit: Suit.clubs, rank: CardRank.king),
+        const PlayingCard(suit: Suit.diamonds, rank: CardRank.queen),
+        const PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+      ]);
+
+      final decision = setup.botAI.makeDecision(bot, setup.gc);
+      expect(decision.action, 'addToMeld');
+      final card = (decision.data as Map)['card'] as PlayingCard;
+      expect(
+        card.rank,
+        CardRank.king,
+        reason: 'completing the clean book (+500) should win',
+      );
+    });
+
     test('discards highest-penalty leftover card on final turn', () {
       final setup = _setupFinalTurnBot();
       final bot = setup.bot;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When **One more turn after going out** is enabled, other players each get a final turn to reduce penalty cards. Bots already had a final-turn scoring path, but it could stall mid-meld:

1. **Stale meld cache** — `BotMeldAnalyzer` cached possible melds by player id only. The final-turn early return in `EnhancedBotAI` skipped the normal cache clear, so after dumping one meld the next decision retried cards already played (`createMeld` failed → turn aborted).
2. **Incomplete dump strategy** — Final-turn play-down, single-meld maximal dumps, and discard selection were weaker than they should be for “round ends after this turn.”

## Changes

- Clear meld caches **before** the final-turn decision path
- Fingerprint the hand in `BotMeldAnalyzer.getPossibleMelds` so cache invalidates when the hand changes
- Harden `_makeFinalTurnScoringDecision`:
  - Meet play-down when needed (or skip illegal melds)
  - Add every legal card to existing melds (wilds onto dirty only — never spoil a clean book)
  - Create maximal new melds (including single meld)
  - Discard 3s / highest point leftovers
- Add coverage in `test/ai/final_turn_scoring_dump_test.dart`

## Test plan

- [x] `flutter test test/ai/final_turn_scoring_dump_test.dart`
- [x] `flutter test test/ai/hand_pile_foot_completion_test.dart --name="Final turn"`
- [ ] Full `flutter test` / analyze in CI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ef7192b-9d9e-41e5-ab77-df416b24534e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ef7192b-9d9e-41e5-ab77-df416b24534e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved final-turn bot decisions, including play-down requirements, empty hand-to-foot handling, book/volume meld completion ordering, and final-turn card dumping.
  * Prevented stale meld suggestions by invalidating cached meld analysis when the bot’s hand contents change.
  * Enhanced final-turn discard behavior by prioritizing penalty cards.
* **Tests**
  * Expanded Flutter test coverage for final-turn one-more-turn meld/dump meld decisions, including wild usage, overlap handling, multi-meld uniqueness, illegal play-down scenarios, and inactive final-turn safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->