### PR TITLE
Fix freeze when tapping hand cards during draw animation

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -742,6 +742,10 @@ class _GameScreenState extends ConsumerState<GameScreen> {
   }
 
   void _onCardTap(int cardIndex) {
+    if (_isCardAnimationActive) {
+      return;
+    }
+
     final currentPlayer = ref.read(currentPlayerProvider);
     if (currentPlayer?.type != PlayerType.human) {
       return;
@@ -792,6 +796,10 @@ class _GameScreenState extends ConsumerState<GameScreen> {
   }
 
   void _onCardDoubleTap(int cardIndex) {
+    if (_isCardAnimationActive) {
+      return;
+    }
+
     final currentPlayer = ref.read(currentPlayerProvider);
     if (currentPlayer?.type != PlayerType.human) {
       return;

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -72,6 +72,10 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
 
   // REUSE: Copy single-player card interaction logic
   void _onCardTap(int cardIndex) {
+    if (_isCardAnimationActive) {
+      return;
+    }
+
     if (_gameController.gameState.currentPlayer.id != _gameController.userId) {
       return; // Same pattern as single-player checking PlayerType.human
     }
@@ -93,6 +97,10 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
   }
 
   void _onCardDoubleTap(int cardIndex) {
+    if (_isCardAnimationActive) {
+      return;
+    }
+
     if (_gameController.gameState.currentPlayer.id != _gameController.userId) {
       return;
     }

--- a/lib/widgets/card_draw_animation_overlay.dart
+++ b/lib/widgets/card_draw_animation_overlay.dart
@@ -102,6 +102,9 @@ class _CardDrawAnimationOverlayState extends State<CardDrawAnimationOverlay>
   void initState() {
     super.initState();
     if (widget.request != null) {
+      // Block hand taps immediately — isAnimating flips true before the first
+      // frame, but the overlay used to stay shrink until post-frame animation.
+      _showScrim = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _startAnimation(widget.request!);
       });
@@ -113,6 +116,7 @@ class _CardDrawAnimationOverlayState extends State<CardDrawAnimationOverlay>
     super.didUpdateWidget(oldWidget);
     if (widget.request != null && widget.request != oldWidget.request) {
       _skipped = false;
+      _showScrim = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _startAnimation(widget.request!);
       });
@@ -131,6 +135,10 @@ class _CardDrawAnimationOverlayState extends State<CardDrawAnimationOverlay>
     }
     _skipped = true;
     _activeController?.stop();
+    setState(() {
+      _showScrim = false;
+      _visuals = [];
+    });
     widget.onSkip();
     widget.onComplete();
   }
@@ -471,7 +479,9 @@ class _CardDrawAnimationOverlayState extends State<CardDrawAnimationOverlay>
 
   @override
   Widget build(BuildContext context) {
-    if (!_showScrim && _visuals.isEmpty) {
+    final shouldBlockInput =
+        widget.request != null || _showScrim || _visuals.isNotEmpty;
+    if (!shouldBlockInput) {
       return const SizedBox.shrink();
     }
 

--- a/lib/widgets/game_hand_display.dart
+++ b/lib/widgets/game_hand_display.dart
@@ -46,6 +46,7 @@ class GameHandDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final sizes = GameResponsiveLayout.handSizes(context);
+    final animationActive = CardAnimationScope.animationActive(context);
     final stackHeight =
         sizes.handHeight + sizes.selectionLift + UIConstants.smallSpacing;
 
@@ -113,11 +114,16 @@ class GameHandDisplay extends StatelessWidget {
                         left: sizes.handCardLeft(index),
                         bottom: 0,
                         child: GestureDetector(
-                          onTap: onCardTap != null && !hideDuringAnimation
+                          onTap:
+                              onCardTap != null &&
+                                  !hideDuringAnimation &&
+                                  !animationActive
                               ? () => onCardTap!(index)
                               : null,
                           onDoubleTap:
-                              onCardDoubleTap != null && !hideDuringAnimation
+                              onCardDoubleTap != null &&
+                                  !hideDuringAnimation &&
+                                  !animationActive
                               ? () => onCardDoubleTap!(index)
                               : null,
                           // Avoid wrapping visible cards in Opacity:

--- a/test/widgets/card_draw_animation_test.dart
+++ b/test/widgets/card_draw_animation_test.dart
@@ -113,6 +113,119 @@ void main() {
     });
 
     testWidgets(
+      'CardDrawAnimationOverlay blocks input on first frame before fly starts',
+      (tester) async {
+        final deckKey = GlobalKey();
+        final discardKey = GlobalKey();
+        final handStackKey = GlobalKey();
+        final meldAreaKey = GlobalKey();
+        final scrollController = ScrollController();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 600,
+                child: Stack(
+                  children: [
+                    SizedBox(key: deckKey, width: 60, height: 80),
+                    CardDrawAnimationOverlay(
+                      request: const CardAnimationRequest(
+                        type: CardDrawAnimationType.deckDraw,
+                        handCards: [
+                          PlayingCard(suit: Suit.hearts, rank: CardRank.seven),
+                        ],
+                        handTargetIndices: [0],
+                      ),
+                      deckKey: deckKey,
+                      discardKey: discardKey,
+                      handStackKey: handStackKey,
+                      meldAreaKey: meldAreaKey,
+                      handScrollController: scrollController,
+                      onComplete: () {},
+                      onSkip: () {},
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Before the post-frame animation callback: full-screen blocker exists.
+        expect(
+          find.descendant(
+            of: find.byType(CardDrawAnimationOverlay),
+            matching: find.byWidgetPredicate(
+              (widget) =>
+                  widget is GestureDetector &&
+                  widget.behavior == HitTestBehavior.opaque,
+            ),
+          ),
+          findsOneWidget,
+        );
+
+        await tester.pump();
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Container &&
+                widget.color != null &&
+                widget.color!.a > 0,
+          ),
+          findsOneWidget,
+        );
+
+        scrollController.dispose();
+      },
+    );
+
+    testWidgets('CardDrawAnimationOverlay clears flying cards when skipped', (
+      tester,
+    ) async {
+      final deckKey = GlobalKey();
+      final discardKey = GlobalKey();
+      final handStackKey = GlobalKey();
+      final meldAreaKey = GlobalKey();
+      final scrollController = ScrollController();
+      var completed = false;
+      var skipped = false;
+
+      await pumpOverlayHarness(
+        tester,
+        request: const CardAnimationRequest(
+          type: CardDrawAnimationType.deckDraw,
+          handCards: [PlayingCard(suit: Suit.diamonds, rank: CardRank.seven)],
+          handTargetIndices: [0],
+        ),
+        deckKey: deckKey,
+        discardKey: discardKey,
+        handStackKey: handStackKey,
+        meldAreaKey: meldAreaKey,
+        scrollController: scrollController,
+        onComplete: () {
+          completed = true;
+        },
+        onSkip: () {
+          skipped = true;
+        },
+      );
+
+      await tester.pump();
+      await tester.pump(GameConfig.cardRevealDuration ~/ 2);
+      expect(find.byType(PlayingCardWidget), findsOneWidget);
+
+      await tester.tapAt(const Offset(400, 300));
+      await tester.pump();
+
+      expect(skipped, isTrue);
+      expect(completed, isTrue);
+      expect(find.byType(PlayingCardWidget), findsNothing);
+      scrollController.dispose();
+    });
+
+    testWidgets(
       'CardDrawAnimationOverlay shows scrim and cards during deck draw',
       (tester) async {
         final deckKey = GlobalKey();

--- a/test/widgets/game_hand_playable_highlight_test.dart
+++ b/test/widgets/game_hand_playable_highlight_test.dart
@@ -84,4 +84,45 @@ void main() {
     },
     tags: ['widget'],
   );
+
+  testWidgets('hand card taps are ignored while draw animation is active', (
+    tester,
+  ) async {
+    final setup = createMeldPhaseTestController();
+    final human = setup.human;
+    human.hand
+      ..clear()
+      ..addAll([
+        PlayingCard(suit: Suit.hearts, rank: CardRank.five),
+        PlayingCard(suit: Suit.spades, rank: CardRank.six),
+      ]);
+    var tapCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: BalatroTheme.testTheme,
+        home: Scaffold(
+          body: CardAnimationScope(
+            isAnimating: true,
+            hiddenHandIndices: const {},
+            child: SizedBox(
+              width: 800,
+              height: 200,
+              child: GameHandDisplay(
+                player: human,
+                selectedCardIndices: const [],
+                onCardTap: (_) => tapCount++,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PlayingCardWidget).first);
+    await tester.pump();
+
+    expect(tapCount, 0);
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a freeze that could happen when tapping a hand card while the discard-pickup or deck-draw animation was still running (e.g. after unlocking the discard pile).

**Root cause:** `isAnimating` flipped to `true` immediately, but the full-screen animation overlay did not render its tap blocker until the next frame. In that brief gap, hand cards could still receive taps. That could leave a flying card stuck on screen and block normal play.

**Changes:**
- Show the overlay input blocker on the first frame when an animation request is active
- Clear flying-card visuals when the animation is skipped
- Ignore all hand card taps while any draw animation is active (UI + screen handlers)
- Apply the same guards in solo and multiplayer screens

## Test plan

- [x] `dart format .`
- [x] `flutter analyze` (zero issues)
- [x] `flutter test test/widgets/card_draw_animation_test.dart test/widgets/game_hand_playable_highlight_test.dart`
- [ ] Manual: unlock discard pile, tap a hand card during the fly-in — game should stay responsive (tap anywhere to skip animation, or wait for it to finish)

## Checklist

- [x] No secrets, `.env` files, or credential JSON committed
- [x] Behavior changes include or update tests when practical
- [ ] Docs updated if this changes contributor or player-facing workflows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60cdb887-2d30-4ae3-8698-b17de5081e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60cdb887-2d30-4ae3-8698-b17de5081e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented card taps and double-taps during active card animations.
  * Improved input blocking while card-draw overlays are starting or being skipped.
  * Ensured hand cards remain non-interactive throughout card animations.

* **Tests**
  * Added coverage for animation input blocking, overlay behavior, and skip completion callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->