### PR TITLE
Fix stale keyboard focus highlighting wrong hand card

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -629,15 +629,23 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       );
 
       // CRITICAL: Detect and recover from stuck bot turns
-      if (currentPlayer.type == PlayerType.bot && !_isBotTurnInProgress) {
-        // Bot turn should be processing but isn't - this indicates a stuck state
-        DebugLogger.debug(
-          'Detected stuck bot turn for ${currentPlayer.name} - initiating recovery',
-        );
-        _botTurnManager.resetProcessingState();
-        // Clear any stale bot queue
-        _botTurnQueue.clear();
-        // Force bot turn processing to restart
+      if (currentPlayer.type == PlayerType.bot) {
+        _lastCurrentPlayerIndexForHighlight = gameState.currentPlayerIndex;
+
+        if (!_isBotTurnInProgress) {
+          // Bot turn should be processing but isn't - this indicates a stuck state
+          DebugLogger.debug(
+            'Detected stuck bot turn for ${currentPlayer.name} - initiating recovery',
+          );
+          _botTurnManager.resetProcessingState();
+          // Clear any stale bot queue
+          _botTurnQueue.clear();
+          // Force bot turn processing to restart
+          _queueBotTurn(currentPlayer);
+          return;
+        }
+
+        DebugLogger.debug('Queueing bot turn for ${currentPlayer.name}');
         _queueBotTurn(currentPlayer);
         return;
       }
@@ -689,13 +697,6 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           }
         }
         return;
-      }
-
-      // Bot turn: Queue for sequential processing
-      if (currentPlayer.type == PlayerType.bot) {
-        _lastCurrentPlayerIndexForHighlight = gameState.currentPlayerIndex;
-        DebugLogger.debug('Queueing bot turn for ${currentPlayer.name}');
-        _queueBotTurn(currentPlayer);
       }
     } catch (e) {
       DebugLogger.error('Error in processCurrentPlayerTurn: $e');
@@ -1184,6 +1185,9 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
     final cardsBeforeUnlock = gameState.discardPile.length;
     if (controller.unlockDiscardPile()) {
+      _hasPlayerInteractedSinceDraw = false;
+      _clearHandHighlightState();
+      setState(() {});
       // UI will update via Riverpod reactivity when DiscardPileUnlockedEvent fires
       debugPrint('DEBUG: Discard pile unlocked successfully');
       _logHumanAction(

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -111,6 +111,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
   // Keyboard shortcuts
   int? _keyboardFocusedCardIndex;
+  int? _lastCurrentPlayerIndexForHighlight;
   bool _showKeyboardHelp = false;
 
   // Card draw animation anchors
@@ -255,7 +256,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       },
       onRoundEnd: () {
         // Clear UI selections and reset for next round
-        _selectedCardIndices.clear();
+        _clearHandHighlightState();
         _viewingPlayerMelds = null;
         processCurrentPlayerTurn();
       },
@@ -291,7 +292,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
           _botTurnManager.assignBotPersonalities();
         }
 
-        _selectedCardIndices.clear();
+        _clearHandHighlightState();
         _viewingPlayerMelds = null;
         _isInitialized = true;
 
@@ -496,7 +497,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       }
     } else {
       if (mounted) {
-        _selectedCardIndices.clear();
+        _clearHandHighlightState();
         _viewingPlayerMelds = null;
 
         _persistenceManager.saveGameState().catchError((error) {
@@ -664,6 +665,20 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       if (currentPlayer.type == PlayerType.human ||
           currentPlayer.name == 'You') {
         DebugLogger.debug('Human turn - waiting for input');
+        final humanIndex = gameState.players.indexWhere(
+          (p) => p.type == PlayerType.human,
+        );
+        if (shouldResetHandHighlightOnTurnChange(
+          currentPlayerIndex: gameState.currentPlayerIndex,
+          humanPlayerIndex: humanIndex,
+          lastCurrentPlayerIndex: _lastCurrentPlayerIndexForHighlight,
+        )) {
+          _clearHandHighlightState();
+          if (mounted) {
+            setState(() {});
+          }
+        }
+        _lastCurrentPlayerIndexForHighlight = gameState.currentPlayerIndex;
         _gameStateManager.validateHumanPlayerState();
         // CRITICAL: Ensure we never auto-process human turns
         _botTurnManager
@@ -678,6 +693,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
       // Bot turn: Queue for sequential processing
       if (currentPlayer.type == PlayerType.bot) {
+        _lastCurrentPlayerIndexForHighlight = gameState.currentPlayerIndex;
         DebugLogger.debug('Queueing bot turn for ${currentPlayer.name}');
         _queueBotTurn(currentPlayer);
       }
@@ -1046,7 +1062,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
 
     setState(() {
       _isInitialized = false;
-      _selectedCardIndices.clear();
+      _clearHandHighlightState();
       _viewingPlayerMelds = null;
     });
 
@@ -1072,7 +1088,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       coordinator.advanceOn(LearnToPlayAction.draw);
       _hasPlayerInteractedSinceDraw = false;
       // Keep the hand unselected so play-down happens in the meld modal.
-      _selectedCardIndices.clear();
+      _clearHandHighlightState();
       setState(() {});
       return;
     }
@@ -1087,7 +1103,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       // Cards are now automatically inserted in sorted position
       _hasPlayerInteractedSinceDraw =
           false; // Reset interaction flag after drawing
-      // UI will update automatically via provider reactivity when event fires
+      _clearHandHighlightState();
+      setState(() {});
     } else {
       // Check if the round ended automatically due to insufficient cards
       final gameState = ref.read(currentGameStateProvider);
@@ -1469,7 +1486,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
       }
       coordinator.advanceOn(LearnToPlayAction.discard);
       session.keepHumanInControl();
-      _selectedCardIndices.clear();
+      _clearHandHighlightState();
       setState(() {});
       return;
     }
@@ -1504,7 +1521,7 @@ class _GameScreenState extends ConsumerState<GameScreen> {
             _botTurnManager.handlePostDiscardState(humanPlayer);
 
             setState(() {});
-            _selectedCardIndices.clear();
+            _clearHandHighlightState();
             await _gameStateManager.checkAndHandleRoundEnd();
 
             // Schedule bot processing for next frame to avoid immediate execution during human turn
@@ -1559,7 +1576,8 @@ class _GameScreenState extends ConsumerState<GameScreen> {
         _botTurnManager.handlePostDiscardState(humanPlayer);
 
         // UI will update automatically via provider reactivity
-        _selectedCardIndices.clear();
+        _clearHandHighlightState();
+        setState(() {});
         await _gameStateManager.checkAndHandleRoundEnd();
 
         // Schedule bot processing for next frame to avoid immediate execution during human turn
@@ -1626,12 +1644,13 @@ class _GameScreenState extends ConsumerState<GameScreen> {
     }
 
     setState(() {
-      _selectedCardIndices.clear();
-      _keyboardFocusedCardIndex = clampKeyboardFocus(
-        index: _keyboardFocusedCardIndex,
-        handLength: humanPlayer.currentHand.length,
-      );
+      _clearHandHighlightState();
     });
+  }
+
+  void _clearHandHighlightState() {
+    _selectedCardIndices.clear();
+    _keyboardFocusedCardIndex = null;
   }
 
   void _onFocusPreviousCard() {

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
 import '../models/card.dart';
 import '../models/player.dart';
 import '../models/game_state.dart';
@@ -50,17 +51,41 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
   final ScrollController _handScrollController = ScrollController();
 
   int? _keyboardFocusedCardIndex;
+  String? _lastCurrentPlayerIdForHighlight;
   bool _showKeyboardHelp = false;
   bool _isCardAnimationActive = false;
+  StreamSubscription<GameState>? _gameStateSubscription;
 
   @override
   void initState() {
     super.initState();
     _gameController = widget.gameController;
+    _lastCurrentPlayerIdForHighlight =
+        _gameController.gameState.currentPlayer.id;
+    _gameStateSubscription = _gameController.gameStateStream.listen(
+      _onGameStateStreamUpdate,
+    );
+  }
+
+  void _onGameStateStreamUpdate(GameState gameState) {
+    if (!mounted) {
+      return;
+    }
+    final userId = _gameController.userId;
+    final currentPlayerId = gameState.currentPlayer.id;
+    final becameMyTurn =
+        currentPlayerId == userId &&
+        _lastCurrentPlayerIdForHighlight != null &&
+        _lastCurrentPlayerIdForHighlight != userId;
+    _lastCurrentPlayerIdForHighlight = currentPlayerId;
+    if (becameMyTurn) {
+      setState(_clearHandHighlightState);
+    }
   }
 
   @override
   void dispose() {
+    _gameStateSubscription?.cancel();
     _handScrollController.dispose();
     try {
       _gameController.dispose();
@@ -157,20 +182,25 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
   }
 
   // REUSE: Copy single-player action methods (simplified)
+  void _clearHandHighlightState() {
+    _selectedCardIndices.clear();
+    _keyboardFocusedCardIndex = null;
+  }
+
   void _onDrawFromDeck() {
     _gameController.drawFromDeck();
-    setState(() => _selectedCardIndices.clear());
+    setState(_clearHandHighlightState);
   }
 
   void _onUnlockDiscard() {
     _gameController.unlockDiscardPile();
-    setState(() => _selectedCardIndices.clear());
+    setState(_clearHandHighlightState);
   }
 
   void _onDiscard() {
     if (_selectedCards.length == 1) {
       _gameController.discardCard(_selectedCards.first);
-      setState(() => _selectedCardIndices.clear());
+      setState(_clearHandHighlightState);
     }
   }
 
@@ -180,13 +210,7 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
       return;
     }
     currentUserPlayer.sortHandByRank();
-    setState(() {
-      _selectedCardIndices.clear();
-      _keyboardFocusedCardIndex = clampKeyboardFocus(
-        index: _keyboardFocusedCardIndex,
-        handLength: currentUserPlayer.currentHand.length,
-      );
-    });
+    setState(_clearHandHighlightState);
   }
 
   void _onFocusPreviousCard() {
@@ -413,7 +437,7 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
       );
     }
 
-    setState(() => _selectedCardIndices.clear());
+    setState(_clearHandHighlightState);
   }
 
   // REUSE: Implement meld interaction methods (copied from earlier)

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -188,18 +188,20 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen> {
   }
 
   void _onDrawFromDeck() {
-    _gameController.drawFromDeck();
-    setState(_clearHandHighlightState);
+    if (_gameController.drawFromDeck()) {
+      setState(_clearHandHighlightState);
+    }
   }
 
   void _onUnlockDiscard() {
-    _gameController.unlockDiscardPile();
-    setState(_clearHandHighlightState);
+    if (_gameController.unlockDiscardPile()) {
+      setState(_clearHandHighlightState);
+    }
   }
 
   void _onDiscard() {
-    if (_selectedCards.length == 1) {
-      _gameController.discardCard(_selectedCards.first);
+    if (_selectedCards.length == 1 &&
+        _gameController.discardCard(_selectedCards.first)) {
       setState(_clearHandHighlightState);
     }
   }

--- a/lib/widgets/game_keyboard_shortcuts.dart
+++ b/lib/widgets/game_keyboard_shortcuts.dart
@@ -231,6 +231,18 @@ class _GameKeyboardShortcutsState extends State<GameKeyboardShortcuts> {
   }
 }
 
+/// True when play just returned to the human player — keyboard focus should
+/// reset so an index from a prior turn does not highlight a different card.
+bool shouldResetHandHighlightOnTurnChange({
+  required int currentPlayerIndex,
+  required int humanPlayerIndex,
+  required int? lastCurrentPlayerIndex,
+}) {
+  return currentPlayerIndex == humanPlayerIndex &&
+      lastCurrentPlayerIndex != null &&
+      lastCurrentPlayerIndex != humanPlayerIndex;
+}
+
 /// Clamps a keyboard focus index into [0, handLength - 1], or null when empty.
 int? clampKeyboardFocus({required int? index, required int handLength}) {
   if (handLength <= 0 || index == null) {

--- a/test/widgets/game_keyboard_shortcuts_test.dart
+++ b/test/widgets/game_keyboard_shortcuts_test.dart
@@ -49,6 +49,44 @@ void main() {
     });
   });
 
+  group('shouldResetHandHighlightOnTurnChange', () {
+    test(
+      'returns false on first human turn before any prior player tracked',
+      () {
+        expect(
+          shouldResetHandHighlightOnTurnChange(
+            currentPlayerIndex: 0,
+            humanPlayerIndex: 0,
+            lastCurrentPlayerIndex: null,
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test('returns true when play returns to the human after a bot turn', () {
+      expect(
+        shouldResetHandHighlightOnTurnChange(
+          currentPlayerIndex: 0,
+          humanPlayerIndex: 0,
+          lastCurrentPlayerIndex: 2,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false while the human remains the current player', () {
+      expect(
+        shouldResetHandHighlightOnTurnChange(
+          currentPlayerIndex: 0,
+          humanPlayerIndex: 0,
+          lastCurrentPlayerIndex: 0,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('clampKeyboardFocus', () {
     test('returns null for empty hand', () {
       expect(clampKeyboardFocus(index: 2, handLength: 0), isNull);

--- a/test/widgets/game_keyboard_shortcuts_test.dart
+++ b/test/widgets/game_keyboard_shortcuts_test.dart
@@ -86,16 +86,20 @@ void main() {
       );
     });
 
-    test('returns false when transitioning from human to bot turn', () {
-      expect(
-        shouldResetHandHighlightOnTurnChange(
-          currentPlayerIndex: 1,
-          humanPlayerIndex: 0,
-          lastCurrentPlayerIndex: 0,
-        ),
-        isFalse,
-      );
-    });
+    test(
+      'returns false when transitioning from human to bot turn',
+      () {
+        expect(
+          shouldResetHandHighlightOnTurnChange(
+            currentPlayerIndex: 1,
+            humanPlayerIndex: 0,
+            lastCurrentPlayerIndex: 0,
+          ),
+          isFalse,
+        );
+      },
+      tags: ['hand_focus_turn_transition'],
+    );
 
     test(
       'human bot human transition resets highlight when bot turn is tracked',
@@ -117,6 +121,7 @@ void main() {
 
         expect(keyboardFocus, isNull);
       },
+      tags: ['hand_focus_turn_transition'],
     );
 
     test(
@@ -136,6 +141,7 @@ void main() {
 
         expect(keyboardFocus, 5);
       },
+      tags: ['hand_focus_turn_transition'],
     );
   });
 

--- a/test/widgets/game_keyboard_shortcuts_test.dart
+++ b/test/widgets/game_keyboard_shortcuts_test.dart
@@ -85,6 +85,58 @@ void main() {
         isFalse,
       );
     });
+
+    test('returns false when transitioning from human to bot turn', () {
+      expect(
+        shouldResetHandHighlightOnTurnChange(
+          currentPlayerIndex: 1,
+          humanPlayerIndex: 0,
+          lastCurrentPlayerIndex: 0,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'human bot human transition resets highlight when bot turn is tracked',
+      () {
+        var lastTrackedPlayerIndex = 0;
+        int? keyboardFocus = 5;
+
+        const botPlayerIndex = 1;
+        lastTrackedPlayerIndex = botPlayerIndex;
+
+        const humanPlayerIndex = 0;
+        if (shouldResetHandHighlightOnTurnChange(
+          currentPlayerIndex: humanPlayerIndex,
+          humanPlayerIndex: humanPlayerIndex,
+          lastCurrentPlayerIndex: lastTrackedPlayerIndex,
+        )) {
+          keyboardFocus = null;
+        }
+
+        expect(keyboardFocus, isNull);
+      },
+    );
+
+    test(
+      'human bot human transition keeps highlight if bot turn is not tracked',
+      () {
+        const lastTrackedPlayerIndex = 0;
+        int? keyboardFocus = 5;
+
+        const humanPlayerIndex = 0;
+        if (shouldResetHandHighlightOnTurnChange(
+          currentPlayerIndex: humanPlayerIndex,
+          humanPlayerIndex: humanPlayerIndex,
+          lastCurrentPlayerIndex: lastTrackedPlayerIndex,
+        )) {
+          keyboardFocus = null;
+        }
+
+        expect(keyboardFocus, 5);
+      },
+    );
   });
 
   group('clampKeyboardFocus', () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a player selected/discarded a card, keyboard focus stayed on that hand index. After the discard, cards shifted left and a different card (e.g. the first 8♦) inherited the blue focus ring on the next turn.

## Fix

- Clear both selection **and** keyboard focus after discard, draw, unlock discard, and hand sort
- Reset hand highlights when the human player's turn starts again after bot turns (solo + multiplayer)
- Track bot-turn player index before early returns so human→bot→human transitions reset correctly
- Only clear multiplayer highlights when draw/unlock/discard operations succeed
- Add `shouldResetHandHighlightOnTurnChange()` helper with unit + regression tests

## Testing

- `flutter analyze` — clean
- `flutter test test/widgets/game_keyboard_shortcuts_test.dart` — all pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-877c98db-64ba-429f-b7d4-17904057c8a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-877c98db-64ba-429f-b7d4-17904057c8a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hand highlight and keyboard focus reset behavior on turn changes, including round transitions, draw/discard (single and meld), unlock/discard, sorting, and new game start.
  * Multiplayer now clears hand highlights exactly when your turn begins.
  * Refined bot turn handling to better recover from “stuck” processing and ensure the correct bot turn is queued.

* **Tests**
  * Expanded unit coverage for hand-highlight reset logic across human/bot transitions and keyboard-focus scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->